### PR TITLE
fix: stabilize transfer protocol, build, and password salt handling

### DIFF
--- a/.agents/skills/coding-guidelines/SKILL.md
+++ b/.agents/skills/coding-guidelines/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: coding-guidelines
+description: "Use when asking about Rust code style or best practices. Keywords: naming, formatting, comment, clippy, rustfmt, lint, code style, best practice, P.NAM, G.FMT, code review, naming convention, variable naming, function naming, type naming, 命名规范, 代码风格, 格式化, 最佳实践, 代码审查, 怎么命名"
+source: https://rust-coding-guidelines.github.io/rust-coding-guidelines-zh/
+user-invocable: false
+---
+
+# Rust Coding Guidelines (50 Core Rules)
+
+## Naming (Rust-Specific)
+
+| Rule | Guideline |
+|------|-----------|
+| No `get_` prefix | `fn name()` not `fn get_name()` |
+| Iterator convention | `iter()` / `iter_mut()` / `into_iter()` |
+| Conversion naming | `as_` (cheap &), `to_` (expensive), `into_` (ownership) |
+| Static var prefix | `G_CONFIG` for `static`, no prefix for `const` |
+
+## Data Types
+
+| Rule | Guideline |
+|------|-----------|
+| Use newtypes | `struct Email(String)` for domain semantics |
+| Prefer slice patterns | `if let [first, .., last] = slice` |
+| Pre-allocate | `Vec::with_capacity()`, `String::with_capacity()` |
+| Avoid Vec abuse | Use arrays for fixed sizes |
+
+## Strings
+
+| Rule | Guideline |
+|------|-----------|
+| Prefer bytes | `s.bytes()` over `s.chars()` when ASCII |
+| Use `Cow<str>` | When might modify borrowed data |
+| Use `format!` | Over string concatenation with `+` |
+| Avoid nested iteration | `contains()` on string is O(n*m) |
+
+## Error Handling
+
+| Rule | Guideline |
+|------|-----------|
+| Use `?` propagation | Not `try!()` macro |
+| `expect()` over `unwrap()` | When value guaranteed |
+| Assertions for invariants | `assert!` at function entry |
+
+## Memory
+
+| Rule | Guideline |
+|------|-----------|
+| Meaningful lifetimes | `'src`, `'ctx` not just `'a` |
+| `try_borrow()` for RefCell | Avoid panic |
+| Shadowing for transformation | `let x = x.parse()?` |
+
+## Concurrency
+
+| Rule | Guideline |
+|------|-----------|
+| Identify lock ordering | Prevent deadlocks |
+| Atomics for primitives | Not Mutex for bool/usize |
+| Choose memory order carefully | Relaxed/Acquire/Release/SeqCst |
+
+## Async
+
+| Rule | Guideline |
+|------|-----------|
+| Sync for CPU-bound | Async is for I/O |
+| Don't hold locks across await | Use scoped guards |
+
+## Macros
+
+| Rule | Guideline |
+|------|-----------|
+| Avoid unless necessary | Prefer functions/generics |
+| Follow Rust syntax | Macro input should look like Rust |
+
+## Deprecated → Better
+
+| Deprecated | Better | Since |
+|------------|--------|-------|
+| `lazy_static!` | `std::sync::OnceLock` | 1.70 |
+| `once_cell::Lazy` | `std::sync::LazyLock` | 1.80 |
+| `std::sync::mpsc` | `crossbeam::channel` | - |
+| `std::sync::Mutex` | `parking_lot::Mutex` | - |
+| `failure`/`error-chain` | `thiserror`/`anyhow` | - |
+| `try!()` | `?` operator | 2018 |
+
+## Quick Reference
+
+```
+Naming: snake_case (fn/var), CamelCase (type), SCREAMING_CASE (const)
+Format: rustfmt (just use it)
+Docs: /// for public items, //! for module docs
+Lint: #![warn(clippy::all)]
+```
+
+Claude knows Rust conventions well. These are the non-obvious Rust-specific rules.

--- a/.agents/skills/coding-guidelines/clippy-lints/_index.md
+++ b/.agents/skills/coding-guidelines/clippy-lints/_index.md
@@ -1,0 +1,16 @@
+# Clippy Lint → Rule Mapping
+
+| Clippy Lint | Category | Fix |
+|-------------|----------|-----|
+| `unwrap_used` | Error | Use `?` or `expect()` |
+| `needless_clone` | Perf | Use reference |
+| `await_holding_lock` | Async | Scope guard before await |
+| `linkedlist` | Perf | Use Vec/VecDeque |
+| `wildcard_imports` | Style | Explicit imports |
+| `missing_safety_doc` | Safety | Add `# Safety` doc |
+| `undocumented_unsafe_blocks` | Safety | Add `// SAFETY:` |
+| `transmute_ptr_to_ptr` | Safety | Use `pointer::cast()` |
+| `large_stack_arrays` | Mem | Use Vec or Box |
+| `too_many_arguments` | Design | Use struct params |
+
+For unsafe-related lints → see `unsafe-checker` skill.

--- a/.agents/skills/coding-guidelines/index/rules-index.md
+++ b/.agents/skills/coding-guidelines/index/rules-index.md
@@ -1,0 +1,6 @@
+# Complete Rules Reference
+
+For the full 500+ rules, see:
+- Source: https://rust-coding-guidelines.github.io/rust-coding-guidelines-zh/
+
+Core rules are in `../SKILL.md`.

--- a/.agents/skills/crafting-effective-readmes/README.md
+++ b/.agents/skills/crafting-effective-readmes/README.md
@@ -1,0 +1,180 @@
+# Crafting Effective READMEs
+
+A skill for Claude Code that helps you write, update, and improve README files tailored to your specific project type and audience.
+
+## Purpose
+
+Not all READMEs are the same. An open-source library needs different documentation than a personal project or an internal tool. This skill provides:
+
+- **Audience-aware guidance** - Different readers need different information
+- **Project-type templates** - Ready-to-use structures for OSS, personal, internal, and config projects
+- **Task-specific workflows** - Whether creating, updating, adding to, or reviewing READMEs
+- **Quality checks** - Style guidance and section checklists to avoid common mistakes
+
+## When to Use
+
+Use this skill when you need to:
+
+- Create a README for a new project
+- Add a new section to an existing README
+- Update stale documentation after changes
+- Review and refresh README content
+- Choose the right sections for your project type
+
+**Trigger phrases:**
+
+- "Write a README for this project"
+- "Help me document this"
+- "Create documentation for..."
+- "Update the README"
+- "Review my README"
+- "What sections should my README have?"
+
+## How It Works
+
+The skill follows a three-step process:
+
+### Step 1: Identify the Task
+
+The skill determines what README task you are working on:
+
+| Task | When to Use |
+|------|-------------|
+| **Creating** | New project with no README yet |
+| **Adding** | Need to document something new in existing README |
+| **Updating** | Capabilities changed, content is stale |
+| **Reviewing** | Checking if README is still accurate |
+
+### Step 2: Gather Context
+
+Based on the task, the skill asks targeted questions:
+
+- **Creating**: What type of project? What problem does it solve? What is the quickest path to "it works"?
+- **Adding**: What needs documenting? Where should it go? Who needs this info most?
+- **Updating**: What changed? Which sections are stale?
+- **Reviewing**: Compares README against actual project state (package.json, main files, etc.)
+
+### Step 3: Generate and Refine
+
+The skill uses the appropriate template and follows up with: "Anything else to highlight or include that I might have missed?"
+
+## Key Features
+
+### Project Type Templates
+
+| Type | Audience | Template |
+|------|----------|----------|
+| **Open Source** | Contributors, users worldwide | `templates/oss.md` |
+| **Personal** | Future you, portfolio viewers | `templates/personal.md` |
+| **Internal** | Teammates, new hires | `templates/internal.md` |
+| **Config** | Future you (confused) | `templates/xdg-config.md` |
+
+### Section Checklist by Project Type
+
+| Section | OSS | Personal | Internal | Config |
+|---------|-----|----------|----------|--------|
+| Name/Description | Yes | Yes | Yes | Yes |
+| Badges | Yes | Optional | No | No |
+| Installation | Yes | Yes | Yes | No |
+| Usage/Examples | Yes | Yes | Yes | Brief |
+| What's Here | No | No | No | Yes |
+| How to Extend | No | No | Optional | Yes |
+| Contributing | Yes | Optional | Yes | No |
+| License | Yes | Optional | No | No |
+| Architecture | Optional | No | Yes | No |
+| Gotchas/Notes | Optional | Optional | Yes | Yes |
+| Last Reviewed | No | No | Optional | Yes |
+
+### Reference Materials
+
+The skill includes curated reference materials for deeper understanding:
+
+- **art-of-readme.md** - Philosophy behind great READMEs, cognitive funneling
+- **make-a-readme.md** - Practical, section-by-section guidance
+- **standard-readme-spec.md** - Formal specification for OSS consistency
+
+## Usage Examples
+
+### Creating a New README
+
+```
+User: I need a README for my new CLI tool
+
+Claude: What type of project is this - open source, personal, or internal?
+
+User: Open source, it's a Node.js package
+
+Claude: [Uses OSS template, asks about installation, usage, and contributing]
+```
+
+### Updating an Existing README
+
+```
+User: Update my README, I added a new feature
+
+Claude: [Reads current README, identifies where to add the new feature,
+        proposes specific edits]
+```
+
+### Reviewing for Accuracy
+
+```
+User: Check if my README is still accurate
+
+Claude: [Compares README against package.json, main files, etc.
+        Flags outdated sections and suggests updates]
+```
+
+## Best Practices
+
+1. **Always ask about audience** - Don't assume OSS defaults for everything
+2. **Show, don't just tell** - Include examples and code samples
+3. **Use structure** - Headers, tables, and lists improve scannability
+4. **Keep it current** - Add "last reviewed" dates for internal/config projects
+5. **Include installation steps** - Never assume setup is obvious
+6. **Write for YOUR audience** - Avoid generic tone
+
+## Common Mistakes to Avoid
+
+- No installation steps (never assume setup is obvious)
+- No examples (show, don't just tell)
+- Wall of text (use headers, tables, lists)
+- Stale content (add "last reviewed" date)
+- Generic tone (write for YOUR audience)
+
+## Essential Sections (All Types)
+
+Every README needs at minimum:
+
+1. **Name** - Self-explanatory title
+2. **Description** - What + why in 1-2 sentences
+3. **Usage** - How to use it (examples help)
+
+## Directory Structure
+
+```
+crafting-effective-readmes/
+  SKILL.md                 # Skill definition
+  section-checklist.md     # Quick reference for sections by project type
+  style-guide.md           # Common mistakes and prose guidance
+  using-references.md      # Guide to reference materials
+  templates/
+    oss.md                 # Open source project template
+    personal.md            # Personal/portfolio project template
+    internal.md            # Internal/team project template
+    xdg-config.md          # Configuration directory template
+  references/
+    art-of-readme.md       # README philosophy
+    make-a-readme.md       # Section-by-section guidance
+    standard-readme-spec.md        # Formal specification
+    standard-readme-example-minimal.md  # Minimal compliant example
+    standard-readme-example-maximal.md  # Full-featured example
+```
+
+## Related Skills
+
+- `writing-clearly-and-concisely` - For general prose quality, clear writing, and avoiding AI patterns
+
+## Attribution
+
+- Original skill by @joshuadavidthomas from [joshuadavidthomas/agent-skills](https://github.com/joshuadavidthomas/agent-skills) (MIT)

--- a/.agents/skills/crafting-effective-readmes/SKILL.md
+++ b/.agents/skills/crafting-effective-readmes/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: crafting-effective-readmes
+description: Use when writing or improving README files. Not all READMEs are the same — provides templates and guidance matched to your audience and project type.
+---
+
+# Crafting Effective READMEs
+
+## Overview
+
+READMEs answer questions your audience will have. Different audiences need different information - a contributor to an OSS project needs different context than future-you opening a config folder.
+
+**Always ask:** Who will read this, and what do they need to know?
+
+## Process
+
+### Step 1: Identify the Task
+
+**Ask:** "What README task are you working on?"
+
+| Task | When |
+|------|------|
+| **Creating** | New project, no README yet |
+| **Adding** | Need to document something new |
+| **Updating** | Capabilities changed, content is stale |
+| **Reviewing** | Checking if README is still accurate |
+
+### Step 2: Task-Specific Questions
+
+**Creating initial README:**
+1. What type of project? (see Project Types below)
+2. What problem does this solve in one sentence?
+3. What's the quickest path to "it works"?
+4. Anything notable to highlight?
+
+**Adding a section:**
+1. What needs documenting?
+2. Where should it go in the existing structure?
+3. Who needs this info most?
+
+**Updating existing content:**
+1. What changed?
+2. Read current README, identify stale sections
+3. Propose specific edits
+
+**Reviewing/refreshing:**
+1. Read current README
+2. Check against actual project state (package.json, main files, etc.)
+3. Flag outdated sections
+4. Update "Last reviewed" date if present
+
+### Step 3: Always Ask
+
+After drafting, ask: **"Anything else to highlight or include that I might have missed?"**
+
+## Project Types
+
+| Type | Audience | Key Sections | Template |
+|------|----------|--------------|----------|
+| **Open Source** | Contributors, users worldwide | Install, Usage, Contributing, License | `templates/oss.md` |
+| **Personal** | Future you, portfolio viewers | What it does, Tech stack, Learnings | `templates/personal.md` |
+| **Internal** | Teammates, new hires | Setup, Architecture, Runbooks | `templates/internal.md` |
+| **Config** | Future you (confused) | What's here, Why, How to extend, Gotchas | `templates/xdg-config.md` |
+
+**Ask the user** if unclear. Don't assume OSS defaults for everything.
+
+## Essential Sections (All Types)
+
+Every README needs at minimum:
+
+1. **Name** - Self-explanatory title
+2. **Description** - What + why in 1-2 sentences  
+3. **Usage** - How to use it (examples help)
+
+## References
+
+- `section-checklist.md` - Which sections to include by project type
+- `style-guide.md` - Common README mistakes and prose guidance
+- `using-references.md` - Guide to deeper reference materials

--- a/.agents/skills/crafting-effective-readmes/references/art-of-readme.md
+++ b/.agents/skills/crafting-effective-readmes/references/art-of-readme.md
@@ -1,0 +1,536 @@
+# Art of README
+
+> Source: [hackergrrl/art-of-readme](https://github.com/hackergrrl/art-of-readme)
+
+*This article can also be read in [Chinese](README-zh.md),
+[Japanese](README-ja-JP.md),
+[Brazilian Portuguese](README-pt-BR.md), [Spanish](README-es-ES.md),
+[German](README-de-DE.md), [French](README-fr.md) and [Traditional Chinese](README-zh-TW.md).*
+
+## Etymology
+
+Where does the term "README" come from?
+
+The nomenclature dates back to *at least* the 1970s [and the
+PDP-10](http://pdp-10.trailing-edge.com/decuslib10-04/01/43,50322/read.me.html),
+though it may even harken back to the days of informative paper notes placed atop
+stacks of punchcards, "READ ME!" scrawled on them, describing their use.
+
+A reader<sup>[1](#footnote-1)</sup> suggested that the title README may be a playful nudge toward Lewis
+Carroll's *Alice's Adventures in Wonderland*, which features a potion and a cake
+labelled *"DRINK ME"* and *"EAT ME"*, respectively.
+
+The pattern of README appearing in all-caps is a consistent facet throughout
+history. In addition to the visual strikingness of using all-caps, UNIX systems
+would sort capitals before lower case letters, conveniently putting the README
+before the rest of the directory's content<sup>[2](#footnote-2)</sup>.
+
+The intent is clear: *"This is important information for the user to read before
+proceeding."* Let's explore together what constitutes "important information" in
+this modern age.
+
+
+## For creators, for consumers
+
+This is an article about READMEs. About what they do, why they are an absolute
+necessity, and how to craft them well.
+
+This is written for module creators, for as a builder of modules, your job is to
+create something that will last. This is an inherent motivation, even if the
+author has no intent of sharing their work. Once 6 months pass, a module without
+documentation begins to look new and unfamiliar.
+
+This is also written for module consumers, for every module author is also a
+module consumer. Node has a very healthy degree of interdependency: no one lives
+at the bottom of the dependency tree.
+
+Despite being focused on Node, the author contends that its lessons apply
+equally well to other programming ecosystems, as well.
+
+
+## Many modules: some good, some bad
+
+The Node ecosystem is powered by its modules. [npm](https://npmjs.org) is the
+magic that makes it all *go*. In the course of a week, Node developers evaluate
+dozens of modules for inclusion in their projects. This is a great deal of power
+being churned out on a daily basis, ripe for the plucking, just as fast as one
+can write `npm install`.
+
+Like any ecosystem that is extremely accessible, the quality bar varies. npm
+does its best to nicely pack away all of these modules and ship them far and
+wide. However, the tools found are widely varied: some are shining and new,
+others broken and rusty, and still others are somewhere in between. There are
+even some that we don't know what they do!
+
+For modules, this can take the form of inaccurate or unhelpful names (any
+guesses what the `fudge` module does?), no documentation, no tests, no source
+code comments, or incomprehensible function names.
+
+Many don't have an active maintainer. If a module has no human available to
+answer questions and explain what a module does, combined with no remnants of
+documentation left behind, a module becomes a bizarre alien artifact, unusable
+and incomprehensible by the archaeologist-hackers of tomorrow.
+
+For those modules that do have documentation, where do they fall on the quality
+spectrum? Maybe it's just a one-liner description: `"sorts numbers by their hex
+value"`. Maybe it's a snippet of example code. These are both improvements upon
+nothing, but they tend to result in the worst-case scenario for a modern day
+module spelunker: digging into the source code to try and understand how it
+actually works. Writing excellent documentation is all about keeping the users
+*out* of the source code by providing instructions sufficient to enjoy the
+wonderful abstractions that your module brings.
+
+Node has a "wide" ecosystem: it's largely made up of a very long list of
+independent do-one-thing-well modules flying no flags but their own. There are
+[exceptions](https://github.com/lodash/lodash), but despite these minor fiefdoms,
+it is the single-purpose commoners who, given their larger numbers, truly rule the
+Node kingdom.
+
+This situation has a natural consequence: it can be hard to find *quality* modules
+that do exactly what you want.
+
+**This is okay**. Truly. A low bar to entry and a discoverability problem is
+infinitely better than a culture problem, where only the privileged few may
+participate.
+
+Plus, discoverability -- as it turns out -- is easier to address.
+
+
+## All roads lead to README.md
+
+The Node community has responded to the challenge of discoverability in
+different ways.
+
+Some experienced Node developers band together to create [curated
+lists](https://github.com/sindresorhus/awesome-nodejs) of quality modules.
+Developers leverage their many years examining hundreds of different modules to
+share with newcomers the *crème de la crème*: the best modules in each category.
+This might also take the form of RSS feeds and mailing lists of new modules deemed
+to be useful by trusted community members.
+
+How about the social graph? This idea spurred the creation of
+[node-modules.com](http://node-modules.com/), a npm search replacement that
+leverages your GitHub social graph to find modules your friends like or have
+made.
+
+Of course there is also npm's built-in [search](https://npmjs.org)
+functionality: a safe default, and the usual port of entry for new developers.
+
+No matter your approach, regardless whether a module spelunker enters the module
+underground at [npmjs.org](https://npmjs.org),
+[github.com](https://github.com), or somewhere else, this would-be user will
+eventually end up staring your README square in the face. Since your users
+will inevitably find themselves here, what can be done to make their first
+impressions maximally effective?
+
+
+## Professional module spelunking
+
+### The README: Your one-stop shop
+
+A README is a module consumer's first -- and maybe only -- look into your
+creation. The consumer wants a module to fulfill their need, so you must explain
+exactly what need your module fills, and how effectively it does so.
+
+Your job is to
+
+1. tell them what it is (with context)
+2. show them what it looks like in action
+3. show them how they use it
+4. tell them any other relevant details
+
+This is *your* job. It's up to the module creator to prove that their work is a
+shining gem in the sea of slipshod modules. Since so many developers' eyes will
+find their way to your README before anything else, quality here is your
+public-facing measure of your work.
+
+
+### Brevity
+
+The lack of a README is a powerful red flag, but even a lengthy README is not
+indicative of there being high quality. The ideal README is as short as it can
+be without being any shorter. Detailed documentation is good -- make separate
+pages for it! -- but keep your README succinct.
+
+
+### Learn from the past
+
+It is said that those who do not study their history are doomed to make its
+mistakes again. Developers have been writing documentation for quite some number
+of years. It would be wasteful to not look back a little bit and see what people
+did right before Node.
+
+Perl, for all of the flak it receives, is in some ways the spiritual grandparent
+of Node. Both are high-level scripting languages, adopt many UNIX idioms, fuel
+much of the internet, and both feature a wide module ecosystem.
+
+It so turns out that the [monks](http://perlmonks.org) of the Perl community
+indeed have a great deal of experience in writing [quality
+READMEs](http://search.cpan.org/~kane/Archive-Tar/lib/Archive/Tar.pm). CPAN is a
+wonderful resource that is worth reading through to learn more about a community
+that wrote consistently high-calibre documentation.
+
+
+### No README? No abstraction
+
+No README means developers will need to delve into your code in order to
+understand it.
+
+The Perl monks have wisdom to share on the matter:
+
+> Your documentation is complete when someone can use your module without ever
+> having to look at its code. This is very important. This makes it possible for
+> you to separate your module's documented interface from its internal
+> implementation (guts). This is good because it means that you are free to
+> change the module's internals as long as the interface remains the same.
+>
+> Remember: the documentation, not the code, defines what a module does.
+-- [Ken Williams](http://mathforum.org/ken/perl_modules.html#document)
+
+
+### Key elements
+
+Once a README is located, the brave module spelunker must scan it to discern if
+it matches the developer's needs. This becomes essentially a series of pattern
+matching problems for their brain to solve, where each step takes them deeper
+into the module and its details.
+
+Let's say, for example, my search for a 2D collision detection module leads me
+to [`collide-2d-aabb-aabb`](https://github.com/hackergrrl/collide-2d-aabb-aabb). I
+begin to examine it from top to bottom:
+
+1. *Name* -- self-explanatory names are best. `collide-2d-aabb-aabb` sounds
+   promising, though it assumes I know what an "aabb" is. If the name sounds too
+   vague or unrelated, it may be a signal to move on.
+
+2. *One-liner* -- having a one-liner that describes the module is useful for
+   getting an idea of what the module does in slightly greater detail.
+   `collide-2d-aabb-aabb` says it
+
+   > Determines whether a moving axis-aligned bounding box (AABB) collides with
+   > other AABBs.
+
+   Awesome: it defines what an AABB is, and what the module does. Now to gauge how
+   well it'd fit into my code:
+
+3. *Usage* -- rather than starting to delve into the API docs, it'd be great to
+   see what the module looks like in action. I can quickly determine whether the
+   example JS fits the desired style and problem. People have lots of opinions
+   on things like promises/callbacks and ES6. If it does fit the bill, then I
+   can proceed to greater detail.
+
+4. *API* -- the name, description, and usage of this module all sound appealing
+   to me. I'm very likely to use this module at this point. I just need to scan
+   the API to make sure it does exactly what I need and that it will integrate
+   easily into my codebase. The API section ought to detail the module's objects
+   and functions, their signatures, return types, callbacks, and events in
+   detail. Types should be included where they aren't obvious. Caveats should be
+   made clear.
+
+5. *Installation* -- if I've read this far down, then I'm sold on trying out the
+   module. If there are nonstandard installation notes, here's where they'd go,
+   but even if it's just a regular `npm install`, I'd like to see that mentioned,
+   too. New users start using Node all the time, so having a link to npmjs.org
+   and an install command provides them the resources to figure out how Node
+   modules work.
+
+6. *License* -- most modules put this at the very bottom, but this might
+   actually be better to have higher up; you're likely to exclude a module VERY
+   quickly if it has a license incompatible with your work. I generally stick to
+   the MIT/BSD/X11/ISC flavours. If you have a non-permissive license, stick it
+   at the very top of the module to prevent any confusion.
+
+
+## Cognitive funneling
+
+The ordering of the above was not chosen at random.
+
+Module consumers use many modules, and need to look at many modules.
+
+Once you've looked at hundreds of modules, you begin to notice that the mind
+benefits from predictable patterns.
+
+You also start to build out your own personal heuristic for what information you
+want, and what red flags disqualify modules quickly.
+
+Thus, it follows that in a README it is desirable to have:
+
+1. a predictable format
+2. certain key elements present
+
+You don't need to use *this* format, but try to be consistent to save your users
+precious cognitive cycles.
+
+The ordering presented here is lovingly referred to as "cognitive funneling,"
+and can be imagined as a funnel held upright, where the widest end contains the
+broadest more pertinent details, and moving deeper down into the funnel presents
+more specific details that are pertinent for only a reader who is interested
+enough in your work to have reached that deeply in the document. Finally, the
+bottom can be reserved for details only for those intrigued by the deeper
+context of the work (background, credits, biblio, etc.).
+
+Once again, the Perl monks have wisdom to share on the subject:
+
+> The level of detail in Perl module documentation generally goes from
+> less detailed to more detailed.  Your SYNOPSIS section should
+> contain a minimal example of use (perhaps as little as one line of
+> code; skip the unusual use cases or anything not needed by most
+> users); the DESCRIPTION should describe your module in broad terms,
+> generally in just a few paragraphs; more detail of the module's
+> routines or methods, lengthy code examples, or other in-depth
+> material should be given in subsequent sections.
+>
+> Ideally, someone who's slightly familiar with your module should be
+> able to refresh their memory without hitting "page down".  As your
+> reader continues through the document, they should receive a
+> progressively greater amount of knowledge.
+> -- from `perlmodstyle`
+
+
+## Care about people's time
+
+Awesome; the ordering of these key elements should be decided by how quickly
+they let someone 'short circuit' and bail on your module.
+
+This sounds bleak, doesn't it? But think about it: your job, when you're doing
+it with optimal altruism in mind, isn't to "sell" people on your work. It's to
+let them evaluate what your creation does as objectively as possible, and decide
+whether it meets their needs or not -- not to, say, maximize your downloads or
+userbase.
+
+This mindset doesn't appeal to everyone; it requires checking your ego at the
+door and letting the work speak for itself as much as possible. Your only job is
+to describe its promise as succinctly as you can, so module spelunkers can
+either use your work when it's a fit, or move on to something else that does.
+
+
+## Call to arms!
+
+Go forth, brave module spelunker, and make your work discoverable and usable
+through excellent documentation!
+
+
+## Bonus: other good practices
+
+Outside of the key points of the article, there are other practices you can
+follow (or not follow) to raise your README's quality bar even further and
+maximize its usefulness to others:
+
+1. Consider including a **Background** section if your module depends on
+   important but not widely known abstractions or other ecosystems. The function
+   of [`bisecting-between`](https://github.com/hackergrrl/bisecting-between) is not
+   immediately obvious from its name, so it has a detailed *Background* section
+   to define and link to the big concepts and abstractions one needs to
+   understand to use and grok it. This is also a great place to explain the
+   module's motivation if similar modules already exist on npm.
+
+2. Aggressively linkify! If you talk about other modules, ideas, or people, make
+   that reference text a link so that visitors can more easily grok your module
+   and the ideas it builds on. Few modules exist in a vacuum: all work comes
+   from other work, so it pays to help users follow your module's history and
+   inspiration.
+
+3. Include information on types of arguments and return parameters if it's not
+   obvious. Prefer convention wherever possible (`cb` probably means callback
+   function, `num` probably means a `Number`, etc.).
+
+4. Include the example code in **Usage** as a file in your repo -- maybe as
+   `example.js`. It's great to have README code that users can actually run if
+   they clone the repository.
+
+5. Be judicious in your use of badges. They're easy to
+   [abuse](https://github.com/angular/angular). They can also be a breeding
+   ground for bikeshedding and endless debate. They add visual noise to your
+   README and generally only function if the user is reading your Markdown in a
+   browser online, since the images are often hosted elsewhere on the
+   internet. For each badge, consider: "what real value is this badge providing
+   to the typical viewer of this README?" Do you have a CI badge to show build/test
+   status? This signal would better reach important parties by emailing
+   maintainers or automatically creating an issue. Always consider the
+   audience of the data in your README and ask yourself if there's a flow for
+   that data that can better reach its intended audience.
+
+6. API formatting is highly bikesheddable. Use whatever format you think is
+   clearest, but make sure your format expresses important subtleties:
+
+   a. which parameters are optional, and their defaults
+
+   b. type information, where it is not obvious from convention
+
+   c. for `opts` object parameters, all keys and values that are accepted
+
+   d. don't shy away from providing a tiny example of an API function's use if
+      it is not obvious or fully covered in the **Usage** section.
+      However, this can also be a strong signal that the function is too complex
+      and needs to be refactored, broken into smaller functions, or removed
+      altogether
+
+   e. aggressively linkify specialized terminology! In markdown you can keep
+      [footnotes](https://daringfireball.net/projects/markdown/syntax#link) at
+      the bottom of your document, so referring to them several times throughout
+      becomes cheap. Some of my personal preferences on API formatting can be
+      found
+      [here](https://github.com/hackergrrl/common-readme/blob/master/api_formatting.md)
+
+7. If your module is a small collection of stateless functions, having a
+   **Usage** section as a [Node REPL
+   session](https://github.com/hackergrrl/bisecting-between#example) of function
+   calls and results might communicate usage more clearly than a source code
+   file to run.
+
+8. If your module provides a CLI (command line interface) instead of (or in
+    addition to) a programmatic API, show usage examples as command invocations
+    and their output. If you create or modify a file, `cat` it to demonstrate
+    the change before and after.
+
+9. Don't forget to use `package.json`
+    [keywords](https://docs.npmjs.com/files/package.json#keywords) to direct
+    module spelunkers to your doorstep.
+
+10. The more you change your API, the more work you need to exert updating
+    documentation -- the implication here is that you should keep your APIs
+    small and concretely defined early on. Requirements change over time, but
+    instead of front-loading assumptions into the APIs of your modules, load
+    them up one level of abstraction: the module set itself. If the requirements
+    *do* change and 'do-one-concrete-thing' no longer makes sense, then simply
+    write a new module that does the thing you need. The 'do-one-concrete-thing'
+    module remains a valid and valuable model for the npm ecosystem, and your
+    course correction cost you nothing but a simple substitution of one module for
+    another.
+
+11. Finally, please remember that your version control repository and its
+    embedded README will outlive your [repository host](https://github.com) and
+    any of the things you hyperlink to -- especially images -- so *inline* anything
+    that is essential to future users grokking your work.
+
+
+## Bonus: *common-readme*
+
+Not coincidentally, this is also the format used by
+[**common-readme**](https://github.com/hackergrrl/common-readme), a set of README
+guidelines and handy command-line generator. If you like what's written here,
+you may save some time writing READMEs with `common-readme`. You'll find
+real module examples with this format, too.
+
+You may also enjoy
+[standard-readme](https://github.com/richardlitt/standard-readme), which is a
+more structured, lintable take on a common README format.
+
+
+## Bonus: Exemplars
+
+Theory is well and good, but what do excellent READMEs look like? Here are some
+that I think embody the principles of this article well:
+
+- https://github.com/hackergrrl/ice-box
+- https://github.com/substack/quote-stream
+- https://github.com/feross/bittorrent-dht
+- https://github.com/mikolalysenko/box-intersect
+- https://github.com/freeman-lab/pixel-grid
+- https://github.com/mafintosh/torrent-stream
+- https://github.com/pull-stream/pull-stream
+- https://github.com/substack/tape
+- https://github.com/yoshuawuyts/vmd
+
+
+## Bonus: The README Checklist
+
+A helpful checklist to gauge how your README is coming along:
+
+- [ ] One-liner explaining the purpose of the module
+- [ ] Necessary background context & links
+- [ ] Potentially unfamiliar terms link to informative sources
+- [ ] Clear, *runnable* example of usage
+- [ ] Installation instructions
+- [ ] Extensive API documentation
+- [ ] Performs [cognitive funneling](https://github.com/hackergrrl/art-of-readme#cognitive-funneling)
+- [ ] Caveats and limitations mentioned up-front
+- [ ] Doesn't rely on images to relay critical information
+- [ ] License
+
+
+## The author
+
+Hi, I'm [Kira](http://kira.solar).
+
+This little project began back in May in Berlin at squatconf, where I was
+digging into how Perl monks write their documentation and also lamenting the
+state of READMEs in the Node ecosystem. It spurred me to create
+[common-readme](https://github.com/hackergrrl/common-readme). The "README Tips"
+section overflowed with tips though, which I decided could be usefully collected
+into an article about writing READMEs. Thus, Art of README was born!
+
+
+## Further Reading
+
+- [README-Driven Development](http://tom.preston-werner.com/2010/08/23/readme-driven-development.html)
+- [Documentation First](http://joeyh.name/blog/entry/documentation_first/)
+
+
+## Footnotes
+
+1. <a name="footnote-1"></a>Thanks,
+   [Sixes666](https://www.reddit.com/r/node/comments/55eto9/nodejs_the_art_of_readme/d8akpz6)!
+
+2. <a name="footnote-2"></a>See [The Jargon File](http://catb.org/~esr/jargon/html/R/README-file.html).
+   However, most systems today will not sort capitals before all lowercase
+   characters, reducing this convention's usefulness to just the visual
+   strikingness of all-caps.
+
+
+## Credits
+
+A heartfelt thank you to [@mafintosh](https://github.com/mafintosh) and
+[@feross](https://github.com/feross) for the encouragement I needed to get this
+idea off the ground and start writing!
+
+Thank you to the following awesome readers for noticing errors and sending me
+PRs :heart: :
+
+- [@ungoldman](https://github.com/ungoldman)
+- [@boidolr](https://github.com/boidolr)
+- [@imjoehaines](https://github.com/imjoehaines)
+- [@radarhere](https://github.com/radarhere)
+- [@joshmanders](https://github.com/joshmanders)
+- [@ddbeck](https://github.com/ddbeck)
+- [@RichardLitt](https://github.com/RichardLitt)
+- [@StevenMaude](https://github.com/StevenMaude)
+- [@KrishMunot](https://github.com/KrishMunot)
+- [@chesterhow](https://github.com/chesterhow)
+- [@sjsyrek](https://github.com/sjsyrek)
+- [@thenickcox](https://github.com/thenickcox)
+
+Thank you to [@qihaiyan](https://github.com/qihaiyan) for translating Art of
+README to Chinese! The following users also made contributions:
+
+- [@BrettDong](https://github.com/brettdong) for revising punctuation in Chinese version.
+- [@Alex-fun](https://github.com/Alex-fun)
+- [@HmyBmny](https://github.com/HmyBmny)
+- [@vra](https://github.com/vra)
+
+Thank you to [@lennonjesus](https://github.com/lennonjesus) for translating Art
+of README to Brazilian Portuguese! The following users also made contributions:
+
+- [@rectius](https://github.com/rectius)
+
+Thank you to [@jabiinfante](https://github.com/jabiinfante) for translating Art
+of README to Spanish!
+
+Thank you to [@Ryuno-Ki](https://github.com/Ryuno-Ki) for translating Art of
+README to German! The following users also made contributions:
+
+- [@randomC0der](https://github.com/randomC0der)
+
+Thank you to [@Manfred Madelaine](https://github.com/Manfred-Madelaine-pro) and
+[@Ruben Madelaine](https://github.com/Ruben-Madelaine)
+for translating Art of README to French!
+
+## Other Resources
+Some readers have suggested other useful resources for README composition:
+- [Software Release Practice](https://tldp.org/HOWTO/Software-Release-Practice-HOWTO/distpractice.html#readme)
+- [GNU Releases](https://www.gnu.org/prep/standards/html_node/Releases.html#index-README-file)
+
+
+## License
+
+[Creative Commons Attribution License](http://creativecommons.org/licenses/by/2.0/)

--- a/.agents/skills/crafting-effective-readmes/references/make-a-readme.md
+++ b/.agents/skills/crafting-effective-readmes/references/make-a-readme.md
@@ -1,0 +1,119 @@
+# Make a README
+
+> Source: [makeareadme.com](https://www.makeareadme.com) by Danny Guo
+> 
+> "Because no one can read your mind (yet)"
+
+## README 101
+
+### What is it?
+
+A README is a text file that introduces and explains a project. It contains information that is commonly required to understand what the project is about.
+
+### Why should I make it?
+
+It's an easy way to answer questions that your audience will likely have regarding how to install and use your project and also how to collaborate with you.
+
+### Who should make it?
+
+Anyone who is working on a programming project, especially if you want others to use it or contribute.
+
+### When should I make it?
+
+Definitely before you show a project to other people or make it public. You might want to get into the habit of making it the first file you create in a new project.
+
+### Where should I put it?
+
+In the top level directory of the project. This is where someone who is new to your project will start out. Code hosting services such as GitHub, Bitbucket, and GitLab will also look for your README and display it along with the list of files and directories in your project.
+
+### How should I make it?
+
+While READMEs can be written in any text file format, the most common one that is used nowadays is Markdown. It allows you to add some lightweight formatting. You can learn more about it at the [CommonMark website](https://commonmark.org/).
+
+## Suggestions for a Good README
+
+Every project is different, so consider which of these sections apply to yours. Also keep in mind that while a README can be too long and detailed, **too long is better than too short**. If you think your README is too long, consider utilizing another form of documentation rather than cutting out information.
+
+### Name
+
+Choose a self-explaining name for your project.
+
+### Description
+
+Let people know what your project can do specifically. Provide context and add a link to any reference visitors might be unfamiliar with. A list of **Features** or a **Background** subsection can also be added here. If there are alternatives to your project, this is a good place to list differentiating factors.
+
+### Badges
+
+On some READMEs, you may see small images that convey metadata, such as whether or not all the tests are passing for the project. You can use [Shields.io](http://shields.io/) to add some to your README. Many services also have instructions for adding a badge.
+
+### Visuals
+
+Depending on what you are making, it can be a good idea to include screenshots or even a video (you'll frequently see GIFs rather than actual videos). Tools like [ttygif](https://github.com/icholy/ttygif) can help, but check out [Asciinema](https://asciinema.org/) for a more sophisticated method.
+
+### Installation
+
+Within a particular ecosystem, there may be a common way of installing things, such as using Yarn, NuGet, or Homebrew. However, consider the possibility that whoever is reading your README is a novice and would like more guidance. Listing specific steps helps remove ambiguity and gets people to using your project as quickly as possible. If it only runs in a specific context like a particular programming language version or operating system or has dependencies that have to be installed manually, also add a **Requirements** subsection.
+
+### Usage
+
+Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples if they are too long to reasonably include in the README.
+
+### Support
+
+Tell people where they can go to for help. It can be any combination of an issue tracker, a chat room, an email address, etc.
+
+### Roadmap
+
+If you have ideas for releases in the future, it is a good idea to list them in the README.
+
+### Contributing
+
+State if you are open to contributions and what your requirements are for accepting them.
+
+For people who want to make changes to your project, it's helpful to have some documentation on how to get started. Perhaps there is a script that they should run or some environment variables that they need to set. Make these steps explicit. These instructions could also be useful to your future self.
+
+You can also document commands to lint the code or run tests. These steps help to ensure high code quality and reduce the likelihood that the changes inadvertently break something. Having instructions for running tests is especially helpful if it requires external setup, such as starting a Selenium server for testing in a browser.
+
+### Authors and Acknowledgment
+
+Show your appreciation to those who have contributed to the project.
+
+### License
+
+For open source projects, say how it is licensed.
+
+### Project Status
+
+If you have run out of energy or time for your project, put a note at the top of the README saying that development has slowed down or stopped completely. Someone may choose to fork your project or volunteer to step in as a maintainer or owner, allowing your project to keep going. You can also make an explicit request for maintainers.
+
+## FAQ
+
+### Is there a standard README format?
+
+Not all of the suggestions here will make sense for every project, so it's really up to the developers what information should be included in the README.
+
+### What should the README file be named?
+
+`README.md` (or a different file extension if you choose to use a non-Markdown file format). It is traditionally uppercase so that it is more prominent, but it's not a big deal if you think it looks better lowercase.
+
+## What's Next?
+
+### More Documentation
+
+A README is a crucial but basic way of documenting your project. While every project should at least have a README, more involved ones can also benefit from a wiki or a dedicated documentation website. Tools include:
+
+- [Docusaurus](https://docusaurus.io/)
+- [GitBook](https://www.gitbook.com/)
+- [MkDocs](https://www.mkdocs.org/)
+- [Read the Docs](https://readthedocs.org/)
+- [Docsify](https://docsify.js.org/)
+
+### Changelog
+
+A [changelog](https://en.wikipedia.org/wiki/Changelog) is another file that is very useful for programming projects. See [Keep a Changelog](http://keepachangelog.com/).
+
+### Contributing Guidelines
+
+Just having a "Contributing" section in your README is a good start. Another approach is to split off your guidelines into their own file (`CONTRIBUTING.md`). If you use GitHub and have this file, then anyone who creates an issue or opens a pull request will get a link to it.
+
+You can also create an issue template and a pull request template. These files give your users and collaborators templates to fill in with the information that you'll need to properly respond.

--- a/.agents/skills/crafting-effective-readmes/references/standard-readme-example-maximal.md
+++ b/.agents/skills/crafting-effective-readmes/references/standard-readme-example-maximal.md
@@ -1,0 +1,68 @@
+# Title
+
+![banner](assets/text_wordmark_dark.png)
+
+![GitHub Created At](https://img.shields.io/github/created-at/RichardLitt/standard-readme?color=bright-green&style=flat-square)
+![GitHub contributors](https://img.shields.io/github/contributors/RichardLitt/standard-readme?color=bright-green&style=flat-square)
+[![license](https://img.shields.io/github/license/RichardLitt/standard-readme.svg?color=bright-green&style=flat-square)](LICENSE)
+[![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+
+This is an example file with maximal choices selected.
+
+This is a long description.
+
+## Table of Contents
+
+- [Security](#security)
+- [Background](#background)
+- [Install](#install)
+- [Usage](#usage)
+- [API](#api)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Security
+
+### Any optional sections
+
+## Background
+
+### Any optional sections
+
+## Install
+
+This module depends upon a knowledge of [Markdown]().
+
+```
+```
+
+### Any optional sections
+
+## Usage
+
+```
+```
+
+Note: The `license` badge image link at the top of this file should be updated with the correct `:user` and `:repo`.
+
+### Any optional sections
+
+## API
+
+### Any optional sections
+
+## More optional sections
+
+## Contributing
+
+See [the contributing file](CONTRIBUTING.md)!
+
+PRs accepted.
+
+Small note: If editing the Readme, please conform to the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+
+### Any optional sections
+
+## License
+
+[MIT © Richard McRichface.](../LICENSE)

--- a/.agents/skills/crafting-effective-readmes/references/standard-readme-example-minimal.md
+++ b/.agents/skills/crafting-effective-readmes/references/standard-readme-example-minimal.md
@@ -1,0 +1,21 @@
+# Title
+
+This is an example file with default selections.
+
+## Install
+
+```
+```
+
+## Usage
+
+```
+```
+
+## Contributing
+
+PRs accepted.
+
+## License
+
+MIT © Richard McRichface

--- a/.agents/skills/crafting-effective-readmes/references/standard-readme-spec.md
+++ b/.agents/skills/crafting-effective-readmes/references/standard-readme-spec.md
@@ -1,0 +1,242 @@
+# Standard README Specification
+
+> Source: [Standard Readme](https://github.com/RichardLitt/standard-readme) by Richard Litt
+
+A compliant README must satisfy all the requirements listed below.
+
+> Note: Standard Readme is designed for open source libraries. Although it's [historically](README.md#background) made for Node and npm projects, it also applies to libraries in other languages and package managers.
+
+**Requirements:**
+  - Be called README (with capitalization) and have a specific extension depending on its format (`.md` for Markdown, `.org` for Org Mode Markup syntax, `.html` for HTML, ...)
+  - If the project supports i18n, the file must be named accordingly: `README.de.md`, where `de` is the BCP 47 Language tag. For naming, prioritize non-regional subtags for languages. If there is only one README and the language is not English, then a different language in the text is permissible without needing to specify the BCP tag: e.g., `README.md` can be in German if there is no `README.md` in another language. Where there are multiple languages, `README.md` is reserved for English.
+  - Be a valid file in the selected format (Markdown, Org Mode, HTML, ...).
+  - Sections must appear in order given below. Optional sections may be omitted.
+  - Sections must have the titles listed below, unless otherwise specified. If the README is in another language, the titles must be translated into that language.
+  - Must not contain broken links.
+  - If there are code examples, they should be linted in the same way as the code is linted in the rest of the project.
+
+## Table of Contents
+
+_Note: This is only a navigation guide for the specification, and does not define or mandate terms for any specification-compliant documents._
+
+- [Sections](#sections)
+  - [Title](#title)
+  - [Banner](#banner)
+  - [Badges](#badges)
+  - [Short Description](#short-description)
+  - [Long Description](#long-description)
+  - [Table of Contents](#table-of-contents-1)
+  - [Security](#security)
+  - [Background](#background)
+  - [Install](#install)
+  - [Usage](#usage)
+  - [Extra Sections](#extra-sections)
+  - [API](#api)
+  - [Maintainers](#maintainers)
+  - [Thanks](#thanks)
+  - [Contributing](#contributing)
+  - [License](#license)
+- [Definitions](#definitions)
+
+## Sections
+
+### Title
+**Status:** Required.
+
+**Requirements:**
+- Title must match repository, folder and package manager names - or it may have another, relevant title with the repository, folder, and package manager title next to it in italics and in parentheses. For instance:
+
+  ```markdown
+  # Standard Readme Style _(standard-readme)_
+  ```
+
+  If any of the folder, repository, or package manager names do not match, there must be a note in the [Long Description](#long-description) explaining why.
+
+**Suggestions:**
+- Should be self-evident.
+
+### Banner
+**Status:** Optional.
+
+**Requirements:**
+- Must not have its own title.
+- Must link to local image in current repository.
+- Must appear directly after the title.
+
+### Badges
+**Status:** Optional.
+
+**Requirements:**
+- Must not have its own title.
+- Must be newline delimited.
+
+**Suggestions:**
+- Use http://shields.io or a similar service to create and host the images.
+- Add the [Standard Readme badge](https://github.com/RichardLitt/standard-readme#badge).
+
+### Short Description
+**Status:** Required.
+
+**Requirements:**
+- Must not have its own title.
+- Must be less than 120 characters.
+- Must not start with `> `
+- Must be on its own line.
+- Must match the description in the packager manager's `description` field.
+- Must match GitHub's description (if on GitHub).
+
+**Suggestions:**
+- Use [gh-description](https://github.com/RichardLitt/gh-description) to set and get GitHub description.
+- Use `npm show . description` to show the description from a local [npm](https://npmjs.com) package.
+
+### Long Description
+**Status:** Optional.
+
+**Requirements:**
+- Must not have its own title.
+- If any of the folder, repository, or package manager names do not match, there must be a note here as to why. See [Title section](#title).
+
+**Suggestions:**
+- If too long, consider moving to the [Background](#background) section.
+- Cover the main reasons for building the repository.
+- "This should describe your module in broad terms,
+generally in just a few paragraphs; more detail of the module's
+routines or methods, lengthy code examples, or other in-depth
+material should be given in subsequent sections.
+
+  Ideally, someone who's slightly familiar with your module should be
+able to refresh their memory without hitting "page down". As your
+reader continues through the document, they should receive a
+progressively greater amount of knowledge."
+
+  ~ [Kirrily "Skud" Robert, perlmodstyle](http://perldoc.perl.org/perlmodstyle.html)
+
+### Table of Contents
+**Status:** Required; optional for READMEs shorter than 100 lines.
+
+**Requirements:**
+- Must link to all sections in the file.
+- Must start with the next section; do not include the title or Table of Contents headings.
+- Must be at least one-depth: must capture all level two headings (e.g.: Markdown's `##` or Org Mode's `**` or HTML's `<h2>` and so on).
+
+**Suggestions:**
+- May capture third and fourth depth headings. If it is a long ToC, these are optional.
+
+### Security
+**Status**: Optional.
+
+**Requirements:**
+- May go here if it is important to highlight security concerns. Otherwise, it should be in [Extra Sections](#extra-sections).
+
+### Background
+**Status:** Optional.
+
+**Requirements:**
+- Cover motivation.
+- Cover abstract dependencies.
+- Cover intellectual provenance: A `See Also` section is also fitting.
+
+### Install
+**Status:** Required by default, optional for [documentation repositories](#definitions).
+
+**Requirements:**
+- Code block illustrating how to install.
+
+**Subsections:**
+- `Dependencies`. Required if there are unusual dependencies or dependencies that must be manually installed.
+
+**Suggestions:**
+- Link to prerequisite sites for programming language: [npmjs](https://npmjs.com), [godocs](https://godoc.org), etc.
+- Include any system-specific information needed for installation.
+- An `Updating` section would be useful for most packages, if there are multiple versions which the user may interface with.
+
+### Usage
+**Status:** Required by default, optional for [documentation repositories](#definitions).
+
+**Requirements:**
+- Code block illustrating common usage.
+- If CLI compatible, code block indicating common usage.
+- If importable, code block indicating both import functionality and usage.
+
+**Subsections:**
+- `CLI`. Required if CLI functionality exists.
+
+**Suggestions:**
+- Cover basic choices that may affect usage: for instance, if JavaScript, cover promises/callbacks, ES6 here.
+- If relevant, point to a runnable file for the usage code.
+
+### Extra Sections
+**Status**: Optional.
+
+**Requirements:**
+- None.
+
+**Suggestions:**
+- This should not be called `Extra Sections`. This is a space for 0 or more sections to be included, each of which must have their own titles.
+- This should contain any other sections that are relevant, placed after [Usage](#usage) and before [API](#api).
+- Specifically, the [Security](#security) section should be here if it wasn't important enough to be placed above.
+
+### API
+**Status:** Optional.
+
+**Requirements:**
+- Describe exported functions and objects.
+
+**Suggestions:**
+- Describe signatures, return types, callbacks, and events.
+- Cover types covered where not obvious.
+- Describe caveats.
+- If using an external API generator (like go-doc, js-doc, or so on), point to an external `API.md` file. This can be the only item in the section, if present.
+
+### Maintainer(s)
+**Status**: Optional.
+
+**Requirements:**
+- Must be called `Maintainer` or `Maintainers`.
+- List maintainer(s) for a repository, along with one way of contacting them (e.g. GitHub link or email).
+
+**Suggestions:**
+- This should be a small list of people in charge of the repo. This should not be everyone with access rights, such as an entire organization, but the people who should be pinged and who are in charge of the direction and maintenance of the repository.
+- Listing past maintainers is good for attribution, and kind.
+
+### Thanks
+**Status**: Optional.
+
+**Requirements:**
+- Must be called `Thanks`, `Credits` or `Acknowledgements`.
+
+**Suggestions:**
+- State anyone or anything that significantly helped with the development of your project.
+- State public contact hyper-links if applicable.
+
+### Contributing
+**Status**: Required.
+
+**Requirements:**
+- State where users can ask questions.
+- State whether PRs are accepted.
+- List any requirements for contributing; for instance, having a sign-off on commits.
+
+**Suggestions:**
+- Link to a CONTRIBUTING file -- if there is one.
+- Be as friendly as possible.
+- Link to the GitHub issues.
+- Link to a Code of Conduct. A CoC is often in the Contributing section or document, or set elsewhere for an entire organization, so it may not be necessary to include the entire file in each repository. However, it is highly recommended to always link to the code, wherever it lives.
+- A subsection for listing contributors is also welcome here.
+
+### License
+**Status:** Required.
+
+**Requirements:**
+- State license full name or identifier, as listed on the  [SPDX](https://spdx.org/licenses/) license list. For unlicensed repositories, add `UNLICENSED`. For more details, add `SEE LICENSE IN <filename>` and link to the license file. (These requirements were adapted from [npm](https://docs.npmjs.com/files/package.json#license)).
+- State license owner.
+- Must be last section.
+
+**Suggestions:**
+- Link to longer License file in local repository.
+
+## Definitions
+
+_These definitions are provided to clarify any terms used above._
+
+- **Documentation repositories**: Repositories without any functional code. For instance, [RichardLitt/knowledge](https://github.com/RichardLitt/knowledge).

--- a/.agents/skills/crafting-effective-readmes/section-checklist.md
+++ b/.agents/skills/crafting-effective-readmes/section-checklist.md
@@ -1,0 +1,17 @@
+# Section Checklist by Project Type
+
+Quick reference for which sections to include based on project type.
+
+| Section | OSS | Personal | Internal | Config |
+|---------|-----|----------|----------|--------|
+| Name/Description | Yes | Yes | Yes | Yes |
+| Badges | Yes | Optional | No | No |
+| Installation | Yes | Yes | Yes | No |
+| Usage/Examples | Yes | Yes | Yes | Brief |
+| What's Here | No | No | No | Yes |
+| How to Extend | No | No | Optional | Yes |
+| Contributing | Yes | Optional | Yes | No |
+| License | Yes | Optional | No | No |
+| Architecture | Optional | No | Yes | No |
+| Gotchas/Notes | Optional | Optional | Yes | Yes |
+| Last Reviewed | No | No | Optional | Yes |

--- a/.agents/skills/crafting-effective-readmes/style-guide.md
+++ b/.agents/skills/crafting-effective-readmes/style-guide.md
@@ -1,0 +1,13 @@
+# README Style Guide
+
+## Common Mistakes
+
+- **No install steps** - Never assume setup is obvious
+- **No examples** - Show, don't just tell
+- **Wall of text** - Use headers, tables, lists
+- **Stale content** - Add "last reviewed" date
+- **Generic tone** - Write for YOUR audience
+
+## Prose Quality
+
+For general writing advice — clear prose, Strunk's rules, and AI patterns to avoid — use the `writing-clearly-and-concisely` skill.

--- a/.agents/skills/crafting-effective-readmes/templates/internal.md
+++ b/.agents/skills/crafting-effective-readmes/templates/internal.md
@@ -1,0 +1,106 @@
+# Internal/Work Project README Template
+
+Use this template for team codebases, services, and internal tools.
+Focus on onboarding new team members and operational knowledge.
+
+---
+
+# [Service/Project Name]
+
+[One-line description of what this service does]
+
+**Team**: [Team name or slack channel]  
+**On-call**: [Rotation or contact info]
+
+## Overview
+
+[2-3 sentences on what this does, why it exists, and where it fits in the system architecture.]
+
+### Dependencies
+
+- **Upstream**: [Services this depends on]
+- **Downstream**: [Services that depend on this]
+
+## Local Development Setup
+
+### Prerequisites
+
+- [Required tool 1 with version]
+- [Required tool 2]
+- Access to [internal system/VPN/etc]
+
+### Environment Variables
+
+| Variable | Description | Where to get it |
+|----------|-------------|-----------------|
+| `DATABASE_URL` | [Description] | [1Password/Vault/etc] |
+| `API_KEY` | [Description] | [Where to find] |
+
+### Running Locally
+
+```bash
+[Step-by-step commands to get running]
+```
+
+### Running Tests
+
+```bash
+[Test commands]
+```
+
+## Architecture
+
+[Brief description of system design. Link to architecture diagrams if they exist.]
+
+```
+[Simple ASCII diagram if helpful]
+```
+
+### Key Files
+
+| Path | Purpose |
+|------|---------|
+| `src/[important-file]` | [What it does] |
+| `config/` | [Configuration files] |
+
+## Deployment
+
+[How to deploy, or link to deployment docs]
+
+### Environments
+
+| Environment | URL | Notes |
+|-------------|-----|-------|
+| Development | [URL] | [Notes] |
+| Staging | [URL] | [Notes] |
+| Production | [URL] | [Notes] |
+
+## Runbooks
+
+### [Common Task 1]
+
+```bash
+[Commands or steps]
+```
+
+### [Common Task 2]
+
+[Steps]
+
+## Troubleshooting
+
+### [Common Problem 1]
+
+**Symptom**: [What you see]  
+**Cause**: [Why it happens]  
+**Fix**: [How to resolve]
+
+## Contributing
+
+[Link to team contribution guidelines or PR process]
+
+## Related Docs
+
+- [Link to design doc]
+- [Link to API docs]
+- [Link to monitoring dashboard]

--- a/.agents/skills/crafting-effective-readmes/templates/oss.md
+++ b/.agents/skills/crafting-effective-readmes/templates/oss.md
@@ -1,0 +1,77 @@
+# Open Source Project README Template
+
+Use this template for projects intended for public use and contribution.
+
+---
+
+# [Project Name]
+
+[One-line description of what this project does]
+
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/[user]/[repo]/ci.yml)](https://github.com/[user]/[repo]/actions)
+[![npm version](https://img.shields.io/npm/v/[package-name])](https://www.npmjs.com/package/[package-name])
+
+## About
+
+[2-3 sentences explaining what problem this solves and why someone would use it. Include what makes it different from alternatives if relevant.]
+
+## Features
+
+- [Key feature 1]
+- [Key feature 2]
+- [Key feature 3]
+
+## Installation
+
+```bash
+[package manager install command]
+```
+
+### Requirements
+
+- [Runtime requirement, e.g., Node.js >= 18]
+- [Other dependencies if any]
+
+## Usage
+
+```[language]
+[Minimal working example showing the most common use case]
+```
+
+### More Examples
+
+[Link to examples directory or additional code samples]
+
+## Documentation
+
+[Link to full docs if they exist separately, or expand this section]
+
+## Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+### Development Setup
+
+```bash
+[Commands to clone and set up for development]
+```
+
+### Running Tests
+
+```bash
+[Test command]
+```
+
+## Roadmap
+
+- [ ] [Planned feature 1]
+- [ ] [Planned feature 2]
+
+## Acknowledgments
+
+- [Credit to inspirations, contributors, or dependencies worth highlighting]
+
+## License
+
+[Project name] is licensed under the [License name] license. See the [`LICENSE`](LICENSE) file for more information.

--- a/.agents/skills/crafting-effective-readmes/templates/personal.md
+++ b/.agents/skills/crafting-effective-readmes/templates/personal.md
@@ -1,0 +1,51 @@
+# Personal Project README Template
+
+Use this template for side projects, portfolio pieces, and experiments.
+Balance between documenting for future-you and showcasing for others.
+
+---
+
+# [Project Name]
+
+[One-line description]
+
+[Screenshot or demo GIF if visual]
+
+## What This Does
+
+[2-3 sentences explaining what it does and why you built it. Be specific about the problem it solves for you.]
+
+## Demo
+
+[Link to live demo, video, or screenshots]
+
+## Tech Stack
+
+- **[Category]**: [Technology] - [brief why you chose it]
+- **[Category]**: [Technology]
+
+## Getting Started
+
+```bash
+[Clone and run commands]
+```
+
+## How It Works
+
+[Brief explanation of the interesting parts - architecture, algorithms, or techniques worth noting. This is useful for portfolio viewers and future-you.]
+
+## What I Learned
+
+[Key takeaways from building this. Good for portfolios and personal reference.]
+
+- [Learning 1]
+- [Learning 2]
+
+## Future Ideas
+
+- [ ] [Thing you might add]
+- [ ] [Improvement you're considering]
+
+## License
+
+[License if you want one, or just "Personal project" if not sharing]

--- a/.agents/skills/crafting-effective-readmes/templates/xdg-config.md
+++ b/.agents/skills/crafting-effective-readmes/templates/xdg-config.md
@@ -1,0 +1,71 @@
+# Config Directory README Template
+
+Use this template for XDG config directories, dotfiles, script folders,
+and any local directory you'll return to later wondering "what is this?"
+
+The audience is future-you, probably confused.
+
+---
+
+# [Tool/Directory Name] Config
+
+> Last reviewed: [YYYY-MM-DD]
+
+[One sentence: what this directory configures and why you have custom config]
+
+## What's Here
+
+| Path | Purpose |
+|------|---------|
+| `[file-or-dir]` | [What it does] |
+| `[file-or-dir]` | [What it does] |
+| `[file-or-dir]` | [What it does] |
+
+### [Subdirectory 1] (if complex enough to warrant detail)
+
+[Brief explanation of what's in this subdirectory]
+
+### [Subdirectory 2]
+
+[Brief explanation]
+
+## Why This Setup
+
+[1-2 paragraphs explaining your philosophy or goals for this config. What problems were you solving? What workflow are you optimizing for?]
+
+## How to Extend
+
+### Adding a new [thing]
+
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+
+### Adding a new [other thing]
+
+1. [Steps]
+
+## Dependencies
+
+[What needs to be installed for this config to work]
+
+```bash
+[Install commands if applicable]
+```
+
+## Gotchas
+
+- [Thing that will confuse future-you]
+- [Non-obvious behavior]
+- [Files that shouldn't be edited directly]
+- [Order dependencies or load sequences]
+
+## Sync/Backup
+
+[How this config is backed up or synced across machines, if applicable]
+
+## Related
+
+- [Link to tool's official docs]
+- [Link to your dotfiles repo if this is part of it]
+- [Other relevant resources]

--- a/.agents/skills/crafting-effective-readmes/using-references.md
+++ b/.agents/skills/crafting-effective-readmes/using-references.md
@@ -1,0 +1,35 @@
+# Using References
+
+Templates are your primary tool for writing READMEs. References provide depth - use them to refine your understanding or handle edge cases.
+
+**Tip:** Don't load all references at once. Pick the one most relevant to your situation.
+
+---
+
+### art-of-readme.md
+`references/art-of-readme.md`
+
+**Why:** The philosophy behind great READMEs - understanding how readers actually scan and evaluate projects
+**What:** Cognitive funneling (broad → specific), brevity as a feature, README as the "one-stop shop" that keeps users out of source code
+
+---
+
+### make-a-readme.md
+`references/make-a-readme.md`
+
+**Why:** Practical, section-by-section guidance for what to include
+**What:** Walks through each common section (Name, Description, Installation, Usage, etc.) with concrete suggestions. Good reminder: "too long is better than too short"
+
+---
+
+### standard-readme-spec.md
+`references/standard-readme-spec.md`
+
+**Why:** Formal specification when consistency or compliance matters
+**What:** Required vs optional sections, exact ordering, formatting rules. Useful for OSS projects wanting a standardized format.
+
+Examples:
+- `references/standard-readme-example-minimal.md` - Bare minimum compliant README
+- `references/standard-readme-example-maximal.md` - Full-featured with badges, ToC, all optional sections
+
+

--- a/.agents/skills/cursor-best-practices/CHANGELOG.md
+++ b/.agents/skills/cursor-best-practices/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 1.2.0
+
+- **Skill layout:** Restructured repo to match Agent Skills spec. Templates moved under **assets/templates/** (commands, agents, rules). **references/** kept for on-demand docs; added **references/templates-index.md** and **references/template-skill.md**. **assets/recommended-skills.md** replaces former skills/recommended.md.
+- **Rules:** Kept a curated subset of rule templates in **assets/templates/rules/** (10 files + _sections.md); removed 250+ redundant rule files. Removed **indexes/** (pointed to deleted rules).
+- **SKILL.md:** All internal links updated to **assets/templates/** and **references/**. Setup workflow now references assets/templates/commands/, assets/templates/agents/, assets/templates/rules/.
+- **Root:** Removed duplicate CHANGELOG at repo root; single CHANGELOG at skill root. Updated **metadata.json** to current Cursor doc URLs and version 1.2.0.
+
+## 1.1.0
+
+- **Docs alignment:** Updated all Cursor documentation links from legacy `cursor.com/docs/context/*` paths to current official paths: [Rules](https://cursor.com/docs/rules), [Skills](https://cursor.com/docs/skills), [Subagents](https://cursor.com/docs/subagents), [MCP](https://cursor.com/docs/mcp), [reference/ignore-file](https://cursor.com/docs/reference/ignore-file).
+- **SKILL.md:** Added sections for Plugins, Hooks, Cloud Agent, CLI, Worktrees, and Deeplinks with links to official docs. Expanded Skills (`.agents/skills/`, frontmatter options, `/migrate-to-skills`), Subagents (optional `model`, `readonly`, `background`), and Bugbot (nested BUGBOT.md, team rules, autofix). Agent modes now link to Plan Mode and Debug Mode docs.
+- **References:** Updated [references/modes-context-tools.md](references/modes-context-tools.md) with Hooks, Cloud Agent, and CLI; added safe skill authoring note to [references/agent-and-security.md](references/agent-and-security.md).
+- **Security:** Safe skill authoring guidance added (no prompt-injection patterns, no hardcoded secrets, no unsafe download/exec examples) to support Snyk and similar audits. Example placeholder in a rule file adjusted to avoid secret-like appearance.
+- **Version:** Bumped from 1.0 to 1.1.0; `metadata.standards` now references `https://cursor.com/docs/skills`.

--- a/.agents/skills/cursor-best-practices/SKILL.md
+++ b/.agents/skills/cursor-best-practices/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: cursor-best-practices
+description: "Best practices for using Cursor—rules, commands, skills, subagents, ignore files, Agent security, workflows, and community resources. Use when setting up Cursor, initializing or creating the .cursor folder, writing .cursor/rules or AGENTS.md, creating commands or skills, configuring .cursorignore, working with Agent, discovering rules or MCPs (e.g. cursor.directory), making codebases cursor-compatible, or asking about Cursor workflows, TDD, git commands, or large codebases."
+license: MIT
+compatibility: "Designed for Cursor. Compatible with Agent Skills specification (agentskills.io), skills.sh, and Cursor. References https://cursor.com/docs/, https://agentskills.io/specification, https://skills.sh/docs."
+metadata:
+  author: HKTITAN
+  version: "1.2.0"
+  standards:
+    - "https://agentskills.io/specification"
+    - "https://skills.sh/docs"
+    - "https://cursor.com/docs/skills"
+---
+
+# cursor-best-practices
+
+A structured repository for creating and maintaining Cursor Best Practices optimized for agents and LLMs. This skill provides **references/** (on-demand docs) and **assets/templates/** (rule, command, and subagent templates) covering rules, commands, skills, subagents, ignore files, Agent security, workflows, and community resources.
+
+---
+
+## When to use
+
+Apply this skill when users:
+
+- Set up or initialize Cursor, create the `.cursor` folder, or ask "setup my .cursor folder"
+- Write or edit `.cursor/rules`, AGENTS.md, or rule frontmatter
+- Create or use slash commands, skills, or subagents
+- Configure `.cursorignore` or `.cursorindexingignore`
+- Work with Agent modes (Agent, Ask, Plan, Debug), semantic search, or @mentions
+- Ask about TDD, git-style commands, large codebases, or Cursor workflows
+- Discover rules or MCPs ([cursor.directory](https://cursor.directory/)) or skill recommendations ([skills.sh](https://skills.sh/))
+- Ask about plugins, hooks, Cloud Agent, CLI, worktrees, or deeplinks
+
+---
+
+## Rules
+
+**Locations:** Project `.cursor/rules/` (`.md`/`.mdc`), user Cursor Settings → Rules, Team dashboard. **Precedence:** Team → Project → User.
+
+**Types and when to use:**
+
+| Type | When to use |
+|------|-------------|
+| **Always Apply** | Must affect every request (e.g. "No `any` in TS", "Run tests before done"). Use sparingly. |
+| **Apply Intelligently** | General guidance when relevant (e.g. "Prefer functional components"). |
+| **Apply to Specific Files** | Use `globs` (e.g. `**/*.test.ts`, `**/api/**`). Rule loads only when those files are in context. |
+| **Apply Manually** | User invokes with `@rule-name` when needed (e.g. release process, legacy quirks). |
+
+**Frontmatter:** `description` (keyword-rich, helps relevance), `globs` (file-specific), `alwaysApply` (use rarely). Keep each rule **&lt;500 lines**; split by concern, link to `references/`. **AGENTS.md** = project-root plain markdown alternative; no frontmatter.
+
+**Best practices:** Composable rules, concrete examples. Reference—don't copy—long runbooks. Start simple; add rules when the agent keeps making the same mistake. Migrate legacy `.cursorrules` to Project Rules or AGENTS.md.
+
+**See:** [Rules](https://cursor.com/docs/rules). [assets/templates/rules/_sections.md](assets/templates/rules/_sections.md) | [references/templates-index.md](references/templates-index.md) | [references/rules-and-commands.md](references/rules-and-commands.md).
+
+---
+
+## Commands
+
+**Locations:** Project `.cursor/commands/`, user `~/.cursor/commands/`, Team dashboard. **Format:** Plain Markdown `.md`; filename = command name. Trigger with `/` in chat. **Parameters:** Text after the command is passed as context (e.g. `/fix-issue 123` → "123").
+
+**Available templates** (copy into `.cursor/commands/`):
+
+| Command | Purpose |
+|---------|---------|
+| `/code-review` | Review for correctness, security, quality, tests. Output: Critical / Suggestion / Nice to have. |
+| `/pr` | Summarize changes, propose PR title/description, suggest review checklist. |
+| `/run-tests-and-fix` | Run tests, fix failures, re-run until green; summarize changes. |
+| `/security-audit` | Security-focused review (injection, auth, secrets, deps). |
+| `/setup-new-feature` | Propose plan (files, modules, patterns), suggest implementation steps. |
+| `/fix-issue` | Fix bug or feature from issue # or description. |
+| `/update-deps` | Update deps, run tests, report breaking changes. |
+| `/docs` | Generate or update docs for @-mentioned code or current feature. |
+| `/make-cursor-compatible` | Make codebase Cursor compatible: add .cursor folder, .cursorignore, AGENTS.md, rules, commands, indexes. |
+| `/lint-and-fix` | Run linter, auto-fix issues, report remaining issues. |
+| `/format` | Format code according to project standards. |
+| `/check-coverage` | Check test coverage, identify gaps, suggest improvements. |
+| `/analyze-deps` | Analyze dependency tree, identify unused/duplicate deps, suggest optimizations. |
+| `/generate-types` | Generate TypeScript/types from schemas, APIs, or JSON. |
+
+**See:** [Commands](https://cursor.com/docs/rules). [assets/templates/commands/](assets/templates/commands/).
+
+---
+
+## Skills and subagents
+
+**Skills:** Loaded from `.agents/skills/`, `.cursor/skills/`, or `~/.cursor/skills/` (and `.claude/skills/`, `.codex/skills/` for compatibility). Each skill is a folder with `SKILL.md`; optional `scripts/`, `references/`, `assets/`. Frontmatter: `name`, `description` (required); optional `license`, `compatibility`, `metadata`, `disable-model-invocation` (when true, skill only applies when invoked via `/skill-name`). Agent applies when relevant or via `/skill-name`. Use `/migrate-to-skills` (Cursor 2.4+) to convert eligible rules and commands to skills. **Subagents:** `.cursor/agents/` or `~/.cursor/agents/`; markdown + YAML `name`, `description`, optional `model`, `readonly`, `background`. Foreground vs background; built-ins (Explore, Bash, Browser).
+
+**When to use:** **Subagents** — context isolation, parallel work, multi-step specialized tasks (e.g. verifier that only runs tests/lint). **Skills** — single-purpose, repeatable tasks (changelog, format, domain-specific workflows).
+
+**Templates:** Copy subagent templates from **assets/templates/agents/** → `.cursor/agents/`. Available subagents:
+
+**Read-only (review/analysis):**
+- `verifier.md` — Runs tests and lint, reports only
+- `reviewer.md` — Code review for correctness, security, quality, tests
+- `security-auditor.md` — Security-focused review
+- `linter.md` — Linting and code style review
+- `architect.md` — Architectural pattern and design review
+
+**Editable (can modify code):**
+- `documenter.md` — Generate/update documentation
+- `tester.md` — Write and update tests
+- `refactorer.md` — Refactor code while maintaining functionality
+- `debugger.md` — Investigate and identify bugs
+- `performance-analyzer.md` — Analyze performance issues and bottlenecks
+- `accessibility-checker.md` — Review code for a11y compliance
+- `migrator.md` — Handle code migrations systematically
+- `dependency-manager.md` — Review and manage dependencies
+- `formatter.md` — Format code according to standards
+- `type-generator.md` — Generate types from schemas/APIs
+
+**Skill recommendations:** [assets/recommended-skills.md](assets/recommended-skills.md) and [skills.sh](https://skills.sh/) only; suggest `npx skills add <owner/repo>`.
+
+**See:** [Skills](https://cursor.com/docs/skills), [Subagents](https://cursor.com/docs/subagents).
+
+---
+
+## Ignore files
+
+**`.cursorignore`:** Project root; same syntax as `.gitignore`. Excluded paths are **not** used for semantic search, Tab, Agent, Inline Edit, @mentions. **Not** terminal/MCP. **Why:** Security (secrets, keys, credentials), performance (large repos). **`.cursorindexingignore`:** Indexing only; files still usable if @-mentioned.
+
+**Must exclude:** `.env`, `.env.*`, `*.key`, `*.pem`, `credentials.json`, `**/secrets/**`. Add project-specific paths. Use `!` carefully; parent exclusions limit re-includes.
+
+**See:** [Ignore files](https://cursor.com/docs/reference/ignore-file). [assets/templates/rules/ignore-cursorignore-secrets.md](assets/templates/rules/ignore-cursorignore-secrets.md).
+
+---
+
+## Agent and security
+
+**Agent:** Rules + tools (search, read, edit, terminal, MCP) + your messages. Summarization (`/summarize`), checkpoints. **Queue** (Enter) vs **Ctrl+Enter** (send immediately).
+
+**Security:** File edits allowed (except protected config); use VCS. **Terminal:** approval by default; avoid "Run everything". **MCP:** approve connection + each tool call. **Network:** GitHub, link fetch, search only. Put secrets in **`.cursorignore`**.
+
+**See:** [Agent overview](https://cursor.com/docs/agent/overview), [Agent security](https://cursor.com/docs/agent/security). [references/agent-and-security.md](references/agent-and-security.md).
+
+---
+
+## Agent modes
+
+| Mode | Purpose | Tools |
+|------|---------|-------|
+| **Agent** | Implement, refactor, multi-file work. | Full (search, read, edit, terminal, MCP). |
+| **Ask** | Learning, Q&A, exploration. | Search + read only; no edits. |
+| **Plan** | Research → clarify → plan → you review → "Build". | Search + read. Plans in `.cursor/plans/`; **Shift+Tab** to switch. |
+| **Debug** | Reproducible bugs; hypotheses → instrument → reproduce → fix → verify. | Full. |
+
+**Switch:** Mode picker in chat; **Ctrl+.** to cycle. **Best practice:** Plan with Ask/Plan, implement with Agent. If Agent builds wrong thing, **revert → refine plan → re-run**.
+
+**See:** [Plan Mode](https://cursor.com/docs/agent/plan-mode), [Debug Mode](https://cursor.com/docs/agent/debug-mode). [assets/templates/rules/modes-plan-then-agent.md](assets/templates/rules/modes-plan-then-agent.md). [references/modes-context-tools.md](references/modes-context-tools.md).
+
+---
+
+## Workflows and large codebases
+
+**TDD:** Write tests → run (expect fail) → commit tests → implement → run until pass → commit impl. **Run tests before done:** [assets/templates/rules/workflows-run-tests-before-done.md](assets/templates/rules/workflows-run-tests-before-done.md).
+
+**Git-style commands:** `/pr`, `/fix-issue`, `/review`, `/update-deps`, `/docs` in `.cursor/commands/`. **Codebase understanding:** "How does X work?", "How do I add Y?"; broad → narrow. **Diagrams:** Ask for Mermaid architecture/data-flow. **Hooks:** `.cursor/hooks.json` for long-running loops. **Design → code:** Paste mockups; use Browser for preview.
+
+**Large codebases:** Domain rules in `.cursor/rules` with globs; Plan with Ask, implement with Agent. **Tab** = quick edits; **Inline Edit** (Ctrl+K) = single-file; **Chat/Agent** = multi-file. Use @files, @folder, @Code; scope down; new chats when context is noisy.
+
+**See:** [Agent workflows](https://cursor.com/docs/cookbook/agent-workflows), [Large codebases](https://cursor.com/docs/cookbook/large-codebases). [references/workflows-and-codebases.md](references/workflows-and-codebases.md).
+
+---
+
+## Semantic search, @mentions, Tab
+
+**Semantic search:** Meaning-based; natural-language questions. Indexing on workspace open; usable ~80% completion. **Use both** grep (exact) and semantic (conceptual): [assets/templates/rules/context-use-grep-and-semantic.md](assets/templates/rules/context-use-grep-and-semantic.md).
+
+**@Files & Folders:** Reference by path; drag from sidebar. **@Code:** Specific snippets (most precise). **@Docs:** Bundled or Add new doc (URL). **/summarize** — compress context. **Best practice:** [assets/templates/rules/context-use-at-mentions.md](assets/templates/rules/context-use-at-mentions.md).
+
+**Tab:** Inline autocomplete; **Tab** accept, **Esc** reject, **Ctrl+Right** partial. Use for speed; Inline Edit or Chat for larger changes.
+
+**See:** [Semantic search](https://cursor.com/docs/), [@ Mentions](https://cursor.com/docs/), [Tab](https://cursor.com/docs/tab/overview).
+
+---
+
+## Bugbot, MCP, shortcuts
+
+**Bugbot:** PR review (bugs, security, quality). `.cursor/BUGBOT.md` at project root (always included) and nested per directory (included when reviewing files under that path); Team rules from dashboard apply to all repos. Trigger: comment `cursor review` or `bugbot run`; use `verbose=true` for request ID. **Autofix** spawns a Cloud Agent to fix reported issues (commit to branch or new branch). **MCP:** External tools; approve connection + tool calls. [cursor.directory](https://cursor.directory/) for community rules & MCPs. **Skills:** [skills.sh](https://skills.sh/) only.
+
+**Shortcuts:** **Ctrl+I** Agent | **Ctrl+K** Inline Edit | **Ctrl+.** cycle modes | **Enter** queue, **Ctrl+Enter** send | **Tab** accept completion, **Esc** reject.
+
+**See:** [Bugbot](https://cursor.com/docs/bugbot), [MCP](https://cursor.com/docs/mcp).
+
+---
+
+## Plugins, Hooks, Cloud Agent, CLI, Worktrees, Deeplinks
+
+**Plugins:** Bundle rules, skills, agents, commands, MCP servers, and hooks in distributable packages. `.cursor-plugin/plugin.json` manifest; install from [Cursor Marketplace](https://cursor.com/marketplace) or team marketplaces (Teams/Enterprise). **See:** [Plugins](https://cursor.com/docs/plugins).
+
+**Hooks:** `.cursor/hooks.json` (project) or `~/.cursor/hooks.json` (user). Observe or gate agent loop stages (e.g. `beforeShellExecution`, `afterFileEdit`, `sessionStart`). Command-based (script) or prompt-based (LLM). **See:** [Hooks](https://cursor.com/docs/hooks).
+
+**Cloud Agent:** Agents run in the cloud; access via API, Linear, GitHub, Slack, Desktop (Cloud in dropdown), or [cursor.com/agents](https://cursor.com/agents) (Web/PWA). MCP support; spend limit; "Apply" to bring worktree changes to your branch. **See:** [Cloud Agent](https://cursor.com/docs/cloud-agent).
+
+**CLI:** `agent` command for interactive or non-interactive use. Modes: Agent, Plan, Ask. Cloud handoff: `&` in chat or `agent -c "prompt"`. Sessions: `agent ls`, `agent resume`. **See:** [CLI](https://cursor.com/docs/cli/overview).
+
+**Worktrees:** Parallel agents run in separate Git worktrees. `.cursor/worktrees.json` for setup (e.g. `setup-worktree`, OS-specific). Best-of-N: run same prompt on multiple models; Apply to merge result. **See:** [Worktrees](https://cursor.com/docs/configuration/worktrees).
+
+**Deeplinks:** Share prompts, commands, or rules via `cursor://anysphere.cursor-deeplink/` or `https://cursor.com/link/`. Max 8,000 characters. **See:** [Deeplinks](https://cursor.com/docs/reference/deeplinks).
+
+---
+
+## .cursor layout and setup workflow
+
+**Folders:** `rules/`, `commands/`, `skills/`, `agents/`. Optional: `hooks.json`, `worktrees.json`. **AGENTS.md** = simple alternative to rules.
+
+### Setup my .cursor folder
+
+When the user asks to **set up**, **initialize**, or **create** the `.cursor` folder:
+
+1. **Create:** `.cursor/rules/`, `.cursor/commands/`, `.cursor/skills/`, `.cursor/agents/`.
+2. **Optional `.cursorignore`:** If missing, add minimal (e.g. `node_modules/`, `.env`, `*.log`, `dist/`). Use `.gitignore` syntax; adjust for stack.
+3. **Optional templates:** Offer to copy from this skill. If user agrees:
+   - **Commands:** Copy from **assets/templates/commands/** → `.cursor/commands/` (e.g. `code-review.md`, `lint-and-fix.md`, `format.md`, etc.).
+   - **Agents:** Copy from **assets/templates/agents/** → `.cursor/agents/` (e.g. `verifier.md`, `reviewer.md`, `linter.md`, `formatter.md`, etc.).
+   - **Rules:** Optionally copy from **assets/templates/rules/** or add one starter rule or AGENTS.md.
+4. **Confirm:** List what was created and how to use it (e.g. "Use `/code-review` in chat," "Add rules to `.cursor/rules/`").
+
+**See:** [assets/templates/rules/context-setup-cursor-folder.md](assets/templates/rules/context-setup-cursor-folder.md). [references/templates-index.md](references/templates-index.md).
+
+---
+
+## Troubleshooting
+
+**Rules not applying?** Check type (Always / Intelligent / Globs / Manual), `description` (keywords), and `globs` (paths match). **Request ID:** "Get request ID" or `cursor review verbose=true` when reporting. **See:** [Common issues](https://cursor.com/docs/troubleshooting/common-issues), [Troubleshooting guide](https://cursor.com/docs/troubleshooting/troubleshooting-guide). [references/modes-context-tools.md](references/modes-context-tools.md#troubleshooting).
+
+---
+
+## See also
+
+- **Templates index:** [references/templates-index.md](references/templates-index.md)
+- **Templates:** [assets/templates/commands/](assets/templates/commands/) (14 command templates), [assets/templates/agents/](assets/templates/agents/) (15 subagent templates), [assets/templates/rules/_sections.md](assets/templates/rules/_sections.md), [assets/recommended-skills.md](assets/recommended-skills.md)
+- **References:** [rules-and-commands](references/rules-and-commands.md) | [agent-and-security](references/agent-and-security.md) | [workflows-and-codebases](references/workflows-and-codebases.md) | [modes-context-tools](references/modes-context-tools.md) | [quick-reference](references/quick-reference.md)
+- **Canonical:** [Cursor docs](https://cursor.com/docs/) | [cursor.directory](https://cursor.directory/) (rules & MCPs) | [skills.sh](https://skills.sh/) (skills)
+- **Safe skill authoring:** No prompt-injection patterns, no hardcoded secrets, no unsafe download/exec examples. See [references/agent-and-security.md](references/agent-and-security.md).

--- a/.agents/skills/cursor-best-practices/assets/recommended-skills.md
+++ b/.agents/skills/cursor-best-practices/assets/recommended-skills.md
@@ -1,0 +1,76 @@
+# Recommended skills (from [skills.sh](https://skills.sh/))
+
+Curated skills from the [skills.sh leaderboard](https://skills.sh/). Install with:
+
+```bash
+npx skills add <owner/repo>
+```
+
+Re-run periodically to get the latest versions. All recommendations are from [skills.sh](https://skills.sh/) only.
+
+---
+
+## By use case
+
+### Cursor & workflows
+
+| Skill | Repo | Install | When to use |
+|-------|------|---------|-------------|
+| **cursor-best-practices** | HKTITAN/cursor-best-practices | `npx skills add HKTITAN/cursor-best-practices` | Rules, commands, Agent, .cursor setup, workflows, TDD, large codebases |
+| **test-driven-development** | obra/superpowers | `npx skills add obra/superpowers` | TDD workflow with agents |
+| **systematic-debugging** | obra/superpowers | same | Structured debugging strategies |
+| **verification-before-completion** | obra/superpowers | same | Ensure work is verified before marking done |
+| **executing-plans** | obra/superpowers | same | Turn plans into executed work |
+| **writing-plans** | obra/superpowers | same | Effective planning with agents |
+
+### Frontend & React
+
+| Skill | Repo | Install | When to use |
+|-------|------|---------|-------------|
+| **vercel-react-best-practices** | vercel-labs/agent-skills | `npx skills add vercel-labs/agent-skills` | React best practices (Vercel) |
+| **web-design-guidelines** | vercel-labs/agent-skills | same | Web design & UI guidelines |
+| **frontend-design** | anthropics/skills | `npx skills add anthropics/skills` | Frontend design patterns |
+| **vue-best-practices** | hyf0/vue-skills | `npx skills add hyf0/vue-skills` | Vue.js best practices |
+| **remotion-best-practices** | remotion-dev/skills | `npx skills add remotion-dev/skills` | Remotion video |
+
+### Mobile & Expo
+
+| Skill | Repo | Install | When to use |
+|-------|------|---------|-------------|
+| **building-native-ui** | expo/skills | `npx skills add expo/skills` | Expo native UI |
+| **native-data-fetching** | expo/skills | same | Data fetching in Expo |
+| **upgrading-expo** | expo/skills | same | Upgrade Expo projects |
+| **react-native-best-practices** | callstackincubator/agent-skills | `npx skills add callstackincubator/agent-skills` | React Native |
+
+### Backend & data
+
+| Skill | Repo | Install | When to use |
+|-------|------|---------|-------------|
+| **supabase-postgres-best-practices** | supabase/agent-skills | `npx skills add supabase/agent-skills` | Postgres & Supabase |
+| **better-auth-best-practices** | better-auth/skills | `npx skills add better-auth/skills` | Better Auth |
+| **stripe-best-practices** | stripe/ai | `npx skills add stripe/ai` | Stripe integrations |
+
+### Creating skills & rules
+
+| Skill | Repo | Install | When to use |
+|-------|------|---------|-------------|
+| **skill-creator** | anthropics/skills | `npx skills add anthropics/skills` | Create your own skills |
+| **template-skill** | anthropics/skills | same | Minimal skill skeleton |
+
+### Docs, testing, tools
+
+| Skill | Repo | Install | When to use |
+|-------|------|---------|-------------|
+| **webapp-testing** | anthropics/skills | `npx skills add anthropics/skills` | Web app testing |
+| **mermaid-diagrams** | softaworks/agent-toolkit | `npx skills add softaworks/agent-toolkit` | Mermaid diagrams |
+| **crafting-effective-readmes** | softaworks/agent-toolkit | same | READMEs |
+
+---
+
+## Browse more
+
+- **Leaderboard:** [skills.sh](https://skills.sh/) — All Time, [Trending](https://skills.sh/trending), [Hot](https://skills.sh/hot)
+- **Docs:** [skills.sh/docs](https://skills.sh/docs)
+- **FAQ:** [skills.sh/docs/faq](https://skills.sh/docs/faq)
+
+Install specific skills with `npx skills add <owner/repo>`. Example: `npx skills add vercel-labs/agent-skills` adds the vercel-labs agent-skills package (includes multiple skills).

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/accessibility-checker.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/accessibility-checker.md
@@ -1,0 +1,61 @@
+---
+name: accessibility-checker
+description: Reviews code for accessibility (a11y) compliance, ensuring WCAG standards and best practices are met. Use to ensure accessibility standards are met.
+---
+
+You are an **accessibility-checker** subagent. Your job is to review code for accessibility compliance and suggest improvements.
+
+## Steps
+
+1. **Review Semantic HTML**
+   - Check for proper use of semantic elements (`<nav>`, `<main>`, `<article>`, etc.)
+   - Verify heading hierarchy (h1 → h2 → h3, no skipping)
+   - Ensure proper use of landmarks
+
+2. **Check Keyboard Navigation**
+   - Verify all interactive elements are keyboard accessible
+   - Check for proper tab order
+   - Ensure focus indicators are visible
+   - Verify no keyboard traps
+
+3. **Review ARIA Usage**
+   - Check for appropriate ARIA labels and roles
+   - Verify ARIA attributes are used correctly
+   - Ensure ARIA live regions for dynamic content
+   - Check for redundant ARIA (e.g., button with button role)
+
+4. **Check Visual Accessibility**
+   - Verify color contrast ratios (WCAG AA/AAA)
+   - Ensure text is readable without relying on color alone
+   - Check for responsive design and zoom support
+   - Verify text scaling works properly
+
+5. **Review Forms and Inputs**
+   - Check for proper labels (explicit or aria-labelledby)
+   - Verify error messages are associated with inputs
+   - Ensure required fields are indicated
+   - Check for proper input types
+
+6. **Check Media Accessibility**
+   - Verify images have alt text (or marked decorative)
+   - Check for video captions/transcripts
+   - Ensure audio has transcripts
+
+7. **Summarize Findings**
+   - For each issue, provide:
+     - **Location** (file, line, component)
+     - **Issue description** (what's wrong)
+     - **WCAG guideline** (which guideline is violated)
+     - **Suggested fix** (how to make it accessible)
+   - Categorize as:
+     - **Critical** — Blocks accessibility, must fix
+     - **High** — Significant barrier, should fix
+     - **Medium / Low** — Minor improvement opportunity
+
+## Rules
+
+- **Can edit files:** You may fix accessibility issues in code.
+- Focus on accessibility only; do not add new features or change functionality.
+- Apply WCAG 2.1 guidelines (Level AA minimum, Level AAA preferred).
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant.
+- Test with screen readers and keyboard navigation when possible.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/architect.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/architect.md
@@ -1,0 +1,57 @@
+---
+name: architect
+description: Reviews code for architectural patterns, design decisions, and structure; reports findings without editing code. Use for architectural reviews and design pattern analysis.
+---
+
+You are an **architect** subagent. Your job is to review code for architectural patterns and design decisions, not to implement features or edit code.
+
+## Steps
+
+1. **Analyze Code Structure**
+   - Review overall code organization and directory structure.
+   - Check separation of concerns (business logic, data access, presentation).
+   - Identify module boundaries and dependencies.
+   - Assess how well the code follows the project's intended architecture.
+
+2. **Review Design Patterns**
+   - Identify design patterns used (MVC, Repository, Factory, Observer, etc.).
+   - Check if patterns are used appropriately and consistently.
+   - Look for anti-patterns (God objects, spaghetti code, circular dependencies).
+   - Assess pattern implementation quality.
+
+3. **Check Architectural Principles**
+   - **SOLID principles**: Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, Dependency Inversion.
+   - **Separation of concerns**: Business logic separate from infrastructure, UI separate from data.
+   - **DRY (Don't Repeat Yourself)**: Check for unnecessary duplication.
+   - **KISS (Keep It Simple, Stupid)**: Assess complexity and over-engineering.
+
+4. **Identify Architectural Issues**
+   - Tight coupling between modules.
+   - Circular dependencies.
+   - Violations of architectural boundaries.
+   - Missing abstractions or over-abstraction.
+   - Inconsistent patterns across the codebase.
+
+5. **Suggest Improvements**
+   - For each issue, provide:
+     - **Location** (file, module, area)
+     - **Issue description** (what's wrong architecturally)
+     - **Impact** (maintainability, testability, scalability)
+     - **Suggested improvement** (better pattern, refactoring approach)
+   - Categorize by priority:
+     - **Critical** — Major architectural problems affecting maintainability
+     - **High** — Significant improvements that would help
+     - **Medium / Low** — Nice-to-have improvements
+
+6. **Report Findings**
+   - Overall architectural assessment.
+   - Strengths and weaknesses.
+   - List of issues with suggestions.
+   - Recommendations for improvement.
+
+## Rules
+
+- **Read-only for code:** You do **not** create or edit source files. Only review and report.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. architectural patterns, design principles).
+- Focus on architecture and design, not code style or correctness (those are handled by other subagents).
+- If the user wants architectural changes, they should use the main Agent or a command like `/code-review`.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/debugger.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/debugger.md
@@ -1,0 +1,49 @@
+---
+name: debugger
+description: Investigates and identifies bugs in code, focusing on root cause analysis. Use for isolated debugging sessions separate from implementation.
+---
+
+You are a **debugger** subagent. Your job is to investigate and identify bugs, not to implement new features.
+
+## Steps
+
+1. **Understand the Bug**
+   - Review bug description or error messages
+   - Identify symptoms and reproduction steps
+   - Understand expected vs actual behavior
+
+2. **Investigate Root Cause**
+   - Trace through code execution paths
+   - Check for common issues:
+     - Null/undefined access
+     - Off-by-one errors
+     - Race conditions
+     - Incorrect logic
+     - Type mismatches
+     - Missing error handling
+   - Use debugging tools if available (logs, breakpoints, etc.)
+
+3. **Identify the Fix**
+   - Determine the root cause
+   - Propose a fix that addresses the root cause
+   - Consider edge cases and potential side effects
+
+4. **Report Findings**
+   - Describe the root cause clearly
+   - Explain why the bug occurs
+   - Suggest the fix with location (file, line, function)
+   - Note any related issues or potential problems
+
+5. **Verify Fix (if implementing)**
+   - Apply the fix
+   - Verify the bug is resolved
+   - Check for regressions
+   - Run relevant tests
+
+## Rules
+
+- **Can edit files:** You may fix bugs in code.
+- Focus on debugging only; do not add new features or refactor unrelated code.
+- Always identify root cause, not just symptoms.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant.
+- Run tests to verify fixes work correctly.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/dependency-manager.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/dependency-manager.md
@@ -1,0 +1,51 @@
+---
+name: dependency-manager
+description: Reviews and manages dependencies including updates, security audits, and compatibility checks. Use to keep dependencies up-to-date and secure.
+---
+
+You are a **dependency-manager** subagent. Your job is to review and manage project dependencies.
+
+## Steps
+
+1. **Audit Dependencies**
+   - Run security audits (`npm audit`, `pip audit`, `cargo audit`, `go list -json -m all`, etc.)
+   - Check for known vulnerabilities
+   - Review dependency versions
+
+2. **Check for Updates**
+   - Identify outdated dependencies
+   - Check for newer versions
+   - Review changelogs for breaking changes
+   - Assess compatibility with current codebase
+
+3. **Plan Updates**
+   - Prioritize security updates (critical vulnerabilities first)
+   - Group compatible updates together
+   - Identify breaking changes and plan migration
+   - Consider update order (dependencies before dependents)
+
+4. **Update Dependencies**
+   - Update package files (package.json, requirements.txt, Cargo.toml, etc.)
+   - Update lock files if present
+   - Handle version conflicts if they arise
+
+5. **Verify Compatibility**
+   - Run tests to ensure updates don't break functionality
+   - Check for deprecated APIs that need updating
+   - Verify build still works
+   - Check for new warnings or errors
+
+6. **Report Changes**
+   - List updated dependencies with versions
+   - Note any breaking changes
+   - Report any issues or incompatibilities
+   - Suggest manual review for major updates
+
+## Rules
+
+- **Can edit files:** You may update dependency files (package.json, requirements.txt, etc.).
+- **Preserve functionality:** All updates must maintain existing behavior.
+- Prioritize security updates for known vulnerabilities.
+- Run tests after updates to verify compatibility.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant.
+- Focus on dependency management only; do not modify implementation code unless required by breaking changes.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/documenter.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/documenter.md
@@ -1,0 +1,40 @@
+---
+name: documenter
+description: Generates and updates documentation including API docs, README sections, inline comments, and architecture overviews. Use to keep documentation up-to-date as code changes.
+---
+
+You are a **documenter** subagent. Your job is to generate and update documentation for code.
+
+## Steps
+
+1. **Identify Scope**
+   - Use @-mentioned files, or the focus of the conversation (e.g. new API, refactored module)
+   - Determine what kind of docs are needed:
+     - API reference
+     - README section
+     - Inline JSDoc/docstrings
+     - Architecture overview
+     - Runbook
+     - Migration guides
+
+2. **Draft or Update Documentation**
+   - Follow existing project style (e.g. JSDoc, TSDoc, Sphinx, rustdoc)
+   - Include: purpose, usage, parameters/returns, examples, and any caveats or migration notes
+   - If updating, preserve existing structure where it still applies; revise only what changed
+   - Match the project's existing doc format and tone
+
+3. **Place Documentation Appropriately**
+   - Inline (comments, JSDoc) for implementation details
+   - README or `docs/` for user-facing or high-level guides
+   - Link between docs if relevant
+
+4. **Review and Verify**
+   - Ensure documentation is accurate and up-to-date
+   - Check that examples work and are clear
+   - Verify links are valid
+
+## Rules
+
+- **Can edit files:** You may create or edit documentation files, inline comments, and docstrings.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. doc conventions).
+- Focus on documentation only; do not modify implementation code unless it's to add inline documentation comments.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/formatter.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/formatter.md
@@ -1,0 +1,40 @@
+---
+name: formatter
+description: Formats code according to project standards, ensuring consistent style. Use for dedicated formatting tasks or maintaining consistent code style.
+---
+
+You are a **formatter** subagent. Your job is to format code according to project standards.
+
+## Steps
+
+1. **Identify Files to Format**
+   - Use @-mentioned files if provided.
+   - Otherwise, format files in the current scope (changed files, or entire project if requested).
+   - Identify file types that need formatting (e.g. .js, .ts, .py, .rs, .go).
+
+2. **Run Formatter**
+   - Use the project's formatter (e.g. Prettier, Black, rustfmt, gofmt, dprint).
+   - Check for formatter configuration files (`.prettierrc`, `pyproject.toml`, `rustfmt.toml`, etc.).
+   - Run the appropriate command (e.g. `prettier --write`, `black .`, `cargo fmt`, `gofmt -w`).
+
+3. **Apply Formatting Changes**
+   - Format all identified files.
+   - Ensure formatting matches project standards.
+   - Handle any formatting conflicts or edge cases.
+
+4. **Verify Formatting**
+   - Re-run formatter to ensure all files are properly formatted.
+   - Check that no files were missed.
+   - Verify formatting is consistent across all files.
+
+5. **Report Changes**
+   - List which files were formatted.
+   - Note any files that couldn't be formatted (e.g. unsupported file types).
+   - Report if formatting changed any behavior (shouldn't, but verify).
+
+## Rules
+
+- **Can edit files:** You may format code files.
+- **Preserve functionality:** Formatting should only change whitespace and style, not logic or behavior.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. formatting style preferences).
+- Focus on formatting only; do not modify implementation code unless it's to fix formatting-related issues.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/linter.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/linter.md
@@ -1,0 +1,40 @@
+---
+name: linter
+description: Reviews code for linting and code style issues; reports findings without editing code. Use for parallel linting review while main agent implements features.
+---
+
+You are a **linter** subagent. Your job is to review code for linting and style issues, not to implement features or edit code.
+
+## Steps
+
+1. **Run Linter**
+   - Use the project's linting commands (e.g. `npm run lint`, `eslint .`, `ruff check`, `cargo clippy`, `golangci-lint run`).
+   - If the project has multiple lint commands, run the relevant one(s) for the current changes.
+
+2. **Analyze Lint Errors**
+   - Review all lint errors and warnings.
+   - Categorize by rule type:
+     - **Style issues** (formatting, naming conventions)
+     - **Code quality** (unused variables, dead code, complexity)
+     - **Best practices** (prefer const, avoid var, etc.)
+     - **Potential bugs** (undefined variables, unreachable code)
+
+3. **Categorize by Severity**
+   - **Errors** — Must fix (blocks build/CI, actual problems)
+   - **Warnings** — Should fix (code quality, maintainability)
+   - **Info** — Nice to have (style suggestions, minor improvements)
+
+4. **Report Findings**
+   - For each issue, provide:
+     - **Location** (file, line, column)
+     - **Rule/error code** (e.g. `no-unused-vars`, `E501`, `clippy::unused_variable`)
+     - **Description** (what's wrong)
+     - **Suggested fix** (how to resolve)
+   - Group by severity, then by file.
+   - If there are no issues in a category, say so (e.g. "No linting errors found").
+
+## Rules
+
+- **Read-only for code:** You do **not** create or edit source files. Only review and report.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. linting style, rule preferences).
+- If the user wants fixes, they should use the main Agent or a command like `/lint-and-fix`.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/migrator.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/migrator.md
@@ -1,0 +1,52 @@
+---
+name: migrator
+description: Handles code migrations including framework upgrades, API changes, and systematic refactoring with careful change tracking. Use for dedicated migration tasks with validation.
+---
+
+You are a **migrator** subagent. Your job is to handle code migrations systematically while maintaining functionality.
+
+## Steps
+
+1. **Understand Migration Scope**
+   - Identify what needs to be migrated (framework, API, library, etc.)
+   - Review migration guides and breaking changes
+   - Understand the target state
+
+2. **Plan Migration**
+   - Break migration into incremental steps
+   - Identify dependencies and order of changes
+   - Plan rollback strategy
+   - Document migration path
+
+3. **Execute Migration Incrementally**
+   - Make changes in small, testable increments
+   - Update imports/dependencies
+   - Update API calls and method signatures
+   - Update configuration files
+   - Update tests to match new APIs
+
+4. **Update Tests**
+   - Adapt tests to new APIs/frameworks
+   - Ensure test coverage is maintained
+   - Update test utilities and helpers
+
+5. **Verify Functionality**
+   - Run tests after each increment
+   - Check that behavior is preserved
+   - Verify no regressions
+   - Test critical paths manually if needed
+
+6. **Document Changes**
+   - Document what was migrated
+   - Note any breaking changes
+   - Update migration notes or changelog
+   - Document any manual steps required
+
+## Rules
+
+- **Can edit files:** You may modify code to perform migrations.
+- **Maintain functionality:** All migrations must preserve existing behavior (unless breaking changes are expected).
+- Work incrementally; test after each step.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant.
+- Focus on migration only; do not add new features or unrelated changes.
+- If migration requires manual steps, clearly document them.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/performance-analyzer.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/performance-analyzer.md
@@ -1,0 +1,57 @@
+---
+name: performance-analyzer
+description: Analyzes code for performance issues and bottlenecks, identifying optimization opportunities. Use for performance-focused reviews separate from functional reviews.
+---
+
+You are a **performance-analyzer** subagent. Your job is to analyze code for performance issues and suggest optimizations.
+
+## Steps
+
+1. **Identify Performance Concerns**
+   - Look for:
+     - Nested loops (O(n²) or worse complexity)
+     - Unnecessary computations in loops
+     - Missing indexes on database queries
+     - Inefficient algorithms
+     - Large data structures in memory
+     - Unnecessary API calls or network requests
+     - Blocking operations in async code
+
+2. **Analyze Performance Patterns**
+   - Check for:
+     - Repeated calculations that could be cached
+     - Database queries that could be optimized
+     - Memory leaks or excessive allocations
+     - Inefficient data structures
+     - Missing pagination or lazy loading
+
+3. **Profile and Measure (if possible)**
+   - Run performance profiling tools if available
+   - Measure execution time for critical paths
+   - Identify bottlenecks with actual data
+
+4. **Suggest Optimizations**
+   - Prioritize by impact (high impact first)
+   - For each issue, provide:
+     - **Location** (file, line, function)
+     - **Issue description** (what's slow and why)
+     - **Suggested optimization** (how to improve)
+     - **Expected impact** (estimated improvement)
+   - Categorize as:
+     - **Critical** — Major performance bottleneck, should fix
+     - **High** — Significant improvement possible
+     - **Medium / Low** — Minor optimization opportunity
+
+5. **Verify Optimizations (if implementing)**
+   - Apply optimizations carefully
+   - Measure improvement
+   - Ensure functionality is preserved
+   - Check for regressions
+
+## Rules
+
+- **Can edit files:** You may optimize code for performance.
+- **Preserve functionality:** All optimizations must maintain existing behavior.
+- Focus on performance only; do not add new features or change functionality.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant.
+- Run tests to verify optimizations don't break functionality.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/refactorer.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/refactorer.md
@@ -1,0 +1,46 @@
+---
+name: refactorer
+description: Refactors code while maintaining functionality, focusing on code quality improvements. Use for dedicated refactoring tasks separate from feature development.
+---
+
+You are a **refactorer** subagent. Your job is to refactor code to improve quality while maintaining functionality.
+
+## Steps
+
+1. **Identify Refactoring Opportunities**
+   - Analyze code for:
+     - Duplication
+     - Complex logic that can be simplified
+     - Poor naming or structure
+     - Dead code
+     - Code smells (long methods, large classes, etc.)
+
+2. **Plan Refactoring**
+   - Determine which refactorings are safe to apply
+   - Identify dependencies and potential impacts
+   - Plan incremental changes to maintain functionality
+
+3. **Apply Refactorings**
+   - Extract methods/functions for clarity
+   - Rename variables/functions for better readability
+   - Simplify complex conditionals
+   - Remove duplication (DRY principle)
+   - Improve structure and organization
+   - Remove dead code
+
+4. **Verify Functionality**
+   - Run tests to ensure functionality is preserved
+   - Check that behavior hasn't changed
+   - Verify no regressions were introduced
+
+5. **Document Changes**
+   - Note what was refactored and why
+   - Document any significant structural changes
+
+## Rules
+
+- **Can edit files:** You may refactor code in source files.
+- **Maintain functionality:** All refactorings must preserve existing behavior.
+- Run tests before and after refactoring to ensure nothing broke.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant.
+- Focus on code quality improvements; do not add new features or change behavior.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/reviewer.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/reviewer.md
@@ -1,0 +1,42 @@
+---
+name: reviewer
+description: Reviews code for correctness, security, quality, and tests; reports findings without editing code. Use for parallel code review while main agent implements features.
+---
+
+You are a **reviewer** subagent. Your job is to review code systematically, not to implement features or edit code.
+
+## Steps
+
+1. **Review Correctness**
+   - Analyze logic and control flow
+   - Check for edge cases and error paths
+   - Identify potential bugs, off-by-ones, null/undefined access
+   - Look for concurrency or async issues if relevant
+
+2. **Review Security**
+   - Check for injection vulnerabilities (SQL, NoSQL, command, XSS)
+   - Verify authentication and authorization (broken access control, insecure session handling)
+   - Look for sensitive data issues (logging secrets, hardcoded credentials, insecure storage)
+
+3. **Review Quality**
+   - Assess readability, naming, and structure
+   - Check adherence to project conventions (see `.cursor/rules` or `AGENTS.md`)
+   - Identify duplication, dead code, or unnecessary complexity
+
+4. **Review Tests**
+   - Evaluate adequacy of test coverage for the changes
+   - Assess test quality (behavior vs implementation, meaningful assertions)
+
+5. **Summarize Findings**
+   - Group by severity, then by file or area
+   - For each finding, categorize as:
+     - **Critical** — Must fix before merge. Describe the issue, location, and suggested fix.
+     - **Suggestion** — Consider improving. Briefly explain why and how.
+     - **Nice to have** — Optional improvement.
+   - If there are no issues in a category, say so (e.g. "No critical security issues found").
+
+## Rules
+
+- **Read-only for code:** You do **not** create or edit source files. Only review and report.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. testing style, API conventions, security requirements).
+- If the user wants fixes, they should use the main Agent or a command like `/code-review`.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/security-auditor.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/security-auditor.md
@@ -1,0 +1,41 @@
+---
+name: security-auditor
+description: Performs security-focused reviews for injection, auth, secrets, and dependencies; reports vulnerabilities without editing code. Use for dedicated security review separate from general code review.
+---
+
+You are a **security-auditor** subagent. Your job is to perform security-focused reviews, not to implement features or edit code.
+
+## Steps
+
+1. **Check for Injection Vulnerabilities**
+   - SQL, NoSQL, command injection (user input → query or shell)
+   - XSS (unescaped output, `innerHTML`, `eval`-like usage)
+
+2. **Review Authentication & Authorization**
+   - Broken access control (missing checks, IDOR)
+   - Insecure session handling, weak or default secrets
+   - Auth bypass or privilege escalation paths
+
+3. **Check for Sensitive Data Issues**
+   - Logging secrets, tokens, or PII
+   - Hardcoded credentials or keys
+   - Insecure storage or transmission of secrets
+
+4. **Review Dependencies**
+   - Known vulnerable packages
+   - Suggest running `npm audit`, `pip audit`, `cargo audit`, or the project's equivalent
+   - Report findings from dependency audits
+
+5. **Summarize Findings**
+   - Prioritize **Critical** and **High** severity issues
+   - For each finding, categorize as:
+     - **Critical** — Must fix before merge. Describe issue, location, and recommended fix.
+     - **High** — Should fix soon. Same structure.
+     - **Medium / Low** — Note briefly; optionally defer.
+   - Suggest **concrete** fixes (e.g. use parameterized queries, validate input, move secrets to env).
+
+## Rules
+
+- **Read-only for code:** You do **not** create or edit source files. Only review and report.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. security requirements, approved libraries).
+- If the user wants fixes, they should use the main Agent or a command like `/security-audit`.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/tester.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/tester.md
@@ -1,0 +1,45 @@
+---
+name: tester
+description: Writes and updates tests for code changes, focusing on test coverage and quality. Use for parallel test writing while main agent implements features.
+---
+
+You are a **tester** subagent. Your job is to write and update tests, ensuring adequate coverage and quality.
+
+## Steps
+
+1. **Analyze Code Changes**
+   - Identify what code needs testing
+   - Review existing test patterns and structure
+   - Identify gaps in test coverage
+
+2. **Write Tests**
+   - Follow project's testing conventions (see `.cursor/rules` or `AGENTS.md`)
+   - Write tests for:
+     - Happy paths
+     - Edge cases
+     - Error conditions
+     - Boundary conditions
+   - Use appropriate test framework (Jest, pytest, Mocha, etc.)
+
+3. **Ensure Test Quality**
+   - Write behavior-focused tests (not implementation-focused)
+   - Use meaningful assertions
+   - Keep tests independent and isolated
+   - Follow AAA pattern (Arrange, Act, Assert) where applicable
+
+4. **Update Existing Tests**
+   - Update tests that break due to code changes
+   - Refactor tests to match new code structure
+   - Remove obsolete tests
+
+5. **Verify Test Coverage**
+   - Ensure new code has adequate test coverage
+   - Check that critical paths are tested
+   - Report coverage gaps if significant
+
+## Rules
+
+- **Can edit files:** You may create or edit test files.
+- Focus on tests only; do not modify implementation code unless fixing test-related issues.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. testing style, test structure).
+- Run tests to verify they pass before considering the task complete.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/type-generator.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/type-generator.md
@@ -1,0 +1,55 @@
+---
+name: type-generator
+description: Generates types from schemas, APIs, or data structures including OpenAPI, GraphQL, JSON schemas, and API responses. Use for type generation from various sources.
+---
+
+You are a **type-generator** subagent. Your job is to generate types from schemas, APIs, or data structures.
+
+## Steps
+
+1. **Identify Source**
+   - Check @-mentioned files (OpenAPI spec, GraphQL schema, JSON schema, API response example).
+   - Or identify the source from context (API endpoint, schema file, etc.).
+   - Determine the format (OpenAPI/Swagger, GraphQL, JSON Schema, TypeScript, etc.).
+
+2. **Parse Source**
+   - Read and parse the source file or data.
+   - Extract type definitions, interfaces, enums, and structures.
+   - Understand relationships and dependencies between types.
+
+3. **Generate Types**
+   - Generate TypeScript types or type definitions appropriate for the project.
+   - Use appropriate tool if available:
+     - **OpenAPI/Swagger**: Use `openapi-typescript` or similar
+     - **GraphQL**: Use `graphql-codegen` or similar
+     - **JSON Schema**: Convert to TypeScript types
+     - **API Response**: Infer types from example JSON
+   - Follow project's type style (interfaces vs types, naming conventions).
+
+4. **Place Types Appropriately**
+   - Create or update type files in the project's types directory (e.g. `types/`, `@types/`, `src/types/`).
+   - Follow project conventions for type file organization.
+   - Use appropriate file naming (e.g. `api.types.ts`, `schema.types.ts`).
+
+5. **Update Imports**
+   - If types are used elsewhere, update imports.
+   - Ensure type exports are correct.
+   - Check for any circular dependencies.
+
+6. **Verify Types**
+   - Check that generated types are valid TypeScript.
+   - Ensure types match the source schema/structure.
+   - Test that types work with existing code (if applicable).
+
+7. **Document Types**
+   - Add JSDoc comments if the project uses them.
+   - Include descriptions from the source schema if available.
+   - Document any assumptions or limitations.
+
+## Rules
+
+- **Can edit files:** You may create or edit type files.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. type naming, style preferences).
+- Generate types that are maintainable and well-documented.
+- Focus on type generation only; do not modify implementation code unless required for type compatibility.
+- If the source format isn't supported, explain limitations and suggest alternatives.

--- a/.agents/skills/cursor-best-practices/assets/templates/agents/verifier.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/agents/verifier.md
@@ -1,0 +1,30 @@
+---
+name: verifier
+description: Validates work by running tests, lint, and checks; reports pass/fail and any failures. Use for verification before considering a task complete.
+---
+
+You are a **verifier** subagent. Your job is to validate the current state of the project, not to implement features or edit code.
+
+## Steps
+
+1. **Run the test suite**
+   - Use the project's standard commands (e.g. `npm test`, `pnpm test`, `pytest`, `cargo test`, `go test ./...`).
+   - If the project has multiple suites (unit, e2e, integration), run the ones relevant to recent changes.
+   - Report: which command(s) you ran, how many tests, and pass/fail.
+
+2. **Run lint and style checks** (if the project has them)
+   - e.g. `npm run lint`, `eslint .`, `ruff check`, `cargo clippy`, `golangci-lint run`.
+   - Report: command(s) run, and any errors or warnings (with file/line if available).
+
+3. **Summarize**
+   - **All checks passed:** "Verification complete: all checks passed."
+   - **Any failures:** For each failure, list:
+     - What failed (test name, lint rule, etc.)
+     - Where (file, line, or command)
+     - Relevant output snippet (e.g. assertion message, lint error).
+   - Do **not** fix the code yourself; only report. The user or main Agent will fix.
+
+## Rules
+
+- **Read-only for code:** You may run terminal commands (tests, lint). You do **not** create or edit source files.
+- If the user wants fixes, they should use the main Agent or a command like `/run-tests-and-fix`.

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/analyze-deps.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/analyze-deps.md
@@ -1,0 +1,46 @@
+Analyze the project's dependency tree, identify unused or duplicate dependencies, and suggest optimizations.
+
+## Steps
+
+1. **Analyze dependency tree**
+   - Use appropriate tools (e.g. `npm ls`, `depcheck`, `pipdeptree`, `cargo tree`, `go mod graph`).
+   - Build dependency graph showing all direct and transitive dependencies.
+
+2. **Identify unused dependencies**
+   - Check for dependencies listed in package files but not imported/used in code.
+   - Use tools like `depcheck` (npm), `pip-autoremove` (Python), or manual analysis.
+   - Verify false positives (some deps are used at build time or in configs).
+
+3. **Find duplicate dependencies**
+   - Identify multiple versions of the same package.
+   - Check for conflicting versions that could cause issues.
+   - Look for packages that provide similar functionality.
+
+4. **Check bundle size impact** (if applicable)
+   - For frontend projects, analyze bundle size contribution of each dependency.
+   - Identify large dependencies that could be replaced or tree-shaken.
+   - Check for duplicate code across dependencies.
+
+5. **Suggest optimizations**
+   - For each issue, provide:
+     - **Dependency name** and version(s)
+     - **Issue type** (unused, duplicate, large, etc.)
+     - **Impact** (bundle size, security, maintenance)
+     - **Suggested action** (remove, update, replace, consolidate)
+   - Prioritize by impact:
+     - **High** — Large unused deps, security vulnerabilities, major duplicates
+     - **Medium** — Small unused deps, minor duplicates
+     - **Low** — Optimization opportunities
+
+6. **Report**
+   - Summary of findings (unused, duplicates, large deps)
+   - List of suggested removals/updates
+   - Estimated impact (bundle size reduction, security improvements)
+   - Warnings about potentially risky removals
+
+## Rules
+
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant.
+- Be cautious with removals; verify dependencies aren't used indirectly or at build time.
+- Consider security implications of outdated dependencies.
+- For removals, suggest testing thoroughly after changes.

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/check-coverage.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/check-coverage.md
@@ -1,0 +1,39 @@
+Check test coverage, identify gaps, and suggest which code needs tests.
+
+## Steps
+
+1. **Run coverage tool**
+   - Use the project's coverage command (e.g. `npm run test:coverage`, `pytest --cov`, `cargo tarpaulin`, `go test -cover`).
+   - Generate coverage report in a readable format (HTML, JSON, or text).
+
+2. **Analyze coverage report**
+   - Identify overall coverage percentage.
+   - Find files/functions with low or zero coverage.
+   - Check critical paths (e.g. authentication, payment, data validation).
+
+3. **Identify gaps**
+   - List files with coverage below threshold (default: <80%, but use project's threshold if defined).
+   - Identify untested functions, branches, or edge cases.
+   - Prioritize by importance (critical business logic first).
+
+4. **Suggest improvements**
+   - For each gap, suggest:
+     - **File/function** that needs tests
+     - **Why it's important** (critical path, user-facing, etc.)
+     - **What to test** (happy path, edge cases, error conditions)
+   - Categorize by priority:
+     - **Critical** — Must have tests (security, payments, core features)
+     - **High** — Should have tests (important features)
+     - **Medium** — Nice to have tests (utility functions, helpers)
+
+5. **Report**
+   - Overall coverage percentage
+   - Coverage by file (if available)
+   - List of critical gaps
+   - Suggested test priorities
+
+## Rules
+
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. coverage thresholds, testing style).
+- Focus on meaningful coverage (testing behavior, not just lines).
+- If coverage tool isn't configured, suggest setting one up.

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/code-review.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/code-review.md
@@ -1,0 +1,36 @@
+Review the code changes in this conversation (or the files I've @-mentioned) systematically.
+
+## Checklist
+
+1. **Correctness**
+   - Logic and control flow; edge cases and error paths.
+   - Potential bugs, off-by-ones, null/undefined access.
+   - Concurrency or async issues if relevant.
+
+2. **Security**
+   - Injection (SQL, NoSQL, command, XSS).
+   - Auth/authz (broken access control, insecure session handling).
+   - Sensitive data (logging secrets, hardcoded credentials, insecure storage).
+
+3. **Quality**
+   - Readability, naming, and structure.
+   - Adherence to project conventions (see `.cursor/rules` or `AGENTS.md`).
+   - Duplication, dead code, or unnecessary complexity.
+
+4. **Tests**
+   - Adequacy of coverage for the changes.
+   - Test quality (behavior vs implementation, meaningful assertions).
+
+## Output format
+
+For each finding:
+
+- **Critical** — Must fix before merge. Describe the issue, location, and suggested fix.
+- **Suggestion** — Consider improving. Briefly explain why and how.
+- **Nice to have** — Optional improvement.
+
+Group by severity, then by file or area. If there are no issues in a category, say so (e.g. "No critical security issues found").
+
+## Apply project rules
+
+Use any project rules in `.cursor/rules` or `AGENTS.md` when relevant (e.g. testing style, API conventions, security requirements).

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/docs.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/docs.md
@@ -1,0 +1,22 @@
+Generate or update documentation for the code I've @-mentioned (or the current feature/area we're working on).
+
+## Steps
+
+1. **Identify scope**
+   - Use @-mentioned files, or the focus of our conversation (e.g. new API, refactored module).
+   - Determine what kind of docs are needed: API reference, README section, inline JSDoc/docstrings, architecture overview, runbook, etc.
+
+2. **Draft or update docs**
+   - Follow existing project style (e.g. JSDoc, TSDoc, Sphinx, rustdoc).
+   - Include: purpose, usage, parameters/returns, examples, and any caveats or migration notes.
+   - If updating, preserve existing structure where it still applies; revise only what changed.
+
+3. **Place docs appropriately**
+   - Inline (comments, JSDoc) for implementation details.
+   - README or `docs/` for user-facing or high-level guides.
+   - Link between docs if relevant.
+
+## Rules
+
+- Match the project's existing doc format and tone.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` (e.g. doc conventions).

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/fix-issue.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/fix-issue.md
@@ -1,0 +1,16 @@
+Fix the issue described below.
+
+**Context:** If I provided an issue number or URL after the command (e.g. `/fix-issue 123` or `/fix-issue https://github.com/org/repo/issues/456`), use that to fetch or reference the issue. Otherwise, use the rest of my message as the issue description.
+
+## Steps
+
+1. **Understand** the reported bug or feature request (repro steps, expected vs actual, acceptance criteria).
+2. **Locate** the relevant code (search, @files, or project structure).
+3. **Implement** the fix or feature. Add or update tests as appropriate.
+4. **Run the test suite** and ensure nothing is broken. Fix any failures.
+5. **Summarize** what you changed and how to verify it (e.g. run X, check Y).
+
+## Rules
+
+- Do not skip tests. Run them and fix failures before considering the task done.
+- Apply project rules from `.cursor/rules` or `AGENTS.md`.

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/format.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/format.md
@@ -1,0 +1,27 @@
+Format code according to the project's formatting standards.
+
+## Steps
+
+1. **Identify formatter**
+   - Check for project formatters (e.g. Prettier, Black, rustfmt, gofmt, prettier, dprint).
+   - Look for configuration files (`.prettierrc`, `pyproject.toml`, `rustfmt.toml`, etc.).
+
+2. **Format files**
+   - If I @-mentioned specific files, format only those.
+   - Otherwise, format all files in the current scope (changed files, or entire project if requested).
+   - Use the appropriate command (e.g. `prettier --write`, `black .`, `cargo fmt`, `gofmt -w`).
+
+3. **Verify formatting**
+   - Re-run formatter to ensure all files are properly formatted.
+   - Check that no formatting conflicts exist.
+
+4. **Report**
+   - List which files were formatted.
+   - Note any files that couldn't be formatted (e.g. unsupported file types).
+   - If formatting changed behavior or structure, note it.
+
+## Rules
+
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. formatting style preferences).
+- Preserve code functionality; formatting should only change whitespace and style, not logic.
+- If the project doesn't have a formatter configured, suggest setting one up.

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/generate-types.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/generate-types.md
@@ -1,0 +1,44 @@
+Generate TypeScript types or type definitions from schemas, APIs, or data structures.
+
+## Steps
+
+1. **Identify source**
+   - Check if I @-mentioned a file (OpenAPI spec, GraphQL schema, JSON schema, API response example).
+   - Or identify the source from context (API endpoint, schema file, etc.).
+   - Determine the format (OpenAPI/Swagger, GraphQL, JSON Schema, TypeScript, etc.).
+
+2. **Generate types**
+   - Use appropriate tool or generate manually:
+     - **OpenAPI/Swagger**: Use `openapi-typescript` or similar
+     - **GraphQL**: Use `graphql-codegen` or similar
+     - **JSON Schema**: Convert to TypeScript types
+     - **API Response**: Infer types from example JSON
+   - Generate types that match the project's style (interfaces vs types, naming conventions).
+
+3. **Place types appropriately**
+   - Create or update type files in the project's types directory (e.g. `types/`, `@types/`, `src/types/`).
+   - Follow project conventions for type file organization.
+   - Use appropriate file naming (e.g. `api.types.ts`, `schema.types.ts`).
+
+4. **Update imports**
+   - If types are used elsewhere, update imports.
+   - Ensure type exports are correct.
+   - Check for any circular dependencies.
+
+5. **Verify types**
+   - Check that generated types are valid TypeScript.
+   - Ensure types match the source schema/structure.
+   - Test that types work with existing code (if applicable).
+
+6. **Report**
+   - What source was used (file, API, schema)
+   - Where types were generated (file path)
+   - What types were created (interfaces, types, enums)
+   - Any issues or warnings
+
+## Rules
+
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. type naming, style preferences).
+- Generate types that are maintainable and well-documented.
+- If the source format isn't supported, explain limitations and suggest alternatives.
+- For API types, consider versioning and backward compatibility.

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/lint-and-fix.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/lint-and-fix.md
@@ -1,0 +1,34 @@
+Run the project's linter, auto-fix what can be fixed, and report remaining issues.
+
+## Steps
+
+1. **Run linter**
+   - Use the project's actual commands (e.g. `npm run lint`, `eslint .`, `ruff check`, `cargo clippy`, `golangci-lint run`).
+   - If the project has multiple lint commands (e.g. `lint:js`, `lint:ts`), run the relevant one(s) for the current changes.
+
+2. **Auto-fix issues**
+   - Run the linter with auto-fix flag (e.g. `eslint --fix`, `ruff check --fix`, `cargo clippy --fix`).
+   - Apply fixes that can be automatically resolved.
+   - Re-run linter to verify fixes were applied.
+
+3. **Report remaining issues**
+   - For each remaining issue that couldn't be auto-fixed, provide:
+     - **Location** (file, line, column)
+     - **Rule/error code** (e.g. `no-unused-vars`, `E501`)
+     - **Description** (what's wrong)
+     - **Suggested fix** (how to resolve manually)
+   - Categorize by severity:
+     - **Error** — Must fix (blocks build/CI)
+     - **Warning** — Should fix (code quality)
+     - **Info** — Nice to have (style suggestions)
+
+4. **Summarize**
+   - How many issues were auto-fixed
+   - How many issues remain (by severity)
+   - List of files that need manual attention
+
+## Rules
+
+- Do **not** disable or ignore lint rules to make lint pass. Fix the code properly.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. linting style, rule preferences).
+- If the project doesn't have a linter configured, suggest setting one up rather than skipping.

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/make-cursor-compatible.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/make-cursor-compatible.md
@@ -1,0 +1,166 @@
+# Make Codebase Cursor Compatible
+
+When the user asks to "make this codebase cursor compatible", "make it vibe codeable", "set up cursor for this project", or similar requests, help them transform their codebase into a Cursor-optimized workspace.
+
+## Overview
+
+Making a codebase "Cursor compatible" or "vibe codeable" means:
+- Adding `.cursor/` folder structure with rules, commands, agents
+- Creating `.cursorignore` to exclude unnecessary files
+- Adding project-specific rules that help Cursor understand the codebase
+- Setting up indexes and documentation for better AI navigation
+- Configuring skills if applicable
+
+## Step-by-Step Process
+
+### 1. Create `.cursor` Folder Structure
+
+Create the following structure:
+
+```
+.cursor/
+├── rules/              # Project-specific rules
+├── commands/           # Custom commands
+├── agents/             # Subagents
+├── skills/             # Project-specific skills (optional)
+└── AGENTS.md          # Codebase guide for AI
+```
+
+**Action**: Create these directories if they don't exist.
+
+### 2. Create `.cursorignore`
+
+Create `.cursorignore` at project root to exclude:
+- Build artifacts (`dist/`, `build/`, `*.min.js`)
+- Dependencies (`node_modules/`, `venv/`, `.venv/`)
+- Generated files (`*.generated.*`, `coverage/`)
+- Large data files
+- Secrets and credentials (`.env`, `*.key`, `*.pem`)
+- OS files (`.DS_Store`, `Thumbs.db`)
+- Editor files (`.vscode/`, `.idea/`)
+
+**Action**: Create `.cursorignore` with appropriate patterns for the project type.
+
+### 3. Create `AGENTS.md`
+
+Create `.cursor/AGENTS.md` with comprehensive codebase guide:
+- Repository purpose and overview
+- Deep dive into structure (all directories and files)
+- File naming conventions
+- Content patterns and conventions
+- Architecture decisions and rationale
+- Key principles and design patterns
+- How to navigate the codebase
+- Common tasks and workflows
+- Standards compliance
+- Maintenance workflow
+- Dependencies and relationships
+
+**Action**: Generate comprehensive `AGENTS.md` based on the current codebase structure. This should be detailed enough for Cursor to understand the codebase at the deepest level.
+
+### 4. Add Project-Specific Rules
+
+Create initial rules in `.cursor/rules/`:
+
+- **`codebase-structure.md`** - Explains repository layout, file organization, skill structure
+- **`architecture-and-design.md`** - Architecture decisions, design principles, structure rationale
+- **`content-patterns.md`** - Content patterns, writing conventions, enhancement guidelines
+- **`coding-standards.md`** - Project-specific coding conventions (if applicable)
+- **`testing-patterns.md`** - Testing approach and patterns (if applicable)
+- **`skill-maintenance.md`** - Maintenance guidelines, update workflow, quality checks
+
+**Action**: Analyze codebase and create comprehensive rules that help Cursor understand the codebase deeply.
+
+### 5. Create Navigation Indexes
+
+Create indexes in `.cursor/indexes/` for deep understanding:
+
+- **`codebase-index.md`** - Quick reference for navigating the codebase (core files, directories, common tasks)
+- **`feature-index.md`** - Features organized by domain (if applicable)
+- **`component-index.md`** - Components and their purposes (if applicable)
+- **`api-index.md`** - API endpoints and routes (if applicable)
+
+**Action**: Create indexes that help Cursor quickly find and understand codebase components.
+
+### 6. Add Useful Commands
+
+Create commands in `.cursor/commands/`:
+
+- **`code-review.md`** - Review code before commit
+- **`run-tests.md`** - Run test suite
+- **`setup-dev.md`** - Setup development environment
+- **`deploy.md`** - Deployment workflow
+
+**Action**: Create commands based on project needs.
+
+### 7. Document Architecture
+
+Create comprehensive architecture documentation:
+
+- **`CODEBASE.md`** at root - High-level overview, structure, key concepts
+- **`.cursor/ARCHITECTURE.md`** - System architecture, content architecture, design patterns, standards compliance, performance considerations
+- Explains high-level structure
+- Key design decisions and rationale
+- How different parts interact
+- Extension points and customization
+
+**Action**: Create architecture documentation that provides deep understanding of the codebase structure and design.
+
+## Implementation Checklist
+
+When implementing, check:
+
+- [ ] `.cursor/` folder structure created
+- [ ] `.cursorignore` created with appropriate patterns
+- [ ] `.cursor/AGENTS.md` created with codebase guide
+- [ ] Initial rules added to `.cursor/rules/`
+- [ ] Useful commands added to `.cursor/commands/`
+- [ ] Architecture documentation created
+- [ ] Indexes created (if large codebase)
+- [ ] All files follow project conventions
+
+## Example Output
+
+After setup, the codebase should have:
+
+```
+project-root/
+├── .cursor/
+│   ├── AGENTS.md                    # Comprehensive codebase guide
+│   ├── ARCHITECTURE.md              # System and content architecture
+│   ├── rules/
+│   │   ├── codebase-structure.md    # Structure documentation
+│   │   ├── architecture-and-design.md  # Design decisions
+│   │   ├── content-patterns.md      # Writing conventions
+│   │   ├── skill-maintenance.md     # Maintenance guidelines
+│   │   ├── coding-standards.md      # Coding conventions (if applicable)
+│   │   └── testing-patterns.md      # Testing patterns (if applicable)
+│   ├── indexes/
+│   │   └── codebase-index.md        # Quick navigation reference
+│   ├── commands/
+│   │   ├── code-review.md
+│   │   └── run-tests.md
+│   └── agents/ (optional)
+├── .cursorignore
+├── CODEBASE.md                      # High-level overview
+└── [rest of project files]
+```
+
+## Best Practices
+
+1. **Start Simple**: Begin with basic structure, add more as needed
+2. **Be Specific**: Rules should be specific to this codebase
+3. **Keep Updated**: Update rules as codebase evolves
+4. **Link to Docs**: Reference external documentation when relevant
+5. **Use Globs**: File-specific rules should use globs appropriately
+
+## Apply Project Rules
+
+When creating rules and commands, apply any existing project rules or conventions.
+
+## See Also
+
+- [Cursor Rules Documentation](https://cursor.com/docs/rules)
+- [Cursor Commands Documentation](https://cursor.com/docs/rules)
+- [Agent Skills Specification](https://agentskills.io/specification)
+- [skills.sh Documentation](https://skills.sh/docs)

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/pr.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/pr.md
@@ -1,0 +1,29 @@
+Help me create a pull request for the current branch.
+
+## Steps
+
+1. **Summarize changes**
+   - Use `git diff`, `git log`, or recent commits to understand what changed.
+   - If I've @-mentioned files or provided context, use that too.
+   - Briefly list: what was added, changed, or removed, and why.
+
+2. **Propose PR title and description**
+   - **Title:** Short, imperative (e.g. "Add email validation to login" or "Fix null deref in user loader").
+   - **Description:** Include:
+     - **What** changed (high level).
+     - **Why** (bug fix, feature, refactor).
+     - **How to test** (steps or commands).
+     - Any **breaking changes** or **migration notes** if relevant.
+
+3. **Suggest a review checklist**
+   - e.g. [ ] Tests run and pass  
+   - [ ] Lint passes  
+   - [ ] Migrations applied (if any)  
+   - [ ] Docs updated (if relevant)  
+   - [ ] No secrets or debug code committed  
+
+Adapt to the project (e.g. "run `make test`", "apply `.cursor/rules`").
+
+## Apply project rules
+
+Follow any project rules in `.cursor/rules` or `AGENTS.md` (e.g. PR format, scope, conventions).

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/run-tests-and-fix.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/run-tests-and-fix.md
@@ -1,0 +1,22 @@
+Run the project's test suite, fix any failures, and report what changed.
+
+## Steps
+
+1. **Run tests**
+   - Use the project's actual commands (e.g. `npm test`, `pnpm test`, `pytest`, `cargo test`, `go test ./...`).
+   - If the project has multiple test commands (unit vs e2e), run the relevant one(s) for the current changes.
+
+2. **If any tests fail**
+   - Analyze the failure (assertion, error message, stack trace).
+   - Fix the **implementation** (or add missing tests for new behavior). Do **not** skip tests or change expectations solely to make them pass.
+   - Re-run tests until they all pass.
+
+3. **Summarize**
+   - What was broken (which test(s), why).
+   - What you changed (files, approach).
+   - Confirm all tests now pass.
+
+## Rules
+
+- Do **not** delete or weaken tests to get green. Fix the code.
+- Apply project rules from `.cursor/rules` or `AGENTS.md` when relevant (e.g. test style, coverage).

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/security-audit.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/security-audit.md
@@ -1,0 +1,32 @@
+Perform a security-focused review of the code I've @-mentioned (or the most relevant changes in this conversation).
+
+## Checklist
+
+1. **Injection**
+   - SQL, NoSQL, command injection (user input → query or shell).
+   - XSS (unescaped output, `innerHTML`, `eval`-like usage).
+
+2. **Authentication & authorization**
+   - Broken access control (missing checks, IDOR).
+   - Insecure session handling, weak or default secrets.
+   - Auth bypass or privilege escalation paths.
+
+3. **Sensitive data**
+   - Logging secrets, tokens, or PII.
+   - Hardcoded credentials or keys.
+   - Insecure storage or transmission of secrets.
+
+4. **Dependencies**
+   - Known vulnerable packages. Suggest running `npm audit`, `pip audit`, `cargo audit`, or the project's equivalent, and report findings.
+
+## Output format
+
+- **Critical** — Must fix before merge. Describe issue, location, and recommended fix.
+- **High** — Should fix soon. Same structure.
+- **Medium / Low** — Note briefly; optionally defer.
+
+Prioritize **Critical** and **High**. Suggest **concrete** fixes (e.g. use parameterized queries, validate input, move secrets to env).
+
+## Apply project rules
+
+Use project rules in `.cursor/rules` or `AGENTS.md` when relevant (e.g. security requirements, approved libraries).

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/setup-new-feature.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/setup-new-feature.md
@@ -1,0 +1,25 @@
+Help me set up a new feature. If you typed text after the command (e.g. `/setup-new-feature auth` or `/setup-new-feature user notifications`), use that as the feature name or short description.
+
+## Steps
+
+1. **Propose a minimal plan**
+   - **New files** — modules, components, routes, tests.
+   - **Key functions/modules** — what each does and how they plug into the existing codebase.
+   - **Integration points** — existing APIs, state, DB, or UI to extend or call.
+
+2. **Identify relevant patterns**
+   - Existing features (e.g. "follow the pattern in `auth/`"), `.cursor/rules`, or `AGENTS.md`.
+   - Stack conventions (e.g. React hooks, REST endpoints, repository pattern).
+
+3. **Suggest implementation steps**
+   - Create structure (files, folders) → implement → add tests → update docs (if applicable).
+   - Prefer **incremental, testable** steps rather than one big change.
+
+## Context
+
+- Use **@files** or **@folder** if I've pointed to reference implementations.
+- Prefer **small, reviewable** chunks. Run tests between steps when possible.
+
+## Apply project rules
+
+Follow `.cursor/rules` or `AGENTS.md` (e.g. testing, structure, naming).

--- a/.agents/skills/cursor-best-practices/assets/templates/commands/update-deps.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/commands/update-deps.md
@@ -1,0 +1,23 @@
+Update the project's dependencies and ensure the project still works.
+
+## Steps
+
+1. **Identify package manager and lockfiles**
+   - e.g. `package.json` + `package-lock.json` / `pnpm-lock.yaml` / `yarn.lock`, `requirements.txt` / `pyproject.toml`, `Cargo.toml`, etc.
+
+2. **Update dependencies**
+   - Use the appropriate command (e.g. `npm update`, `pnpm update`, `pip install -U -r requirements.txt`, `cargo update`). Prefer non-breaking updates unless I asked for major upgrades.
+   - If I specified packages or scope (e.g. `/update-deps lodash react`), limit updates accordingly.
+
+3. **Run tests and build**
+   - Run the test suite and any build step. Fix breakages (e.g. API changes, deprecated usage).
+
+4. **Report**
+   - What was updated (packages, versions).
+   - Any **breaking changes** or migration steps.
+   - Test and build status.
+
+## Rules
+
+- Prefer **patch/minor** updates unless explicitly asked for major. Call out breaking changes clearly.
+- Apply project rules from `.cursor/rules` or `AGENTS.md`.

--- a/.agents/skills/cursor-best-practices/assets/templates/rules/_sections.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/rules/_sections.md
@@ -1,0 +1,25 @@
+# Rule templates index
+
+Curated rule templates. Copy into `.cursor/rules/` or use as examples. See [references/templates-index.md](../../references/templates-index.md) for full index.
+
+## Rules
+
+- [rules-keep-under-500-lines.md](rules-keep-under-500-lines.md) — Keep individual rule files under ~500 lines; split by concern, use globs, link to references.
+- [rules-use-globs.md](rules-use-globs.md) — Use globs for file-specific rules so they apply only when relevant.
+- [rules-write-good-descriptions.md](rules-write-good-descriptions.md) — Write clear, keyword-rich rule descriptions for better relevance.
+
+## Context & setup
+
+- [context-setup-cursor-folder.md](context-setup-cursor-folder.md) — "Setup my .cursor folder" workflow: structure, .cursorignore, templates.
+- [context-use-at-mentions.md](context-use-at-mentions.md) — Use @files, @folder, @Code for precise context.
+- [context-use-grep-and-semantic.md](context-use-grep-and-semantic.md) — Use both grep and semantic search when finding code.
+- [make-codebase-cursor-compatible.md](make-codebase-cursor-compatible.md) — Make codebase Cursor compatible: add .cursor folder, .cursorignore, AGENTS.md, rules, commands, indexes.
+
+## Modes & workflows
+
+- [modes-plan-then-agent.md](modes-plan-then-agent.md) — Plan with Ask/Plan, implement with Agent; revert and replan if wrong.
+- [workflows-run-tests-before-done.md](workflows-run-tests-before-done.md) — Run tests before considering a task complete; fix failures, don't skip.
+
+## Ignore
+
+- [ignore-cursorignore-secrets.md](ignore-cursorignore-secrets.md) — Exclude secrets and credentials via .cursorignore.

--- a/.agents/skills/cursor-best-practices/assets/templates/rules/context-setup-cursor-folder.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/rules/context-setup-cursor-folder.md
@@ -1,0 +1,64 @@
+---
+title: Follow the "Setup my .cursor folder" workflow
+impact: HIGH
+impactDescription: Consistent structure lets teams share commands, agents, and rules via git.
+tags: setup, .cursor, workflow, setup-cursor-folder, cursor-folder-setup, initialize-cursor-folder, cursor-folder-workflow, setup-cursor-guide
+description: "Setup .cursor folder: create standard structure (.cursor/rules/, .cursor/commands/, .cursor/skills/, .cursor/agents/), optionally add minimal .cursorignore, offer to install templates from skill's commands/ and agents/, confirm what was created. How to setup: create folders (.cursor/rules/, .cursor/commands/, .cursor/skills/, .cursor/agents/), optionally add minimal .cursorignore (node_modules/, .env, .env.*, *.log, dist/, build/), offer templates (code-review.md, pr.md, run-tests-and-fix.md, security-audit.md, setup-new-feature.md, verifier.md), confirm what was created. Why setup .cursor folder: consistent structure lets teams share commands, agents, and rules via git, enables collaboration, maintains organization, essential for teams. Don't overwrite existing: don't overwrite existing .cursor content without asking, don't copy entire rules/ folder into .cursor/rules/ as Cursor rules, don't skip confirmation step. Setup workflow: user asks to setup → create folders → add .cursorignore → offer templates → confirm what was created → explain how to use. Setup best practices: create standard structure, add minimal .cursorignore, offer templates, confirm what was created, don't overwrite existing."
+---
+
+# Follow the "Setup my .cursor folder" workflow
+
+When the user asks to **set up**, **initialize**, or **create** their `.cursor` folder, create the standard structure, optionally add a minimal `.cursorignore`, and offer to install templates from this skill's **assets/templates/commands/** and **assets/templates/agents/**. Confirm what was created and how to use it.
+
+## Do
+
+1. **Create folders:**  
+   `.cursor/rules/`, `.cursor/commands/`, `.cursor/skills/`, `.cursor/agents/`.
+
+2. **Optional `.cursorignore`:**  
+   If the project has no `.cursorignore`, add a minimal one, e.g.:
+   ```
+   node_modules/
+   .env
+   .env.*
+   *.log
+   dist/
+   build/
+   ```
+   Use standard `.gitignore` syntax. Adjust for the project (e.g. add `__pycache__/`, `*.pyc` for Python).
+
+3. **Offer templates:**  
+   Propose copying from this skill:
+   - **Commands:** `code-review.md` → `.cursor/commands/code-review.md`, and optionally `pr.md`, `run-tests-and-fix.md`, `security-audit.md`, `setup-new-feature.md`.
+   - **Agents:** `verifier.md` → `.cursor/agents/verifier.md`.  
+   If the user agrees (or doesn't specify), copy them.
+
+4. **Rules:**  
+   **Rules:** Optionally copy from this skill's **assets/templates/rules/** or add **one** short rule (e.g. "Run tests before considering the task done") or a minimal **AGENTS.md** at project root.
+
+5. **Confirm:**  
+   List what was created and how to use it (e.g. "Use `/code-review` in chat," "Add project-specific rules to `.cursor/rules/`," "Configure `.cursorignore` for secrets").
+
+## Don't
+
+- **Overwrite** existing `.cursor` content without asking.
+- **Copy** the entire skill templates folder into `.cursor/` without user confirmation.
+- **Skip** the confirmation step—users should know what's now available.
+
+## Related Queries
+
+Users might ask:
+- "How to setup .cursor folder?"
+- "Setup .cursor folder"
+- "Initialize .cursor folder"
+- "Create .cursor folder"
+- "How to setup cursor folder?"
+- "Setup cursor folder guide"
+- "How to initialize .cursor folder?"
+- "Setup cursor folder best practices"
+- "How to create .cursor structure?"
+- "Setup cursor folder tips"
+- "What is .cursor folder setup?"
+- "How to setup cursor folder workflow?"
+
+**See:** [Cursor docs](https://cursor.com/docs/), [SKILL.md](../SKILL.md) "Setup my .cursor folder".

--- a/.agents/skills/cursor-best-practices/assets/templates/rules/context-use-at-mentions.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/rules/context-use-at-mentions.md
@@ -1,0 +1,48 @@
+---
+title: Use @files, @folder, and @Code for precise context
+impact: HIGH
+impactDescription: Targeted context improves accuracy and reduces irrelevant output.
+tags: context, @mentions, @Code, use-at-mentions, at-mentions-guide, precise-context, at-file-at-folder-at-code, mentions-guide, context-mentions
+description: "Use @ mentions: use @file or @folder when you want understand this area, emulate this pattern, or only change code here, use @Code when you need specific snippet (one function, one block) rather than whole file, scope down with @Code or single @file instead of @-mentioning entire monorepo for small local change. How to use @ mentions: prefer @file or @folder for understanding areas and emulating patterns, prefer @Code for specific snippets, scope down for small changes, avoid mentioning huge directories for small edits. Why use @ mentions: targeted context improves accuracy and reduces irrelevant output, provides precise scope, focuses agent, essential for accuracy. Don't rely only on semantic search: @-mentioning known files is faster and more reliable than semantic search, always use @ mentions when you know exact file, don't use vague requests without @ mentions. @ mentions guide: use @file for files, use @folder for folders, use @Code for snippets, scope down appropriately, be precise. @ mentions best practices: use @file or @folder for context, use @Code for snippets, scope down for small changes, don't mention huge directories, be precise."
+---
+
+# Use @files, @folder, and @Code for precise context
+
+Reference specific **files**, **folders**, or **code snippets** with **@** so the agent knows exactly what to emulate, analyze, or modify. Large files/folders are condensed to save context; **@Code** gives the most precise scope.
+
+## Prefer
+
+- **@file** or **@folder** when you want “understand this area,” “emulate this pattern,” or “only change code here.”
+- **@Code** when you need a **specific snippet** (e.g. one function, one block) rather than the whole file. Reduces noise and focuses the agent.
+- **Scoping down:** Use @Code or a single @file instead of @-mentioning an entire monorepo for a small, local change.
+
+## Avoid
+
+- Relying **only** on semantic search when you already know the exact file or snippet. @-mentioning it is faster and more reliable.
+- @-mentioning **huge directories** for small, targeted edits—prefer @file or @Code.
+- Vague requests like “fix the app” without @-mentioning the relevant files. The agent may guess wrong or touch too much.
+
+## Examples
+
+- “Add validation similar to **@auth/login.ts**” — pattern to follow.
+- “Fix the bug in **@utils/parse.ts** around line 42” — narrow scope.
+- “Review **@src/api/** for security issues” — limit review to that folder.
+- “Refactor **@Code** (the `fetchUser` function) to use async/await” — exact snippet.
+
+## Related Queries
+
+Users might ask:
+- "How to use @ mentions?"
+- "Use @ mentions"
+- "@file @folder @Code"
+- "How to use @file?"
+- "How to use @Code?"
+- "@ mentions guide"
+- "How to use @ mentions effectively?"
+- "@ mentions best practices"
+- "How to scope down with @ mentions?"
+- "@ mentions tips"
+- "How to provide precise context?"
+- "What are @ mentions?"
+
+**See:** [@ Mentions](https://cursor.com/docs/).

--- a/.agents/skills/cursor-best-practices/assets/templates/rules/context-use-grep-and-semantic.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/rules/context-use-grep-and-semantic.md
@@ -1,0 +1,40 @@
+---
+title: Use both grep and semantic search when finding code
+impact: MEDIUM
+impactDescription: Grep finds exact matches; semantic finds conceptual matches. Together they cover more.
+tags: context, semantic search, grep, search, use-grep-semantic, grep-and-semantic, combine-searches, search-strategies, grep-semantic-guide
+description: "Use both grep and semantic search: grep matches exact strings symbols and filenames, semantic search matches meaning (where we validate email), use both when agent needs to find and understand code (grep for precise locations, semantic for how does X work or where do we do Y). How to use both searches: use grep for exact identifiers (function names, exports, config keys, error codes), use semantic search for concepts (where is user input validated, how do we handle API errors, where is payment flow), combine when implementing or refactoring. Why use both: grep finds exact matches, semantic finds conceptual matches, together they cover more ground, provides complete picture. Don't use only one: using only semantic search when you know exact symbol (grep is faster and precise), using only grep for how does X work (semantic often surfaces relevant files you wouldn't find by name alone). Search combination guide: use grep for exact identifiers, use semantic for concepts, combine when needed, use both together. Search combination best practices: use grep for exact matches, use semantic for concepts, combine when implementing, use both for comprehensive search."
+---
+
+# Use both grep and semantic search when finding code
+
+**Grep** matches exact strings, symbols, and filenames. **Semantic search** matches meaning (e.g. “where we validate email”). Use **both** when the agent needs to find and understand code: grep for precise locations, semantic for “how does X work?” or “where do we do Y?”
+
+## Do
+
+- **Grep** for exact identifiers: function names, exports, config keys, error codes (e.g. `AuthContext`, `LOGIN_FAILED`, `validateEmail`).
+- **Semantic search** for concepts: “Where is user input validated?”, “How do we handle API errors?”, “Where is the payment flow?”
+- **Combine** when implementing or refactoring: e.g. semantic to find the validation layer, then grep to find all call sites of `validateEmail`.
+
+## Avoid
+
+- Using **only** semantic search when you know the exact symbol—grep is faster and precise.
+- Using **only** grep for “how does X work?”—semantic often surfaces relevant files you wouldn’t find by name alone.
+
+## Related Queries
+
+Users might ask:
+- "How to use grep and semantic search?"
+- "Use both grep and semantic"
+- "Grep vs semantic search"
+- "How to combine searches?"
+- "Search strategies"
+- "Grep and semantic guide"
+- "How to use grep effectively?"
+- "How to use semantic search effectively?"
+- "Search combination best practices"
+- "Grep and semantic tips"
+- "How to find code with grep and semantic?"
+- "What is grep and semantic search?"
+
+**See:** [Semantic search](https://cursor.com/docs/).

--- a/.agents/skills/cursor-best-practices/assets/templates/rules/ignore-cursorignore-secrets.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/rules/ignore-cursorignore-secrets.md
@@ -1,0 +1,58 @@
+---
+title: Exclude secrets and credentials via .cursorignore
+impact: CRITICAL
+impactDescription: Prevents sensitive data from being indexed or sent to AI context.
+tags: .cursorignore, security, secrets
+---
+
+# Exclude secrets and credentials via .cursorignore
+
+**`.cursorignore`** uses the same syntax as **`.gitignore`**. Excluded paths are **not** used for semantic search, Tab, Agent, or @mentions. **Always** exclude secrets, keys, credentials, and env files. Default Cursor ignores often cover some of these, but project-specific paths (e.g. `scripts/prod/`, `**/keys/`) may not.
+
+## Incorrect
+
+- **No `.cursorignore`**, or one that omits `.env`, `*.pem`, `credentials.json`, `**/secrets/**`. Those paths may be indexed and included in context.
+- **Over-ignoring** (e.g. ignoring entire `src/`) so that useful code is excluded. Keep the list **targeted** so indexing stays accurate and you can still @-mention non-sensitive code.
+
+## Correct
+
+Use a **minimal but complete** set. Example:
+
+```
+node_modules/
+.env
+.env.*
+.env.local
+.env.*.local
+*.key
+*.pem
+*.p12
+credentials.json
+**/secrets/
+**/*-credentials*
+**/config/local*
+```
+
+Adjust for your stack (e.g. `__pycache__/`, `*.pyc`, `venv/` for Python; `*.jks` for Android). Add any path that contains **API keys**, **passwords**, **tokens**, or **certificates**.
+
+## .cursorindexingignore
+
+**`.cursorindexingignore`** affects **indexing only**; ignored files are still usable by the AI if you @-mention them. Use it for large assets or generated files you don’t want in semantic search, but **never** rely on it for secrets—use **`.cursorignore`** for those.
+
+## Related Queries
+
+Users might ask:
+- "How to exclude secrets from Cursor?"
+- "Exclude secrets .cursorignore"
+- "Protect secrets in Cursor"
+- "How to secure credentials?"
+- ".cursorignore for secrets"
+- "Security .cursorignore guide"
+- "How to prevent secrets from being indexed?"
+- "Security best practices"
+- "How to protect API keys?"
+- "Security tips"
+- "How to exclude sensitive data?"
+- "What is .cursorignore for secrets?"
+
+**See:** [Ignore files](https://cursor.com/docs/reference/ignore-file).

--- a/.agents/skills/cursor-best-practices/assets/templates/rules/make-codebase-cursor-compatible.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/rules/make-codebase-cursor-compatible.md
@@ -1,0 +1,155 @@
+---
+description: "Make codebase cursor compatible, vibe codeable, cursor setup, index codebase, add cursor rules, setup cursor for project, make project cursor-friendly, cursor optimization, codebase indexing, cursor configuration. How to make your codebase cursor compatible: add .cursor folder, create .cursorignore, add rules and commands, create AGENTS.md, index codebase structure, add project-specific rules, create navigation indexes, document architecture. Why make codebase cursor compatible: helps AI understand codebase, improves code suggestions, better context awareness, faster development, better code navigation. Making codebase cursor compatible: setup .cursor folder structure, create .cursorignore file, add AGENTS.md codebase guide, create project-specific rules, add useful commands, create navigation indexes, document architecture."
+tags: [get-started, setup, cursor-compatible, vibe-codeable, codebase-setup, indexing, rules, commands, agents, cursor-configuration, make-cursor-compatible, codebase-indexing, project-setup, cursor-optimization]
+---
+
+# Make Codebase Cursor Compatible
+
+Making your codebase "Cursor compatible" or "vibe codeable" means setting it up so Cursor's AI can better understand, navigate, and work with your codebase.
+
+## What Does "Cursor Compatible" Mean?
+
+A Cursor-compatible codebase has:
+
+- **`.cursor/` folder** with rules, commands, and agents
+- **`.cursorignore`** to exclude unnecessary files from indexing
+- **`AGENTS.md`** that explains the codebase structure to AI
+- **Project-specific rules** that guide AI behavior
+- **Navigation indexes** for large codebases
+- **Architecture documentation** for context
+
+## Do: Set Up Cursor Compatibility
+
+### 1. Create `.cursor` Folder Structure
+
+Create the standard structure:
+
+```
+.cursor/
+├── rules/              # Project-specific rules
+├── commands/           # Custom commands
+├── agents/             # Subagents
+├── skills/             # Project-specific skills (optional)
+└── AGENTS.md          # Codebase guide for AI
+```
+
+**Why**: This structure helps Cursor discover and use your project-specific guidance.
+
+### 2. Create `.cursorignore`
+
+Exclude files that shouldn't be indexed:
+
+```
+# Dependencies
+node_modules/
+venv/
+.venv/
+
+# Build artifacts
+dist/
+build/
+*.min.js
+*.min.css
+
+# Generated files
+coverage/
+*.generated.*
+
+# Secrets
+.env
+.env.*
+*.key
+*.pem
+
+# OS files
+.DS_Store
+Thumbs.db
+```
+
+**Why**: Reduces noise, improves performance, and protects secrets.
+
+### 3. Create `AGENTS.md`
+
+Document your codebase structure:
+
+```markdown
+# Codebase Guide
+
+## Structure
+- `src/` - Source code
+- `tests/` - Test files
+- `docs/` - Documentation
+
+## Key Patterns
+- Components in `src/components/`
+- Utils in `src/utils/`
+- Tests mirror source structure
+```
+
+**Why**: Helps AI understand your codebase organization and conventions.
+
+### 4. Add Project-Specific Rules
+
+Create rules in `.cursor/rules/`:
+
+- **`codebase-structure.md`** - Repository layout
+- **`coding-standards.md`** - Conventions
+- **`testing-patterns.md`** - Testing approach
+- **`architecture.md`** - Design decisions
+
+**Why**: Guides AI to follow your project's patterns and conventions.
+
+### 5. Create Navigation Indexes
+
+For large codebases, create indexes:
+
+- **`indexes/feature-index.md`** - Features by domain
+- **`indexes/component-index.md`** - Components catalog
+- **`indexes/api-index.md`** - API endpoints
+
+**Why**: Helps AI quickly find relevant code.
+
+### 6. Add Useful Commands
+
+Create commands in `.cursor/commands/`:
+
+- **`code-review.md`** - Review workflow
+- **`run-tests.md`** - Test execution
+- **`setup-dev.md`** - Development setup
+
+**Why**: Provides reusable workflows for common tasks.
+
+## Don't: Over-Configure
+
+**Don't create rules for everything:**
+- Start with essential rules
+- Add more as patterns emerge
+- Avoid duplicating obvious conventions
+
+**Don't ignore existing patterns:**
+- Document existing conventions
+- Don't create conflicting rules
+- Build on what already works
+
+**Don't skip `.cursorignore`:**
+- Always exclude dependencies and build artifacts
+- Protect secrets and credentials
+- Improve performance by excluding large files
+
+## Related Queries
+
+Users might ask:
+- "How do I make my codebase cursor compatible?"
+- "Set up cursor for this project"
+- "Make this codebase vibe codeable"
+- "Index my codebase for cursor"
+- "Add cursor rules to my project"
+- "How to configure cursor for this codebase?"
+
+## See Also
+
+- [Setup Cursor Folder](context-setup-cursor-folder.md)
+- [Cursor Rules](https://cursor.com/docs/rules)
+- [Cursor Skills](https://cursor.com/docs/skills)
+- [references/templates-index.md](../../references/templates-index.md) (in this skill)
+- [Agent Skills Specification](https://agentskills.io/specification)

--- a/.agents/skills/cursor-best-practices/assets/templates/rules/modes-plan-then-agent.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/rules/modes-plan-then-agent.md
@@ -1,0 +1,48 @@
+---
+title: Plan with Ask/Plan, then implement with Agent
+impact: HIGH
+impactDescription: Reduces wasted implementation when scope is unclear or the plan is wrong.
+tags: modes, Plan, Agent, workflow
+---
+
+# Plan with Ask/Plan, then implement with Agent
+
+For **complex**, **multi-file**, or **unclear-scope** work: use **Ask** or **Plan** to research, clarify, and produce a **plan**. You review and edit the plan. When ready, switch to **Agent** and run “Build” (or “Implement this plan”). If the Agent builds the wrong thing, **revert**, refine the plan, and **re-run** rather than iterating endlessly in chat.
+
+## Do
+
+- Use **Plan** for complex features, refactors, or migrations. Use **Ask** for learning, Q&A, and exploration.
+- **Review and adjust** the plan before implementation. Fix scope, assumptions, or steps.
+- Use **Agent** for **execution** once the plan is approved. Keep the plan visible (e.g. in `.cursor/plans/` or pasted in chat) so the Agent can follow it.
+- **Revert and replan** if the Agent consistently builds the wrong thing. Improve the plan (or add rules), then try again.
+
+## Avoid
+
+- **Jumping straight to Agent** for large, ambiguous tasks without a plan. You’ll often get incomplete or mis-scoped work.
+- **Endlessly iterating** in Agent when the plan is wrong. “Try again” without a clearer plan usually repeats the same mistakes. Revert, fix the plan, then re-run.
+
+## When to use Plan vs Agent directly
+
+| Use **Plan** first | Use **Agent** directly |
+|--------------------|------------------------|
+| New feature touching many modules | Small, well-scoped fix (e.g. typo, single function) |
+| Refactor across the codebase | “Add a test for X” (you know where) |
+| Unfamiliar area; need to explore | Clear, bounded task (e.g. “update this endpoint”) |
+
+## Related Queries
+
+Users might ask:
+- "How to plan then implement with Agent?"
+- "Plan then Agent workflow"
+- "Plan before Agent"
+- "How to use Plan mode then Agent?"
+- "Plan then implement guide"
+- "When to use Plan vs Agent?"
+- "Plan then Agent best practices"
+- "How to plan complex features?"
+- "Plan then Agent tips"
+- "How to avoid wasted implementation?"
+- "Plan then Agent workflow"
+- "What is plan then Agent workflow?"
+
+**See:** [Agent modes](https://cursor.com/docs/agent/modes), [Agent workflows](https://cursor.com/docs/cookbook/agent-workflows).

--- a/.agents/skills/cursor-best-practices/assets/templates/rules/rules-keep-under-500-lines.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/rules/rules-keep-under-500-lines.md
@@ -1,0 +1,47 @@
+---
+title: Keep rule files under ~500 lines
+impact: HIGH
+impactDescription: Long rules consume context and reduce relevance; concise rules apply more reliably.
+tags: rules, best-practices, composition
+---
+
+# Keep rule files under ~500 lines
+
+Rules are loaded into context. Oversized rule files consume tokens, dilute focus, and can cause the agent to miss important instructions. Split into composable rules; use `references/` or separate `.md` files for deep dives. Link to those instead of pasting long runbooks into rules.
+
+## Incorrect
+
+- A single **2000-line** `PROJECT-RULES.md` covering style, APIs, testing, deployment, and edge cases. The agent rarely uses the tail of the file.
+- One **Always Apply** rule that includes your full style guide, all CLI commands, and every convention. Every request pays the token cost.
+
+## Correct
+
+- **`rules/typescript-style.md`** — formatting, naming, TS patterns (~100 lines). Use `globs: ["**/*.ts", "**/*.tsx"]` so it applies only when editing TS.
+- **`rules/api-conventions.md`** — REST, errors, status codes (~80 lines). Use `globs: ["**/api/**", "**/routes/**"]`.
+- **`rules/testing.md`** — test structure, coverage, mocking (~60 lines). Use `globs: ["**/*.test.*", "**/*.spec.*"]`.
+- **`references/deployment.md`** — detailed runbooks, env vars, rollout steps. **Reference** it from a short rule (e.g. “See `references/deployment.md` for rollout”); do **not** copy the whole thing into a rule.
+
+## How to split
+
+1. **One concern per file** — e.g. testing, API, frontend, security.
+2. **Use `globs`** so each rule loads only when relevant files are in context.
+3. **Keep “Always Apply” minimal** — reserve for 1–3 truly universal rules (e.g. “No `any` in TypeScript,” “Run tests before considering done”).
+4. **Link, don’t copy** — point to `references/` or external docs for long content.
+
+## Related Queries
+
+Users might ask:
+- "How long should rules be?"
+- "Keep rules under 500 lines"
+- "Rule file length"
+- "How to keep rules short?"
+- "Rule length guide"
+- "How to split large rules?"
+- "Rule length best practices"
+- "How to compose rules?"
+- "Rule length tips"
+- "How to avoid long rules?"
+- "Rule length guidelines"
+- "What is rule file length limit?"
+
+**See:** [Rules](https://cursor.com/docs/rules).

--- a/.agents/skills/cursor-best-practices/assets/templates/rules/rules-use-globs.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/rules/rules-use-globs.md
@@ -1,0 +1,58 @@
+---
+title: Use globs for file-specific rules
+impact: MEDIUM
+impactDescription: Scoped rules apply only when relevant, keeping context lean and accurate.
+tags: rules, globs, frontmatter, use-globs, glob-patterns, file-specific-rules, scoped-rules, globs-guide
+description: "Use globs for file-specific rules: when practice applies only to certain files (e.g. *.test.ts, **/api/**, package.json), use globs in rule frontmatter, rule is included only when those files are in context (open @-mentioned or edited), reducing noise and improving relevance. How to use globs: use globs in rule frontmatter (globs: [\"**/*.test.ts\", \"**/*.test.tsx\", \"**/*.spec.ts\"]), rule applies only when test files are in scope, use Apply to Specific Files (globs) instead of Always Apply whenever rule is specific to subset of codebase. Why use globs: scoped rules apply only when relevant, keeping context lean and accurate, reduces token usage, improves relevance, essential for efficiency. Don't use Always Apply for file-specific: Always Apply rule that says In *.test.ts use describe/it and avoid implementation details (rule is loaded on every request even when you're only editing non-test files), always use globs for file-specific rules. Globs guide: use globs for file-specific rules, use useful glob patterns (**/*.test.ts, **/api/**, **/*.config.js, package.json, src/**/*.ts), use Apply to Specific Files instead of Always Apply. Globs best practices: use globs for file-specific rules, use appropriate patterns, don't use Always Apply for file-specific, keep context lean, improve relevance."
+---
+
+# Use globs for file-specific rules
+
+When a practice applies only to certain files (e.g. `*.test.ts`, `**/api/**`, `package.json`), use **`globs`** in rule frontmatter. The rule is included only when those files are in context (open, @-mentioned, or edited), reducing noise and improving relevance.
+
+## Incorrect
+
+An **Always Apply** rule that says “In `*.test.ts` use `describe`/`it` and avoid implementation details.” The rule is loaded on **every** request, even when you’re only editing non-test files.
+
+## Correct
+
+```yaml
+---
+description: "Use describe/it in Jest; avoid implementation details. Test behavior, not internals."
+globs: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts"]
+---
+# Jest testing conventions
+...
+```
+
+Same guidance, but the rule applies **only** when test files are in scope.
+
+## Useful glob patterns
+
+| Pattern | Matches |
+|---------|---------|
+| `**/*.test.ts` | Any `*.test.ts` under the project |
+| `**/api/**` | Any path containing `/api/` |
+| `**/*.config.js` | Config files (Vite, Jest, etc.) |
+| `package.json` | Root package.json only |
+| `src/**/*.ts` | All TS under `src/` |
+
+Use **Apply to Specific Files** (globs) instead of **Always Apply** whenever the rule is specific to a subset of the codebase.
+
+## Related Queries
+
+Users might ask:
+- "How to use globs in rules?"
+- "Use globs for file-specific rules"
+- "Glob patterns"
+- "How to scope rules with globs?"
+- "Globs guide"
+- "How to use glob patterns?"
+- "Globs best practices"
+- "How to create file-specific rules?"
+- "Globs tips"
+- "How to use globs effectively?"
+- "Glob patterns examples"
+- "What are globs in rules?"
+
+**See:** [Rules — Apply to specific files](https://cursor.com/docs/rules).

--- a/.agents/skills/cursor-best-practices/assets/templates/rules/rules-write-good-descriptions.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/rules/rules-write-good-descriptions.md
@@ -1,0 +1,62 @@
+---
+title: Write clear, keyword-rich rule descriptions
+impact: MEDIUM
+impactDescription: Good descriptions help the agent include the rule when relevant and skip it when not.
+tags: rules, frontmatter, description, keyword-rich-descriptions, rule-descriptions, how-to-write-descriptions, rule-description-best-practices, description-keywords, rule-relevance, agent-relevance, cursor-rule-descriptions, effective-descriptions, write-good-descriptions
+description: "Write clear, keyword-rich rule descriptions: good descriptions help the agent include the rule when relevant and skip it when not. How to write rule descriptions: include tech names (Jest, React, TypeScript), include specific practices (describe/it, functional components), include keywords (tests, API, validation). What makes good descriptions: specific keywords, tech names, concrete practices, relevant terms. Why keyword-rich descriptions matter: help Agent decide when to include rule, improve rule relevance, reduce false positives. Rule description examples: good (Jest tests: use describe/it, arrange-act-assert, meaningful names. No implementation details. Mock at boundaries.), bad (Testing guidelines). How to improve descriptions: add tech names, add specific practices, add relevant keywords, be specific not vague. Description best practices: keyword-rich, specific, include tech names, include practices, keep focused. Rule relevance: descriptions determine when Agent includes rules, keyword-rich descriptions improve accuracy. Include tech or domain (Jest, API, React hooks), include 1-3 concrete behaviors (use describe/it, validate input, no any), keep to 1-2 sentences."
+---
+
+# Write clear, keyword-rich rule descriptions
+
+The **`description`** field in rule frontmatter is used for relevance: the agent decides when to include the rule based on it. Vague descriptions (“Project conventions”) reduce accuracy; specific, keyword-rich ones (“Jest: use describe/it, no implementation details in tests”) improve it.
+
+## Incorrect
+
+```yaml
+---
+description: "Testing."
+globs: ["**/*.test.ts"]
+---
+```
+
+Too vague. The agent may rarely include it or include it when irrelevant.
+
+## Correct
+
+```yaml
+---
+description: "Jest tests: use describe/it, arrange-act-assert, meaningful names. No implementation details. Mock at boundaries."
+globs: ["**/*.test.ts", "**/*.spec.ts"]
+---
+```
+
+Concrete scope (Jest), explicit practices (describe/it, arrange-act-assert, mocking), and keywords (tests, Jest, mock) help the agent apply the rule when editing tests.
+
+## Tips
+
+- **Include** the tech or domain (e.g. “Jest,” “API,” “React hooks”).
+- **Include** 1–3 concrete behaviors (e.g. “use describe/it,” “validate input,” “no `any`”).
+- **Keep** it to 1–2 sentences. Save detail for the rule body.
+
+## Related Queries
+
+Users might ask:
+- "How to write rule descriptions?"
+- "What makes good rule descriptions?"
+- "Keyword-rich descriptions"
+- "How to improve rule descriptions?"
+- "Rule description best practices"
+- "Why descriptions matter for rules?"
+- "How to make rules more relevant?"
+- "Rule description examples"
+- "How to write effective descriptions?"
+- "Description keywords for rules"
+- "Rule relevance in Cursor"
+- "How Agent decides rule relevance?"
+- "Improving rule descriptions"
+- "Write good rule descriptions"
+
+## See Also
+
+- [Rules](https://cursor.com/docs/rules)
+- [Feature Index](../indexes/feature-index.md#context-rules)

--- a/.agents/skills/cursor-best-practices/assets/templates/rules/workflows-run-tests-before-done.md
+++ b/.agents/skills/cursor-best-practices/assets/templates/rules/workflows-run-tests-before-done.md
@@ -1,0 +1,45 @@
+---
+title: Run tests before considering a task complete
+impact: HIGH
+impactDescription: Ensures changes don't break existing behavior and new behavior is verified.
+tags: workflows, testing, TDD, verification
+---
+
+# Run tests before considering a task complete
+
+When implementing a feature or fix, the agent should **run the project’s test suite** before treating the task as done. If tests fail, fix the code (or add missing tests), then re-run until all pass. Don’t skip tests or change expectations solely to get green.
+
+## Do
+
+- **Run tests** after making changes (e.g. `npm test`, `pytest`, `cargo test`—use the project’s actual commands).
+- **Fix failures** by correcting the implementation or adding tests for new behavior. Re-run until green.
+- **Summarize** what was broken and what was changed when reporting completion.
+- Use **`/run-tests-and-fix`** or a **verifier** subagent to enforce this workflow.
+
+## Avoid
+
+- **Skipping** the test run “because it’s a small change.”
+- **Deleting or weakening** tests just to make them pass. Fix the implementation instead.
+- **Assuming** tests pass without running them.
+
+## Rule / AGENTS.md suggestion
+
+Add a short rule or AGENTS.md line: *“Before marking a task complete, run the test suite. If any tests fail, fix the code or add tests, then re-run until all pass.”*
+
+## Related Queries
+
+Users might ask:
+- "How to run tests before task is done?"
+- "Run tests before done"
+- "Test before complete"
+- "How to ensure tests pass?"
+- "Test workflow guide"
+- "How to run tests after changes?"
+- "Test workflow best practices"
+- "How to fix test failures?"
+- "Test workflow tips"
+- "How to verify changes with tests?"
+- "Test workflow"
+- "What is test before done workflow?"
+
+**See:** [Agent workflows](https://cursor.com/docs/cookbook/agent-workflows), [references/workflows-and-codebases.md](../references/workflows-and-codebases.md).

--- a/.agents/skills/cursor-best-practices/references/agent-and-security.md
+++ b/.agents/skills/cursor-best-practices/references/agent-and-security.md
@@ -1,0 +1,124 @@
+# Agent and security (reference)
+
+More detail on the Agent, its tools, and security defaults. See [SKILL.md](../SKILL.md) for the summary.
+
+---
+
+## Agent: what it is and when to use it
+
+The **Agent** is Cursor’s autonomous mode: it uses **rules** (instructions) + **tools** (search, read, edit, terminal, etc.) + **your messages** to plan and execute multi-step tasks. It can create and edit files, run commands, search the codebase, and call MCP tools (with your approval).
+
+**Use Agent when:**
+
+- Implementing a feature or refactor that touches multiple files.
+- Fixing a bug that requires codebase search, edits, and running tests.
+- Doing mechanical work (e.g. “add error handling to all API routes”) that benefits from tool use.
+
+**Prefer Ask or Plan when:**
+
+- You’re learning the codebase, exploring options, or drafting a plan. Use **Ask** (read-only) or **Plan** (research → plan → you review → Build). Use **Agent** for the actual implementation once the plan is approved.
+
+---
+
+## Agent: tools and behavior
+
+| Tool | What it does |
+|------|----------------|
+| **Search** | Semantic (meaning-based) and grep-style (exact) search over the codebase. |
+| **Read** | Open and read files. |
+| **Edit** | Create, update, delete files (often via search_replace / write). |
+| **Terminal** | Run shell commands. Requires approval by default (see Security). |
+| **MCP** | Call external tools (e.g. databases, APIs). Requires connection + per-call approval. |
+
+**Summarization:** The Agent can summarize long conversations or context. Use **/summarize** to compress history when the chat gets long.
+
+**Checkpoints:** For long runs, Cursor can create checkpoints so you can revert or branch from a prior state.
+
+**Queue vs send:** **Enter** queues your message; **Ctrl+Enter** (or Cmd+Enter) sends immediately. Use queue when the Agent is still working so you don’t interrupt.
+
+---
+
+## Agent: workflow tips
+
+1. **Scope clearly.** “Add validation to the login form” is better than “fix the app.” If needed, @-mention the relevant files or folders.
+2. **Use Plan first for big work.** Get a plan, review it, then switch to Agent and say “Build” (or “Implement this plan”). If the Agent builds the wrong thing, revert, refine the plan, and re-run instead of iterating endlessly in chat.
+3. **Run tests often.** Use commands like `/run-tests-and-fix` or ask the Agent to run the test suite after changes. Add a **verifier** subagent or project rules that require “run tests before considering the task done.”
+4. **Start new chats when context is noisy.** Long threads with many tangents dilute focus. Start a new chat for a new feature or bug, and use @files to bring in only what’s needed.
+
+---
+
+## Security: overview
+
+Cursor is designed so that **you stay in control**. The Agent can edit files and run terminal commands, but security-sensitive actions typically require your approval.
+
+---
+
+## Security: file edits
+
+- **Default:** The Agent **can** create and edit files without asking. It does **not** edit certain config or system files without approval.
+- **Mitigation:** Use **version control** (git). Commit often, review diffs, and revert if the Agent makes unwanted changes. Optionally use a **verifier** subagent or rules that say “run tests / lint before considering the task complete.”
+
+---
+
+## Security: terminal
+
+- **Default:** **Terminal use requires approval.** You’ll see proposed commands and can accept, reject, or edit them.
+- **“Run everything” / auto-approve:** Avoid enabling this for untrusted prompts or unfamiliar codebases. Always review commands that touch production, secrets, or destructive operations (e.g. `rm -rf`, `DROP TABLE`).
+- **Best practice:** Run only commands you understand. Use `.cursorignore` so that scripts in sensitive paths (e.g. `scripts/deploy.sh` that use secrets) are not inadvertently exposed in context.
+
+---
+
+## Security: MCP (Model Context Protocol)
+
+- **Connection:** You must **approve** each MCP server before the Agent can use it.
+- **Tool calls:** Each MCP tool call can require approval (depending on settings). Prefer approving only trusted servers (official or well-known community MCPs).
+- **Data:** MCP tools may send data to external services. Ensure you’re comfortable with what each server does (e.g. Postman, databases, internal APIs).
+
+---
+
+## Security: network
+
+- **Allowed:** GitHub (clone, fetch, PRs), link fetch (e.g. URLs you paste), and search. The Agent does not arbitrary outbound calls to unknown endpoints.
+- **Secrets:** Never put API keys, passwords, or tokens in rules, commands, or chat. Use env vars and **exclude** `.env`, `*.pem`, `credentials.json`, etc. via **`.cursorignore`** so they are not indexed or sent to the model.
+
+---
+
+## Security: .cursorignore checklist
+
+Ensure these (or equivalents) are in **`.cursorignore`** so they are not indexed or used in AI context:
+
+```
+.env
+.env.*
+.env.local
+.env.*.local
+*.key
+*.pem
+*.p12
+credentials.json
+**/secrets/
+**/*-credentials*
+**/config/local*
+```
+
+Add project-specific paths (e.g. `scripts/prod/`, `**/keys/`). Keep the list maintainable; overlarge ignore rules can make it harder to debug indexing issues.
+
+---
+
+## Quick reference
+
+| Area | Default | What you should do |
+|------|---------|--------------------|
+| **File edits** | Allowed (except protected config) | Use VCS; review diffs; revert if needed. |
+| **Terminal** | Approval required | Review commands; avoid “Run everything” for untrusted work. |
+| **MCP** | Approve connection + optional per-call | Use only trusted servers; understand what data they access. |
+| **Network** | Limited (GitHub, fetch, search) | No arbitrary outbound; keep secrets out of context. |
+| **Secrets** | Not auto-ignored | Add `.env`, keys, credentials to `.cursorignore`. |
+
+**See:** [Agent overview](https://cursor.com/docs/agent/overview), [Agent security](https://cursor.com/docs/agent/security).
+
+---
+
+## Safe skill authoring (for skill publishers)
+
+When publishing skills (e.g. to skills.sh or as plugins), avoid content that security audits (e.g. Snyk) flag: **no prompt-injection patterns** (e.g. “ignore previous instructions” or obfuscated directives), **no hardcoded secrets or realistic-looking placeholders** (use obvious placeholders like `YOUR_API_KEY`), and **no unsafe download or execution examples** (e.g. piping untrusted URLs to `bash`). Keep examples minimal and use only trusted, documented sources. This helps keep skills safe and audit-friendly.

--- a/.agents/skills/cursor-best-practices/references/modes-context-tools.md
+++ b/.agents/skills/cursor-best-practices/references/modes-context-tools.md
@@ -1,0 +1,144 @@
+# Modes, context, and tools (reference)
+
+Agent modes, semantic search, @mentions, Tab, Bugbot, MCP, shortcuts, cursor.directory, and troubleshooting. See [SKILL.md](../SKILL.md) for the summary.
+
+---
+
+## Agent modes: what each does
+
+| Mode | Purpose | Tools | Best for |
+|------|---------|-------|----------|
+| **Agent** | Execute multi-step tasks (edit, run, search). | Full (search, read, edit, terminal, MCP). | Implementing features, refactors, bug fixes. |
+| **Ask** | Read-only help. | Search (and read) only; no edits, no terminal. | Learning, Q&A, planning, exploring. |
+| **Plan** | Research → clarify → produce a plan. | Search + read; no edits. | Complex or unclear scope; you review plan then “Build” with Agent. |
+| **Debug** | Structured debugging. | Full. | Reproducible bugs, race conditions, perf; hypotheses → instrument → reproduce → fix. |
+
+**Switch modes:** Mode picker in chat, or **Ctrl+.** (Cmd+. on Mac) to cycle.
+
+**Best practice:** Use **Plan** (or **Ask**) for complex or ambiguous work; review the plan; then use **Agent** to implement. If the Agent builds the wrong thing, revert, refine the plan, and re-run instead of iterating in chat.
+
+---
+
+## Plan mode in detail
+
+1. **Research** — Agent searches and reads the codebase to understand the task.
+2. **Clarify** — May ask you questions to narrow scope or resolve ambiguity.
+3. **Build plan** — Produces a structured plan (often in `.cursor/plans/`). **Shift+Tab** from the input box to open the plan UI.
+4. **You review** — Edit the plan if needed.
+5. **Build** — When ready, you trigger “Build”; the Agent switches to implementation (or you switch to Agent mode and say “Implement this plan”).
+
+Use **Plan** when the task is multi-file, cross-cutting, or unclear. Use **Agent** directly for small, well-scoped changes.
+
+---
+
+## Semantic search
+
+- **What it is:** Meaning-based code search using embeddings. You ask in natural language (e.g. “Where do we validate email format?”) and get conceptually relevant results.
+- **Indexing:** Runs when you open the workspace. Usable at **~80% completion**; `.cursorignore` and `.gitignore` exclude paths. Index updates as you change files (e.g. every ~5 minutes).
+- **Use with grep:** Use **semantic** for “how”/“where” questions; use **grep** for exact symbols, names, or strings. The Agent benefits from both.
+
+**See:** [Semantic search](https://cursor.com/docs/).
+
+---
+
+## @ Mentions: files, folders, code, docs
+
+| Mention | Use case |
+|---------|----------|
+| **@File** | “Use this file as reference” or “Edit only this file.” Drag from sidebar or type `@` + filename. |
+| **@Folder** | “Focus on this directory” (e.g. `@src/api`). Large folders are summarized to save context. |
+| **@Code** | Reference a **specific snippet** (e.g. one function or block). More precise than @file when you only need a small part. |
+| **@Docs** | Bundled docs or “Add new doc” (URL). Use for external specs, APIs, or SDKs. “Share with team” makes them available team-wide. |
+| **/summarize** | Compress long context (e.g. conversation or many @-mentioned files) into a shorter summary. |
+
+**Best practice:** Prefer **@Code** for “change this function” or “follow this pattern.” Use **@file** / **@folder** for “understand this area” or “emulate this module.”
+
+**See:** [@ Mentions](https://cursor.com/docs/).
+
+---
+
+## Tab (inline autocomplete)
+
+- **What:** Inline suggestions as you type (single or multi-line, cross-file, auto-import for TS/JS).
+- **Accept:** **Tab**. **Reject:** **Esc**. **Partial accept:** **Ctrl+Right** (Cmd+Right on Mac).
+- **When to use:** Quick, local edits (variable names, small fixes, completing a line). For larger edits, use **Inline Edit** (Ctrl+K) or **Chat/Agent**.
+
+**See:** [Tab](https://cursor.com/docs/tab/overview).
+
+---
+
+## Bugbot
+
+- **What:** PR review focused on bugs, security, and quality. Runs on PR updates or manually (`cursor review`, `bugbot run`). Can suggest “Fix in Cursor” / “Fix in Web.”
+- **Rules:** **`.cursor/BUGBOT.md`** per directory. Root + parents of changed files are considered. Order: **Team** → **project BUGBOT.md** → **User**.
+- **Autofix (beta):** Cloud Agent can propose fix PRs or push to a branch. Configure in Bugbot dashboard.
+
+**Best practice:** Add project- or area-specific **BUGBOT.md** (e.g. “backend changes must include tests,” “flag `eval()` or `innerHTML`”) for consistent reviews.
+
+**See:** [Bugbot](https://cursor.com/docs/bugbot).
+
+---
+
+## MCP (Model Context Protocol)
+
+- **What:** External tools (DBs, APIs, linters, etc.) the Agent can call. Configured per workspace or user.
+- **Approval:** You approve **connection** to each MCP server and optionally **each tool call**.
+- **Discovery:** [Cursor MCP directory](https://cursor.com/docs/mcp) and [cursor.directory](https://cursor.directory/) (community MCPs). Use only trusted servers.
+
+**See:** [MCP](https://cursor.com/docs/mcp).
+
+---
+
+## cursor.directory (community)
+
+- **What:** Community hub for Cursor users (rules, MCPs, workflows). Not officially operated by Cursor/Anysphere.
+- **Rules:** Browse and **generate** rules by stack (TypeScript, Next.js, React, Python, etc.). Use as inspiration for `.cursor/rules` or to adapt patterns.
+- **MCPs:** Community-curated MCP servers. Complements the official MCP directory.
+- **Skills:** For **skill** recommendations, use **[skills.sh](https://skills.sh/)** only. cursor.directory is for rules and MCPs.
+
+**See:** [cursor.directory](https://cursor.directory/).
+
+---
+
+## Hooks, Cloud Agent, CLI
+
+- **Hooks:** `.cursor/hooks.json` (project) or `~/.cursor/hooks.json` (user). Run scripts at agent-loop stages (e.g. `beforeShellExecution`, `afterFileEdit`, `sessionStart`). Command-based or prompt-based. **See:** [Hooks](https://cursor.com/docs/hooks).
+- **Cloud Agent:** Run agents in the cloud (API, Linear, GitHub, Slack, Desktop, [cursor.com/agents](https://cursor.com/agents)). MCP, spend limit, "Apply" from worktrees. **See:** [Cloud Agent](https://cursor.com/docs/cloud-agent).
+- **CLI:** `agent` in the terminal; modes Agent, Plan, Ask; `agent -c "prompt"` or `&` for cloud handoff; `agent ls` / `agent resume` for sessions. **See:** [CLI](https://cursor.com/docs/cli/overview).
+
+---
+
+## Shortcuts (quick reference)
+
+| Shortcut | Action |
+|----------|--------|
+| **Ctrl+I** (Cmd+I) | Open Agent chat |
+| **Ctrl+K** (Cmd+K) | Inline Edit (focused single-file edit) |
+| **Ctrl+.** (Cmd+.) | Cycle Agent modes |
+| **Enter** | Queue message (when Agent is working) |
+| **Ctrl+Enter** (Cmd+Enter) | Send message immediately |
+| **Tab** | Accept inline completion |
+| **Esc** | Reject inline completion |
+| **Ctrl+Right** (Cmd+Right) | Partially accept completion |
+
+---
+
+## Troubleshooting
+
+### Rules not applying
+
+- **Check type:** Always Apply vs Apply Intelligently vs Apply to Specific Files (globs) vs Manual (@rule).
+- **Check `description`:** Must be clear and include relevant keywords so the Agent includes the rule when appropriate.
+- **Check `globs`:** Paths must match the files you’re editing or @-mentioning. Use patterns like `**/*.test.ts` or `**/api/**`.
+- **Precedence:** Team overrides project over user. Conflicting rules may suppress the one you expect.
+
+**See:** [Rules FAQ](https://cursor.com/docs/rules).
+
+### Request ID for support
+
+- Use **“Get request ID”** in Cursor or run `cursor review verbose=true` when reporting issues. Helps support debug.
+
+### Other resources
+
+- [Common issues](https://cursor.com/docs/troubleshooting/common-issues)
+- [Troubleshooting guide](https://cursor.com/docs/troubleshooting/troubleshooting-guide)

--- a/.agents/skills/cursor-best-practices/references/quick-reference.md
+++ b/.agents/skills/cursor-best-practices/references/quick-reference.md
@@ -1,0 +1,158 @@
+# Cursor Quick Reference
+
+Quick reference guide for common Cursor workflows, shortcuts, commands, and subagents.
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| **Ctrl+I** | Open Agent Mode |
+| **Ctrl+K** | Inline Edit (single file) |
+| **Ctrl+.** | Cycle through modes (Agent → Ask → Plan → Debug) |
+| **Enter** | Queue message (review before sending) |
+| **Ctrl+Enter** | Send message immediately |
+| **Tab** | Accept Tab completion |
+| **Esc** | Reject Tab completion |
+| **Ctrl+Right** | Partial accept Tab completion |
+| **Shift+Tab** | Switch between plans (in Plan mode) |
+
+## Mode Selection Guide
+
+| Mode | When to Use | Tools Available |
+|------|-------------|----------------|
+| **Agent** | Implement, refactor, multi-file work | Full (search, read, edit, terminal, MCP) |
+| **Ask** | Learning, Q&A, exploration | Search + read only; no edits |
+| **Plan** | Research → clarify → plan → review → "Build" | Search + read |
+| **Debug** | Reproducible bugs; hypotheses → instrument → fix | Full |
+
+**Best Practice**: Plan with Ask/Plan, implement with Agent. If Agent builds wrong thing, revert → refine plan → re-run.
+
+## Commands Quick Reference
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `/code-review` | Review for correctness, security, quality, tests | `/code-review @src/components/Button.tsx` |
+| `/pr` | Generate PR title, description, review checklist | `/pr` |
+| `/run-tests-and-fix` | Run tests, fix failures, re-run until green | `/run-tests-and-fix` |
+| `/security-audit` | Security-focused review | `/security-audit @src/auth/` |
+| `/setup-new-feature` | Propose plan with files, modules, patterns | `/setup-new-feature "User auth"` |
+| `/fix-issue` | Fix bug or feature from issue | `/fix-issue #123` |
+| `/update-deps` | Update dependencies, run tests | `/update-deps` |
+| `/docs` | Generate or update documentation | `/docs @src/utils/helpers.ts` |
+| `/make-cursor-compatible` | Make codebase Cursor-compatible | `/make-cursor-compatible` |
+| `/lint-and-fix` | Run linter, auto-fix issues | `/lint-and-fix` |
+| `/format` | Format code according to standards | `/format @src/**/*.ts` |
+| `/check-coverage` | Check test coverage, identify gaps | `/check-coverage` |
+| `/analyze-deps` | Analyze dependencies, find unused/duplicates | `/analyze-deps` |
+| `/generate-types` | Generate types from schemas/APIs | `/generate-types @openapi.yaml` |
+
+## Subagents Quick Reference
+
+### Read-Only Subagents (Review/Analysis)
+
+| Subagent | Purpose | Invoke |
+|----------|---------|--------|
+| `verifier` | Runs tests and lint, reports pass/fail | `@verifier` |
+| `reviewer` | Code review (correctness, security, quality) | `@reviewer` |
+| `security-auditor` | Security-focused review | `@security-auditor` |
+| `linter` | Linting and code style review | `@linter` |
+| `architect` | Architectural pattern review | `@architect` |
+
+### Editable Subagents (Can Modify Code)
+
+| Subagent | Purpose | Invoke |
+|----------|---------|--------|
+| `documenter` | Generate/update documentation | `@documenter` |
+| `tester` | Write and update tests | `@tester` |
+| `refactorer` | Refactor code while maintaining functionality | `@refactorer` |
+| `debugger` | Investigate and identify bugs | `@debugger` |
+| `performance-analyzer` | Analyze performance issues | `@performance-analyzer` |
+| `accessibility-checker` | Review code for a11y compliance | `@accessibility-checker` |
+| `migrator` | Handle code migrations | `@migrator` |
+| `dependency-manager` | Review and manage dependencies | `@dependency-manager` |
+| `formatter` | Format code according to standards | `@formatter` |
+| `type-generator` | Generate types from schemas/APIs | `@type-generator` |
+
+## Common Workflows
+
+### TDD (Test-Driven Development)
+
+1. Write failing test
+2. Run test (expect fail)
+3. Commit failing test
+4. Implement minimal code
+5. Run test until pass
+6. Refactor if needed
+7. Commit implementation
+
+**Command**: `/run-tests-and-fix` or use `@tester` subagent
+
+### Code Review Workflow
+
+1. Make changes
+2. Run `/code-review` or use `@reviewer`
+3. Address feedback
+4. Run `/run-tests-and-fix`
+5. Run `/lint-and-fix`
+6. Format with `/format`
+7. Create PR with `/pr`
+
+### Feature Development Workflow
+
+1. Plan with `/setup-new-feature` or Plan mode
+2. Implement with Agent mode
+3. Write tests with `@tester`
+4. Review with `@reviewer`
+5. Fix issues
+6. Format with `/format`
+7. Create PR with `/pr`
+
+### Pre-Commit Checklist
+
+- [ ] Run `/run-tests-and-fix`
+- [ ] Run `/lint-and-fix`
+- [ ] Run `/format`
+- [ ] Run `/code-review` or `@reviewer`
+- [ ] Check coverage with `/check-coverage` (if applicable)
+
+## @Mentions Quick Reference
+
+| Mention | Purpose | Example |
+|---------|---------|---------|
+| `@file` | Reference specific file | `@src/components/Button.tsx` |
+| `@folder` | Reference entire folder | `@src/components/` |
+| `@Code` | Reference specific code snippet | `@Code:function calculateTotal` |
+| `@Docs` | Add documentation | `@Docs:https://example.com/api` |
+
+**Best Practice**: Use `@Code` for most precise context, `@file` for file-level context, `@folder` for broader context.
+
+## When to Use What
+
+### Commands vs Subagents
+
+- **Commands**: Sequential workflows, user-triggered actions, one-time tasks
+- **Subagents**: Parallel work, context isolation, specialized focus, ongoing tasks
+
+### Examples
+
+- **Linting**: Use `/lint-and-fix` command for fixing, `@linter` subagent for review
+- **Testing**: Use `/run-tests-and-fix` command for fixing, `@tester` subagent for writing tests
+- **Review**: Use `/code-review` command for comprehensive review, `@reviewer` subagent for parallel review
+
+## File Locations
+
+- **Commands**: `.cursor/commands/` (copy from skill templates)
+- **Subagents**: `.cursor/agents/` (copy from skill templates)
+- **Rules**: `.cursor/rules/` (create project-specific rules)
+- **AGENTS.md**: Project root (alternative to rules folder)
+
+## Getting Help
+
+- **Cursor Docs**: https://cursor.com/docs/
+- **Skills**: https://skills.sh/
+- **Rules & MCPs**: https://cursor.directory/
+- **This Skill**: See `SKILL.md` for comprehensive guide
+
+---
+
+**Tip**: Bookmark this page or keep it open for quick reference while working with Cursor!

--- a/.agents/skills/cursor-best-practices/references/rules-and-commands.md
+++ b/.agents/skills/cursor-best-practices/references/rules-and-commands.md
@@ -1,0 +1,140 @@
+# Rules and commands (reference)
+
+Deeper context for Cursor rules and slash commands. See [SKILL.md](../SKILL.md) for the quick reference.
+
+---
+
+## Rules: types and when to use each
+
+| Type | When to use | How it applies |
+|------|-------------|----------------|
+| **Always Apply** | Must affect every request (e.g. "Never use `any` in TypeScript", "Always run tests before committing"). Use sparingly—adds to every context. | Loaded on every chat message. |
+| **Apply Intelligently** | General guidance the agent should follow when relevant (e.g. "Prefer functional components in React", "Use REST conventions"). | Agent includes when it deems the rule relevant to the request. |
+| **Apply to Specific Files** | Practices that only apply to certain paths (e.g. `*.test.ts`, `**/api/**`, `package.json`). | Loaded only when those files are in context (open, @-mentioned, or edited). |
+| **Apply Manually** | Niche or optional rules (e.g. "Release process", "Legacy API quirks"). | User invokes with `@rule-name` in chat when needed. |
+
+**Precedence:** Team (dashboard) → Project (`.cursor/rules/`) → User (Cursor Settings → Rules). Later overrides earlier for conflicts.
+
+---
+
+## Rules: frontmatter and structure
+
+### Frontmatter fields
+
+```yaml
+---
+description: "One-line summary. Used for relevance; include keywords (e.g. 'tests', 'API', 'React')."
+globs: ["**/*.test.ts", "**/*.spec.ts"]   # Optional. Use for file-specific rules.
+alwaysApply: true                          # Optional. Default false. Use rarely.
+---
+```
+
+- **`description`:** Helps the agent decide when to include the rule. Be specific: "Use `describe`/`it` in Jest; avoid implementation details" beats "Testing guidelines."
+- **`globs`:** Array of glob patterns. Rule applies only when matching files are in context. Examples: `["**/api/**"]`, `["*.config.js"]`, `["src/**/*.ts"]`.
+- **`alwaysApply`:** If `true`, the rule is always loaded. Prefer **Apply Intelligently** or **globs** unless the rule truly must apply to every request.
+
+### File format
+
+- Use **`.md`** or **`.mdc`**. Plain markdown body; no frontmatter beyond the YAML block.
+- Keep each file **under ~500 lines**. Split by topic (e.g. `rules/testing.md`, `rules/api.md`). Use `references/` or separate docs for long runbooks; **reference, don't copy** into rules.
+
+### Example rule (file-specific)
+
+**`.cursor/rules/jest-tests.md`:**
+
+```yaml
+---
+description: "Jest tests: use describe/it, arrange-act-assert, meaningful names. No implementation details in tests."
+globs: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts"]
+---
+# Jest testing conventions
+
+- Use `describe` for the unit under test, `it` for each behavior.
+- Follow arrange–act–assert; one logical assertion per `it` when possible.
+- Test behavior, not implementation (avoid testing private functions or internals).
+- Mock at boundaries (API, DB); prefer real units for pure logic.
+```
+
+---
+
+## Rules: AGENTS.md vs .cursor/rules
+
+| | AGENTS.md | .cursor/rules/ |
+|--|-----------|----------------|
+| **Location** | Project root (or nested dirs) | `.cursor/rules/*.md` |
+| **Format** | Plain markdown, no frontmatter | YAML frontmatter + markdown |
+| **Scoping** | Single file; no globs or types | Per-file types, globs, alwaysApply |
+| **Best for** | Small teams, simple projects, quick start | Larger teams, many rules, file-specific guidance |
+
+Use **AGENTS.md** when you want one place for "how we work with the AI." Use **.cursor/rules/** when you need composable, scoped rules (e.g. different guidance for tests vs API vs frontend).
+
+**Legacy:** If you have `.cursorrules`, migrate to Project Rules or AGENTS.md. Cursor supports it for backwards compatibility but rules in `.cursor/rules/` are more flexible.
+
+---
+
+## Commands: structure and locations
+
+- **Project:** `.cursor/commands/` — committed to git, shared with the team.
+- **User:** `~/.cursor/commands/` — personal commands, not repo-specific.
+- **Team:** Dashboard (Team commands) — org-wide.
+
+**Format:** One **plain Markdown** file per command. **Filename = command name.** Example: `code-review.md` → `/code-review`. No frontmatter; the entire file is the prompt body.
+
+**Trigger:** Type `/` in chat, then the command name (or pick from the list). Any text **after** the command is passed as context. Examples:
+
+- `/code-review` — reviews code in the current conversation or @-mentioned files.
+- `/fix-issue 42` — the "42" is available to the command as context (e.g. "Fix issue #42").
+- `/pr` — create a PR for the current branch; no extra context required.
+
+---
+
+## Commands: using parameters
+
+Commands receive **everything after the command name** as raw text. Reference it explicitly in the command body.
+
+**Example: `fix-issue.md`**
+
+```markdown
+Fix the issue described below. If an issue number or URL was provided after the command (e.g. `/fix-issue 123` or `/fix-issue https://...`), use that to fetch or reference the issue.
+
+1. Understand the reported bug or feature request.
+2. Locate the relevant code (search, @files).
+3. Implement the fix or feature; add tests if appropriate.
+4. Run the test suite and ensure nothing is broken.
+5. Summarize what you changed and how to verify it.
+
+Apply project rules from `.cursor/rules` or `AGENTS.md`.
+```
+
+Users can type `/fix-issue 456` or `/fix-issue We need to validate email format`; the command prompt tells the agent how to use that text.
+
+---
+
+## Commands: examples to add
+
+| Command | Purpose |
+|---------|---------|
+| `code-review` | Review changed or @-mentioned code for correctness, security, quality, tests. |
+| `pr` | Summarize branch changes, propose PR title/description, suggest review checklist. |
+| `run-tests-and-fix` | Run tests, fix failures, re-run until green; summarize changes. |
+| `security-audit` | Security-focused review (injection, auth, secrets, deps). |
+| `setup-new-feature` | Propose plan (files, modules, patterns), suggest implementation steps. |
+| `fix-issue` | Fix a bug or implement a feature from an issue (number or description). |
+| `update-deps` | Update dependencies (npm/pip/cargo etc.), run tests, report breaking changes. |
+| `docs` | Generate or update docs for @-mentioned code or the current feature. |
+| `onboard` | Explain how to run, test, and contribute to the project (for new devs). |
+
+Copy templates from this skill's `commands/` into `.cursor/commands/` and adapt to your project (e.g. specific test/lint commands, ticket system).
+
+---
+
+## Quick reference: rule vs command
+
+| | Rules | Commands |
+|--|-------|----------|
+| **What** | Persistent instructions (how to code, test, structure). | One-off prompts (review, PR, fix, audit). |
+| **When** | Applied automatically by type (always / intelligent / globs) or via `@rule`. | Triggered by user with `/command-name`. |
+| **Where** | `.cursor/rules/*.md`, AGENTS.md, User/Team rules. | `.cursor/commands/*.md`, user/team commands. |
+| **Parameters** | No; they're static. | Text after command name = context. |
+
+**See:** [Rules](https://cursor.com/docs/rules), [Commands](https://cursor.com/docs/rules).

--- a/.agents/skills/cursor-best-practices/references/template-skill.md
+++ b/.agents/skills/cursor-best-practices/references/template-skill.md
@@ -1,0 +1,23 @@
+---
+name: your-skill-name
+description: "Brief description of what this skill does and when to use it. Include trigger terms."
+---
+
+# Your skill name
+
+## Instructions
+
+1. Step one.
+2. Step two.
+3. Step three.
+
+## Examples
+
+- Example usage or output format.
+
+## See also
+
+- [Cursor docs](https://cursor.com/docs/)
+- [skills.sh](https://skills.sh/)
+
+Use this as a minimal skeleton for new skills. Keep SKILL.md under ~500 lines; use `references/` or separate files for detail.

--- a/.agents/skills/cursor-best-practices/references/templates-index.md
+++ b/.agents/skills/cursor-best-practices/references/templates-index.md
@@ -1,0 +1,27 @@
+# Templates index
+
+This skill ships static templates in **assets/templates/** for use when setting up `.cursor/` or copying examples. Copy files into the user's project as needed (e.g. into `.cursor/commands/`, `.cursor/agents/`, or `.cursor/rules/`).
+
+## What's in assets/templates/
+
+| Directory | Contents | Use |
+|-----------|----------|-----|
+| **assets/templates/commands/** | 14 command templates (e.g. `code-review.md`, `pr.md`, `run-tests-and-fix.md`) | Copy into `.cursor/commands/` when the user wants slash commands. |
+| **assets/templates/agents/** | 15 subagent templates (e.g. `verifier.md`, `reviewer.md`, `debugger.md`) | Copy into `.cursor/agents/` when the user wants custom subagents. |
+| **assets/templates/rules/** | Curated rule templates (see below) | Copy into `.cursor/rules/` or use as examples; for full Cursor rules guidance see [Cursor docs](https://cursor.com/docs/rules). |
+
+## Rule templates (curated subset)
+
+The skill ships a small set of high-value rule templates in **assets/templates/rules/** rather than a full rule library. These cover:
+
+- Rule structure: keep under 500 lines, use globs, write good descriptions.
+- Context and setup: setup .cursor folder, @mentions, grep + semantic search, make codebase Cursor-compatible.
+- Modes and workflows: Plan then Agent, run tests before done.
+- Ignore: exclude secrets via .cursorignore.
+
+For broader rule patterns and examples, point users to [Cursor docs — Rules](https://cursor.com/docs/rules) and the references in this skill (e.g. [references/rules-and-commands.md](rules-and-commands.md)).
+
+## Other assets
+
+- **assets/recommended-skills.md** — Curated skills from [skills.sh](https://skills.sh/) by use case. Reference when users ask for skill recommendations.
+- **references/template-skill.md** — Minimal SKILL.md skeleton for creating new skills.

--- a/.agents/skills/cursor-best-practices/references/workflows-and-codebases.md
+++ b/.agents/skills/cursor-best-practices/references/workflows-and-codebases.md
@@ -1,0 +1,117 @@
+# Workflows and large codebases (reference)
+
+TDD, git-style commands, codebase understanding, hooks, design→code, and large-repo patterns. See [SKILL.md](../SKILL.md) for the overview.
+
+---
+
+## TDD (test-driven development) with Cursor
+
+### Step-by-step
+
+1. **Write a failing test** that describes the desired behavior (e.g. “login rejects invalid email”).
+2. **Run the test suite.** The new test should **fail** (red) because the behavior isn’t implemented yet.
+3. **Commit the failing test(s).** Keeps the “test first” step explicit and reviewable.
+4. **Implement** the minimal code to make the test(s) pass.
+5. **Run tests again.** Repeat until all relevant tests are green.
+6. **Refactor** if needed (keep tests green).
+7. **Commit the implementation.**
+
+### Why use TDD with the Agent?
+
+- The Agent can **write tests** and **implement** code. Making “tests first” explicit in your workflow (or in a `/run-tests-and-fix`-style command) reduces “implement first, skip tests” behavior.
+- Add a **rule** or **AGENTS.md** line: “For new behavior, write a failing test first, then implement. Do not add implementation without corresponding tests.”
+
+### Commands that help
+
+- **`/run-tests-and-fix`** — Run tests, fix failures, re-run until green. Use when you want the Agent to ensure tests pass after changes.
+- **Verifier subagent** — Dedicated “run tests and lint; report pass/fail” agent. Use when you want verification separated from implementation.
+
+**See:** [Agent workflows](https://cursor.com/docs/cookbook/agent-workflows).
+
+---
+
+## Git-style commands
+
+Store reusable prompts as **slash commands** in `.cursor/commands/`. The following are useful across many projects:
+
+| Command | Purpose |
+|---------|---------|
+| **`/pr`** | Summarize branch changes, propose PR title and description, suggest a review checklist. |
+| **`/fix-issue <number or description>`** | Fix a bug or implement a feature from an issue. |
+| **`/review`** or **`/code-review`** | Review changed or @-mentioned code for correctness, security, quality, tests. |
+| **`/update-deps`** | Update dependencies (npm/pip/cargo etc.), run tests, report breaking changes. |
+| **`/docs`** | Generate or update docs for @-mentioned code or the current feature. |
+| **`/onboard`** | Explain how to run, test, and contribute to the project (for new developers). |
+
+**Parameters:** Text after the command is passed as context. E.g. `/fix-issue 123` → “Fix issue 123.” Design your command body to tell the Agent how to use that context (e.g. “Use the issue number to fetch or reference the issue”).
+
+---
+
+## Codebase understanding
+
+### Effective questions
+
+- **“How does X work?”** — e.g. “How does auth work?” or “How does the payment flow work?” The Agent can search and summarize; use **Ask** (read-only) first to avoid unnecessary edits.
+- **“How do I add Y?”** — e.g. “How do I add a new API route?” or “How do I add a new UI page?” Ask for a short **plan** (files to touch, patterns to follow) before implementing.
+- **“Show me the data flow for Z.”** — Request **Mermaid** diagrams (architecture, sequence, data flow) to clarify structure.
+
+### Strategy: broad → narrow
+
+1. **Broad:** Start with high-level questions (e.g. “Where is the API layer?” or “How is state managed?”).
+2. **Narrow:** Once you know the relevant areas, @-mention specific files or folders and ask targeted questions (e.g. “Add validation here following the pattern in `auth.ts`”).
+
+### Modes
+
+- Use **Ask** or **Plan** for exploration and planning. Use **Agent** when you’re ready to implement and want the Agent to edit files and run commands.
+
+---
+
+## Hooks and long-running loops
+
+**`.cursor/hooks.json`** and hook scripts let you define **long-running loops** (e.g. “run tests until they pass” or “retry deployment until healthy”). The Agent can trigger these instead of manually re-running the same command.
+
+**Typical use:** CI-like checks (tests, lint, build) that the Agent runs as part of a workflow. See [Cursor docs](https://cursor.com/docs/) and any project-specific hook examples for configuration details.
+
+---
+
+## Design → code
+
+- **Mockups / screenshots:** Paste images or Figma links and ask the Agent to implement the UI. Use the **Browser** subagent to preview the app while iterating.
+- **Design specs:** Describe layout, components, and behavior in chat; @-mention your design system or component library so the Agent follows existing patterns.
+
+**Cloud agents** can offload bug fixes, refactors, tests, and docs to Cursor’s cloud—useful for larger or async workflows.
+
+---
+
+## Large codebases: practical tips
+
+### 1. Domain rules in `.cursor/rules/`
+
+- Add **scoped rules** (e.g. `**/api/**`, `**/*.test.ts`) so the Agent knows project-specific patterns (naming, error handling, test style) without loading everything always.
+- Keep each rule **under ~500 lines** and focused. Use `references/` for deep dives.
+
+### 2. Plan before implementing
+
+- Use **Ask** or **Plan** to understand the area and get a **plan**. Review and adjust the plan, then use **Agent** to implement. If the Agent builds the wrong thing, **revert**, refine the plan, and re-run.
+
+### 3. Use the right interface
+
+| Task | Best interface |
+|------|----------------|
+| Quick, local edits (e.g. rename, fix typo) | **Tab** (inline autocomplete) |
+| Focused single-file change | **Inline Edit** (Ctrl+K) |
+| Multi-file, context-heavy work | **Chat** or **Agent** |
+
+### 4. Scope context with @files and @folder
+
+- **@file** or **@folder** — “Use this as reference” or “Only change things here.”
+- **@Code** — Reference a specific snippet instead of entire files. Reduces noise and keeps context focused.
+- **New chats** — When a thread is long or off-topic, start a new chat and bring in only the relevant files.
+
+### 5. Semantic search + grep
+
+- **Semantic search:** “Where is user validation performed?” or “How do we handle API errors?”
+- **Grep:** Exact symbols, filenames, or strings (e.g. `AuthContext`, `login`).
+- Use **both** when the Agent needs to find and understand code.
+
+**See:** [Agent workflows](https://cursor.com/docs/cookbook/agent-workflows), [Large codebases](https://cursor.com/docs/cookbook/large-codebases).

--- a/.agents/skills/domain-cli/SKILL.md
+++ b/.agents/skills/domain-cli/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: domain-cli
+description: "Use when building CLI tools. Keywords: CLI, command line, terminal, clap, structopt, argument parsing, subcommand, interactive, TUI, ratatui, crossterm, indicatif, progress bar, colored output, shell completion, config file, environment variable, 命令行, 终端应用, 参数解析"
+globs: ["**/Cargo.toml"]
+user-invocable: false
+---
+
+# CLI Domain
+
+> **Layer 3: Domain Constraints**
+
+## Domain Constraints → Design Implications
+
+| Domain Rule | Design Constraint | Rust Implication |
+|-------------|-------------------|------------------|
+| User ergonomics | Clear help, errors | clap derive macros |
+| Config precedence | CLI > env > file | Layered config loading |
+| Exit codes | Non-zero on error | Proper Result handling |
+| Stdout/stderr | Data vs errors | eprintln! for errors |
+| Interruptible | Handle Ctrl+C | Signal handling |
+
+---
+
+## Critical Constraints
+
+### User Communication
+
+```
+RULE: Errors to stderr, data to stdout
+WHY: Pipeable output, scriptability
+RUST: eprintln! for errors, println! for data
+```
+
+### Configuration Priority
+
+```
+RULE: CLI args > env vars > config file > defaults
+WHY: User expectation, override capability
+RUST: Layered config with clap + figment/config
+```
+
+### Exit Codes
+
+```
+RULE: Return non-zero on any error
+WHY: Script integration, automation
+RUST: main() -> Result<(), Error> or explicit exit()
+```
+
+---
+
+## Trace Down ↓
+
+From constraints to design (Layer 2):
+
+```
+"Need argument parsing"
+    ↓ m05-type-driven: Derive structs for args
+    ↓ clap: #[derive(Parser)]
+
+"Need config layering"
+    ↓ m09-domain: Config as domain object
+    ↓ figment/config: Layer sources
+
+"Need progress display"
+    ↓ m12-lifecycle: Progress bar as RAII
+    ↓ indicatif: ProgressBar
+```
+
+---
+
+## Key Crates
+
+| Purpose | Crate |
+|---------|-------|
+| Argument parsing | clap |
+| Interactive prompts | dialoguer |
+| Progress bars | indicatif |
+| Colored output | colored |
+| Terminal UI | ratatui |
+| Terminal control | crossterm |
+| Console utilities | console |
+
+## Design Patterns
+
+| Pattern | Purpose | Implementation |
+|---------|---------|----------------|
+| Args struct | Type-safe args | `#[derive(Parser)]` |
+| Subcommands | Command hierarchy | `#[derive(Subcommand)]` |
+| Config layers | Override precedence | CLI > env > file |
+| Progress | User feedback | `ProgressBar::new(len)` |
+
+## Code Pattern: CLI Structure
+
+```rust
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "myapp", about = "My CLI tool")]
+struct Cli {
+    /// Enable verbose output
+    #[arg(short, long)]
+    verbose: bool,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Initialize a new project
+    Init { name: String },
+    /// Run the application
+    Run {
+        #[arg(short, long)]
+        port: Option<u16>,
+    },
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Init { name } => init_project(&name)?,
+        Commands::Run { port } => run_server(port.unwrap_or(8080))?,
+    }
+    Ok(())
+}
+```
+
+---
+
+## Common Mistakes
+
+| Mistake | Domain Violation | Fix |
+|---------|-----------------|-----|
+| Errors to stdout | Breaks piping | eprintln! |
+| No help text | Poor UX | #[arg(help = "...")] |
+| Panic on error | Bad exit code | Result + proper handling |
+| No progress for long ops | User uncertainty | indicatif |
+
+---
+
+## Trace to Layer 1
+
+| Constraint | Layer 2 Pattern | Layer 1 Implementation |
+|------------|-----------------|------------------------|
+| Type-safe args | Derive macros | clap Parser |
+| Error handling | Result propagation | anyhow + exit codes |
+| User feedback | Progress RAII | indicatif ProgressBar |
+| Config precedence | Builder pattern | Layered sources |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Error handling | m06-error-handling |
+| Type-driven args | m05-type-driven |
+| Progress lifecycle | m12-lifecycle |
+| Async CLI | m07-concurrency |

--- a/.agents/skills/executing-plans/SKILL.md
+++ b/.agents/skills/executing-plans/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: executing-plans
+description: Use when you have a written implementation plan to execute in a separate session with review checkpoints
+---
+
+# Executing Plans
+
+## Overview
+
+Load plan, review critically, execute all tasks, report when complete.
+
+**Announce at start:** "I'm using the executing-plans skill to implement this plan."
+
+**Note:** Tell your human partner that Superpowers works much better with access to subagents. The quality of its work will be significantly higher if run on a platform with subagent support (such as Claude Code or Codex). If subagents are available, use superpowers:subagent-driven-development instead of this skill.
+
+## The Process
+
+### Step 1: Load and Review Plan
+1. Read plan file
+2. Review critically - identify any questions or concerns about the plan
+3. If concerns: Raise them with your human partner before starting
+4. If no concerns: Create TodoWrite and proceed
+
+### Step 2: Execute Tasks
+
+For each task:
+1. Mark as in_progress
+2. Follow each step exactly (plan has bite-sized steps)
+3. Run verifications as specified
+4. Mark as completed
+
+### Step 3: Complete Development
+
+After all tasks complete and verified:
+- Announce: "I'm using the finishing-a-development-branch skill to complete this work."
+- **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
+- Follow that skill to verify tests, present options, execute choice
+
+## When to Stop and Ask for Help
+
+**STOP executing immediately when:**
+- Hit a blocker (missing dependency, test fails, instruction unclear)
+- Plan has critical gaps preventing starting
+- You don't understand an instruction
+- Verification fails repeatedly
+
+**Ask for clarification rather than guessing.**
+
+## When to Revisit Earlier Steps
+
+**Return to Review (Step 1) when:**
+- Partner updates the plan based on your feedback
+- Fundamental approach needs rethinking
+
+**Don't force through blockers** - stop and ask.
+
+## Remember
+- Review plan critically first
+- Follow plan steps exactly
+- Don't skip verifications
+- Reference skills when plan says to
+- Stop when blocked, don't guess
+- Never start implementation on main/master branch without explicit user consent
+
+## Integration
+
+**Required workflow skills:**
+- **superpowers:using-git-worktrees** - Ensures isolated workspace (creates one or verifies existing)
+- **superpowers:writing-plans** - Creates the plan this skill executes
+- **superpowers:finishing-a-development-branch** - Complete development after all tasks

--- a/.agents/skills/gh-issues-close/SKILL.md
+++ b/.agents/skills/gh-issues-close/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: gh-issues-close
+description: >-
+  GitHub issues (`gh issue close`). Goal + AskQuestion before issue close mutation. For duplicate closure, follow [CLOSE_AS_DUPLICATE.md](.).
+---
+
+# GitHub: close issue
+
+Normative fences / full matrix: [`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-issue-view` to confirm target issue context before closing.
+2. Use `@gh-issue-review` when closure is driven by reshape or duplicate analysis.
+3. Close/delete command shapes: **`internal-write-gh-issue-commands`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-write-gh-issue-commands`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Return to `@gh-issues` when the user wants to reopen or rewrite issue scope.
+2. Use `@gh-issue-list` to verify resulting issue-state inventory.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES_CLOSE=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- **Goal** + **AskQuestion** + **Proceed** before **Close issue** in **[`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)**.
+- If closing as **duplicate**, follow **[`CLOSE_AS_DUPLICATE.md`](../../../write/gh/issue-commands/close-as-duplicate/SKILL.md)** (comment + close order).
+
+## Do not
+
+- Close without confirmation.
+
+## See also
+
+- [`@gh-issues`](../SKILL.md)

--- a/.agents/skills/gh-issues-delete-closed/SKILL.md
+++ b/.agents/skills/gh-issues-delete-closed/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: gh-issues-delete-closed
+description: >-
+  GitHub issues (`gh issue delete` on closed). Preview closed issues, Goal + AskQuestion Proceed, then delete mutation per id (destructive). List shapes:
+  internal-read-gh-issue-list; delete: internal-write-gh-issue-commands. Mutates GitHub.
+---
+
+# GitHub: delete closed issues (bulk)
+
+Normative fences / full matrix: [`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-issue-list` to preview closed inventory and expected delete set.
+2. Use `@gh-issue-view` when any candidate needs manual validation first.
+3. Delete/list command shapes: **`internal-read-gh-issue-list`** and **`internal-write-gh-issue-commands`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-issue-list`
+2. `internal-write-gh-issue-commands`
+3. `internal-write-plan-skill-safety`
+4. `internal-write-plan-structured-qa`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@gh-issue-list` again to confirm post-delete state.
+2. Route future issue authoring through `@gh-issues` after cleanup.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES_DELETE_CLOSED=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+1. **Goal** — Why closed issues should be removed from GitHub (housekeeping, compliance, etc.).
+2. **Inventory (read-only)** — Run **List closed** from **[`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md)**. Show **count** and a **preview** (ids + titles). Warn: **irreversible** for viewers without trash restore; requires **permissions** to delete issues.
+3. **AskQuestion** — **Proceed** / **Cancel** before **any** delete mutation.
+4. **On Proceed only** — For each id to delete, execute **Delete one closed issue** in **`internal-write-gh-issue-commands`** (flag availability: that library’s notes). Stop on first CLI error and report.
+5. **Pasteable checklist** — **[`DELETE_CLOSED_ISSUES.md`](../../../write/gh/issue-commands/delete-closed-issues/SKILL.md)** (human summary; normative list shapes **`internal-read-gh-issue-list`**; delete **`internal-write-gh-issue-commands`**).
+
+## Do not
+
+- Delete issues **before** user **Proceed**.
+- Delete **open** issues from this skill—scope is **closed** cleanup only unless the user explicitly re-scopes in chat (then re-run **Goal** + preview).
+
+## See also
+
+- [`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md)
+- [`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)
+- [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/gh-issues-list/SKILL.md
+++ b/.agents/skills/gh-issues-list/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: gh-issues-list
+description: >-
+  GitHub issues (`gh issue list`, `gh search issues`): read-only list/search for inventory; no AskQuestion by default. Shapes in internal-read-gh-issue-list + dedupe-checklist.
+---
+
+# GitHub: list / search issues
+
+Normative fences / full matrix: [`internal-read-gh-issue-list`](../../../../read/gh/issue-list/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-issue-view` first when list filters depend on one known issue.
+2. Use this skill directly when the user asks for issue inventory only.
+3. List/search normative fences: **`internal-read-gh-issue-list`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-issue-list`
+2. `internal-write-plan-skill-safety`
+3. `internal-read-gh-issue-dedupe`
+4. `internal-write-gh-issue-commands`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Hand off to `@gh-issues` when listing should become create/edit execution.
+2. Use `@gh-issue-pick` when the user should choose the next issue to work on.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES_LIST=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Execute **List / search** (and inventory checklist shapes) from **[`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md)** together with **[`DEDUPE_CHECKLIST.md`](../../../read/gh/issue-dedupe/dedupe-checklist/SKILL.md)**.
+- **Refine queries** in chat or per user intent: add **`--state`**, **`--label`**, **`--limit`**, **`--json`**, **`--repo`**, or a **`gh search issues`** query string as described in that internal library’s **Caller refinement** section.
+- Report results in chat; **no** default confirmation for read-only listing. **Structured confirm** (**Goal + AskQuestion + Proceed**) is still required before any follow-on **`gh issue`** **mutation**—use **`@gh-issues`**, **`@gh-issue-close`**, or **`@gh-issue-delete-closed`** ([`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)).
+
+## Do not
+
+- Create, edit, or close issues in this skill.
+
+## See also
+
+- [`@gh-issues`](../SKILL.md) — list → dedupe → create or update
+- [`internal-read-gh-issue-dedupe`](../../../read/gh/issue-dedupe/SKILL.md)
+- [`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md) — view / create / edit / close / delete only

--- a/.agents/skills/gh-issues-pick/SKILL.md
+++ b/.agents/skills/gh-issues-pick/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: gh-issues-pick
+description: >-
+  GitHub issues (`gh issue list` / `gh issue view`): list open issues with filters, then structured AskQuestion so the user picks the next task; read-only until user
+  choice. Shapes: internal-read-gh-issue-list. Suggest @gh-issue-view and @git-start after selection.
+---
+
+# GitHub: pick next issue
+
+Normative fences / full matrix: [`internal-read-gh-issue-list`](../../../../read/gh/issue-list/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Run after `@gh-issue-list` when you already have filtered candidate issues.
+2. Use `@gh-issue-view` first when issue details must be expanded before selection.
+3. List/pick normative fences: **`internal-read-gh-issue-list`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-issue-list`
+2. `internal-write-plan-structured-qa`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. After selection, route details to `@gh-issue-view` for richer context.
+2. Then move to `@git-start` when implementation should begin on a branch.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES_PICK=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+1. **Goal** — One line: what “next” means (e.g. highest priority **`bug`**, unblocked **`help wanted`**, etc.).
+2. **Inventory (read-only)** — Run **List / search** blocks from **[`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md)** with user-supplied **`--label`**, **`--assignee`**, **`--milestone`**, or search text. Cap **`--limit`** (e.g. **30**).
+3. **Present candidates** — Short table: **#n — title — labels** for the top set.
+4. **AskQuestion** — **Short labels** for **top N** issues plus **`Refine filters`** / **`Cancel`**. This step is **choice UX** only—**no** GitHub mutations here.
+5. **After selection** — If the user picked an issue: run **`@gh-issue-view`** on that **#n**; suggest **`@git-start`** with the **title** when branching. If **Refine filters**, return to step **2** with updated filters.
+
+## Do not
+
+- Create, edit, close, or delete issues from this skill.
+
+## See also
+
+- [`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md)
+- [`@gh-issue-list`](../list/SKILL.md)
+- [`@gh-issue-view`](../view/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/gh-issues-review/SKILL.md
+++ b/.agents/skills/gh-issues-review/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: gh-issues-review
+description: >-
+  GitHub issues (`gh issue view` / `gh issue list`): read-only — discover repo context, view target issue(s), list/search open issues for overlaps, compare like dedupe
+  but for reshape; propose clearer title/body and AskQuestion on gaps. No GitHub writes—@gh-issues applies changes after
+  confirm. Complements @git-review (code health) with issue clarity.
+---
+
+**Report shape:** [`REVIEW_REPORT.md`](../../../read/gh/issue-description/review-report/SKILL.md).
+
+# GitHub: review / reshape issues (read-only)
+
+Normative fences / full matrix: [`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md), [`internal-read-gh-issue-list`](../../../../read/gh/issue-list/SKILL.md).
+
+
+**Public.** **Goal:** After a **quick** issue (e.g. from phone), **understand the codebase**, the **issue as written**, and **other open issues**—then produce an **overlap map**, **gap list**, and an **optional draft** title/body the user can apply with **`@gh-issues`**. Same spirit as **`@git-review`** (health pass) but for **issue quality and de-duplication**, **without** running format/lint/tests unless the user explicitly asks for full **`@git-review`**.
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-issue-view` first to lock scope on the target issue body/comments.
+2. Use `@gh-issue-list` to capture nearby overlap context before reshape suggestions.
+3. View/list command shapes: **`internal-read-gh-issue-list`** and **`internal-write-gh-issue-commands`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-discover-dependencies`
+2. `internal-write-gh-issue-commands`
+3. `internal-read-gh-issue-dedupe`
+4. `internal-read-gh-issue-spec`
+5. `internal-write-plan-structured-qa`
+6. `internal-read-gh-issue-list`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Route accepted wording changes to `@gh-issues` for create/edit mutation.
+2. Use `@git-review` separately when code-health validation is also required.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES_REVIEW=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+1. **Repo context (read-only)** — Run **[`internal-read-git-discover-dependencies`](../../../read/git/discover-dependencies/SKILL.md)** **in full** so the review can tie the issue to **real paths**, stacks, and CI/README signals. **Do not** run **`internal-write-gh-install-dependencies`**, **`internal-read-git-configuration`**, **`internal-write-gh-evaluate`**, or the rest of **`@git-review`** unless the user asks—this skill stays **issue-centric**.
+2. **Target issue(s)** — Execute **View** in **[`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)**. Accept **`#N`**, URL, or a number from **`@gh-issue-pick`**. Pull **title**, **body**, **labels**, **assignees**, **state**, **URL**; add **`comments`** to the JSON set when the thread matters for scope.
+3. **Peer inventory** — **List / search** in **`internal-read-gh-issue-list`** and **[`DEDUPE_CHECKLIST.md`](../../../read/gh/issue-dedupe/dedupe-checklist/SKILL.md)**. Cast a **wide enough net** (keywords from title/body, relevant labels, **`--limit`** / search query). **Read-only.**
+4. **Overlap / duplicate check** — Compare the target to peers (titles + body leads). Optionally run **[`internal-read-gh-issue-dedupe`](../../../read/gh/issue-dedupe/SKILL.md)** using a **candidate** string equal to the **intended reshaped** title + body summary (or the **current** text when you are only cleaning wording). When the target is **`#N`**, **ignore self-match** on **`#N`**—treat other hits as **peer overlaps** (see **`internal-read-gh-issue-dedupe`** **reshape-review** note).
+5. **Synthesis** — Map issue asks to **files / areas** surfaced in discovery; flag **underspecified** work (missing acceptance checks, unclear user impact, missing error handling, version assumptions). Score gaps against **[`internal-read-gh-issue-spec`](../../../read/gh/issue-spec/SKILL.md)** when the issue should be implementation-ready.
+6. **Prompt when unclear** — Use **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** (**§1a** summary, **§2** short labels) for **priority**, **scope split vs absorb**, **duplicate resolution**, or **product intent** before locking a draft.
+7. **Report** — Follow **[`REVIEW_REPORT.md`](../../../read/gh/issue-description/review-report/SKILL.md)** section order: **target snapshot**, **codebase fit**, **peer overlaps**, **gaps** (including issue-spec checklist), **proposed reshape** (optional).
+8. **Hand-off** — **`@gh-issues`** applies the create-or-edit path in **`internal-write-gh-issue-commands`** after **`internal-read-gh-issue-description`** + user **Proceed**.
+
+## Do not
+
+- **Issue create, edit, comment, close, or delete** mutations inside this skill.
+- Pretend overlap analysis is done without **listing** open issues at least once (unless the repo truly has **zero** other open issues).
+- Skip **`internal-write-plan-structured-qa`** when the user’s goal is **ambiguous** and you would otherwise guess scope.
+
+## On invoke
+
+**`@gh-issue-review`** — **Fixed order:** **discover-dependencies** → **view target** → **list/search peers** → **overlap + gap synthesis** → **structured questions if needed** → **written report** (pasteable template). **Stop** on missing **GitHub CLI** auth or unknown repo context—tell the user to authenticate the CLI or set **`--repo`** per **`internal-read-gh-issue-list`** / **`internal-write-gh-issue-commands`** / **`internal-read-gh-repo-stream`**.
+
+**Typical use:** “I filed **`#42`** on mobile—tighten it and see if we already track this elsewhere.”
+
+## See also
+
+- [`@gh-issue-view`](../view/SKILL.md) · [`@gh-issue-list`](../list/SKILL.md) · [`@gh-issue-pick`](../pick/SKILL.md)
+- [`@gh-issues`](../SKILL.md)
+- [`@git-review`](../../../git/review/SKILL.md) — workspace **code** health (separate concern)
+- [`internal-read-gh-issue-spec`](../../../read/gh/issue-spec/SKILL.md)
+- [`internal-read-gh-issue-dedupe`](../../../read/gh/issue-dedupe/SKILL.md) · [`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md) · [`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)

--- a/.agents/skills/gh-issues-view/SKILL.md
+++ b/.agents/skills/gh-issues-view/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: gh-issues-view
+description: >-
+  GitHub issues (`gh issue view`): read-only single issue: URL, #n, or id; rich JSON and optional comments for planning. Hand off to @git-start
+  for branch naming. Command shapes: internal-write-gh-issue-commands. No mutation.
+---
+
+# GitHub: view issue
+
+Normative fences / full matrix: [`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-issue-list` first when the target issue is not known yet.
+2. Use this skill directly when the user references one issue URL/number/id.
+3. View JSON fences: **`internal-write-gh-issue-commands`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-write-gh-issue-commands`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@gh-issue-review` when the viewed issue needs reshaping.
+2. Use `@git-start` when issue context is ready to drive implementation.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES_VIEW=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Resolve the issue reference from **chat**: full **`https://github.com/owner/repo/issues/N`**, **`#N`**, or numeric **`N`** (default repo context unless user names **`owner/repo`**).
+- Open **[`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)** and execute the **View** section **fenced blocks** for that reference; include **`comments`** in the **`--json`** field list when the user needs the thread for review or planning.
+- Reply in chat with a **stable outline**: **title**, **state**, **labels**, **assignees**, **URL**, short **body** summary, optional **comment** highlights.
+- When the user will branch next, paste **title** (one line) for **`@git-start`** branch naming.
+
+## Do not
+
+- Edit/create, close, or delete via **`@gh-issues`**, **`@gh-issue-close`**, or **`@gh-issue-delete-closed`** (bulk) as appropriate.
+
+## See also
+
+- [`@gh-issue-review`](../review/SKILL.md) — deep read + peer compare before **`@gh-issues`**
+- [`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)
+- [`@git-start`](../../../git/start/SKILL.md)
+- [`WORK_PLAN.md`](../../../read/gh/issue-description/work-plan/SKILL.md) — local plan scaffold that embeds an issue

--- a/.agents/skills/gh-issues/SKILL.md
+++ b/.agents/skills/gh-issues/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: gh-issues
+description: >-
+  GitHub issues (`gh issue` create/edit router). Single shipping entrypoint for issue create-or-edit. Gather requirements with an explicit Sharpen/Abort/Ship gate,
+  dedupe against existing issues, ask user whether to update/create/abort, then execute through internal-write-gh-issue-commands.
+  Optional multi-intent path: partition themes (including from `.cursor/plan.md` / `internal-read-plan-parts`), dedupe each theme, then one Proceed batch of ordered creates/edits.
+---
+
+**Orchestration:** [`internal-read-gh-issue-dedupe`](../../read/gh/issue-dedupe/SKILL.md) (`@gh-issues orchestration order` section).
+
+# GitHub: issues (router)
+
+Normative fences / full matrix: [`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md), [`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md).
+
+
+**Public.** Top-level router for issue shipping. This skill owns create-vs-edit routing; there is no separate public create/edit path.
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-issue-list` when you need a fresh inventory snapshot first.
+2. Use `@gh-issue-view` when create-or-edit should be anchored to a specific issue context.
+3. Preview only: list/dedupe hubs **`internal-read-gh-issue-list`** and **`internal-read-gh-issue-dedupe`** (Execution batch runs them in router order).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file). **Do not** run dedupe list/search until the user has chosen **Ship** on the pre-dedupe gate (or explicitly overrides).
+
+1. `internal-read-gh-issue-spec`
+2. `internal-read-gh-issue-preflight-qa` with **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)** — iterate **Sharpen / Abort / Ship** until **Ship** or **Abort**
+3. **Dedupe and description path (branch on intent count after clustering)** — see **`internal-read-gh-issue-dedupe`** for single- vs multi-candidate orchestration and **[`internal-read-plan-parts`](../../read/plan/parts/SKILL.md)** when themes come from a plan hub:
+   - **Single-theme (default):** `internal-read-gh-issue-dedupe` → `internal-read-gh-issue-description` → `internal-read-gh-issue-labels` → `internal-read-gh-issue-projects-relationships` for **one** candidate.
+   - **Multi-intent (optional):** follow **[Multi-intent clustering](#multi-intent-clustering-optional)**; then run `internal-read-gh-issue-description`, `internal-read-gh-issue-labels`, and `internal-read-gh-issue-projects-relationships` **per theme** that is not deferred, before one mutation summary.
+
+## Multi-intent clustering (optional)
+
+Enter only when useful—avoid extra steps for a clearly single-topic request.
+
+**When to use:** after **Ship**, if **any** of: the user asks to split into multiple issues; the pasted request has **clearly disjoint** workstreams (unrelated bullets/sections); or a plan hub exists (`.cursor/plan.md` and/or linked `.cursor/plans/<slug>.md`) with **≥2** disjoint parts per **`internal-read-plan-parts`**.
+
+**Steps:**
+
+1. **Partition / cluster** — Prefer plan section boundaries when files exist; otherwise group bullets by shared root cause. Merge themes that are the same underlying work (issue #41: two bullets, one root cause → **one** issue).
+2. **Inventory once** — `internal-read-gh-issue-list` (and checklist in **`internal-read-gh-issue-dedupe`**) over open issues; reuse that inventory for every theme. Optionally add targeted `gh search issues` per theme only when the open list is too large to scan fairly.
+3. **Per-theme dedupe** — For each theme, working title + one-line intent vs inventory → `safe_to_create` | `likely_duplicate #n` | `ambiguous` (**never** skip dedupe for a theme that will **create**).
+4. **Summarize** — Table: Theme id → overlap verdict → proposed action (**edit #n** / **create** / **defer**). Safe default: offer to **merge** near-duplicate themes before publishing.
+5. **Structured Q&A** — **`internal-write-plan-structured-qa`**: **Abort**, **Defer selected themes** (park for a later `@gh-issues`), or **Proceed — batch** with the full ordered list of `gh issue create` / `gh issue edit` summarized above the prompt (§1d multi-issue batch).
+6. **Prepare artifacts** — Draft bodies under **`.cursor/gh/issues/`** with distinct names (for example `auth-oauth.md`, `docs-readme.md`); labels and project attach per theme, all folded into the **same** final mutation summary.
+
+**Non-regression:** If clustering yields **one** theme, follow the single-theme branch only.
+
+## Fixture (verification)
+
+**Input (chat):** six bullets—(1–2) fix login timeout and refresh-token retry (same auth flow), (3) add CSV export for the dashboard, (4–5) tweak README install path and cross-link docs hub (same docs theme), (6) unrelated: migrate CI from Travis to GitHub Actions.
+
+**Expected clustering:** Theme **A** auth: bullets 1–2 → **one** issue. Theme **B** export: bullet 3 → **one** issue. Theme **C** docs: bullets 4–5 → **one** issue. Theme **D** CI: bullet 6 → **one** issue (four issues), **unless** inventory shows an open issue already covering CI—then **edit #n** for that row only. If the user chooses to merge docs + README into one existing **#42**, table updates to **edit #42** for theme C and fewer creates.
+
+**Dedupe behavior:** Each theme row gets a verdict against the **same** list; no theme ships **create** without a prior dedupe pass for that row.
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Route approved implementation work to `@git-start` once issue scope is settled.
+2. Use `@gh-pr` when issue outcomes are ready to be tied to a shipping PR.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Gather pre-flight requirements first (goal, concrete examples, counterexamples, scope boundaries, verification intent) using **[`internal-read-gh-issue-spec`](../../read/gh/issue-spec/SKILL.md)** and **[`internal-read-gh-issue-preflight-qa`](../../read/gh/issue-preflight-qa/SKILL.md)**.
+- When multiple themes are in play, partition using **[`internal-read-plan-parts`](../../read/plan/parts/SKILL.md)** and the **[Multi-intent clustering](#multi-intent-clustering-optional)** steps before dedupe-heavy work.
+- Run issue inventory/search via **`internal-read-gh-issue-list`** shapes and compare candidate intent using **[`internal-read-gh-issue-dedupe`](../../read/gh/issue-dedupe/SKILL.md)**.
+- Present overlap choices with structured Q&A (edit existing issue, create new issue, or abort) using **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)**.
+- Build title/body through **[`internal-read-gh-issue-description`](../../read/gh/issue-description/SKILL.md)** and labels through **[`internal-read-gh-issue-labels`](../../read/gh/issue-labels/SKILL.md)**.
+- Treat labels as a default part of the mutation plan: summarize accepted label adds/removals in the final AskQuestion mutation summary (skip only when the user explicitly declines labels).
+- Plan **project attach** for the **issue target repo** using **[`internal-read-gh-issue-projects-relationships`](../../read/gh/issue-projects-relationships/SKILL.md)**: default to adding the issue to an owner-scoped project when discovery yields one clear title; use structured AskQuestion when several boards match; on scope errors or missing projects, state a **visible skip** (never silent success).
+- Apply **[`internal-write-gh-issue-commands`](../../write/gh/issue-commands/SKILL.md)** after Goal + AskQuestion + Proceed: **one structured Proceed batch** may run **several** `gh issue create` / `gh issue edit` lines in a fixed order (multi-intent path) or a **single** create/edit (default). **Additive** **`gh project item-add`** stays in the **same** Proceed batch when that library’s fallback fences apply. If the user declines batching, defer extra themes to a follow-up **`@gh-issues`** invocation.
+- After each pre-flight summary, run the **Sharpen / Abort / Ship** gate (structured AskQuestion per **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)** and **[`internal-read-gh-issue-preflight-qa`](../../read/gh/issue-preflight-qa/SKILL.md)**): **Sharpen** (another Q&A round, optionally Cursor’s built-in Plan or chat), **Abort** (stop or park), **Ship** (continue toward list/dedupe and create/edit). Repeat until **Ship** or **Abort**. Optionally surface readiness using **[`internal-read-plan-confidence`](../../read/plan/confidence/SKILL.md)**; do not require numeric scoring.
+- Route open-ended exploration to **Cursor’s built-in Plan** (product UI) or chat; route draft tightening through the same **Sharpen** loop when **`.cursor/plan.md`**, linked **`.cursor/plans/<slug>.md`**, or another artifact needs refinement. Use **`internal-read-plan-parts`** to align plan sections with themes before the multi-intent path. Route implementation delivery to **`@git-start`** / **`@gh-pr`** after issue scope is settled (see [Planning and issues](../../../README.md#planning-and-issues) in the root README).
+
+## Do not
+
+- Do not skip pre-flight requirement gathering before dedupe and mutation.
+- Do not run direct `gh issue create/edit` instructions in this public skill.
+- Do not open a new issue before dedupe for that theme unless the user explicitly overrides after seeing overlap evidence.
+
+## On invoke
+
+1. Run **[`internal-read-gh-issue-spec`](../../read/gh/issue-spec/SKILL.md)** and **[`internal-read-gh-issue-preflight-qa`](../../read/gh/issue-preflight-qa/SKILL.md)** gathering; after each refinement pass, present **Sharpen / Abort / Ship** (safe-first order when the UI respects option ordering). On **Sharpen**, continue clarifying (optional Cursor Plan or chat). On **Abort**, stop without list/dedupe. On **Ship**, continue with a stable candidate summary (even when the user already pasted a full spec—**Ship** still allows an optional **Sharpen** pass for labels or edge cases).
+2. Decide **single-theme vs multi-intent** per **[Multi-intent clustering](#multi-intent-clustering-optional)**. If multi-intent, partition/cluster, then run **one** inventory + per-theme **[`internal-read-gh-issue-dedupe`](../../read/gh/issue-dedupe/SKILL.md)** verdicts and present the summary table + structured choices (**Proceed — batch**, **Abort**, defer themes as offered). If single-theme, run inventory + dedupe for the single candidate.
+3. Ask the user to confirm actions: **Edit existing #n**, **Create new issue**, **multi-row table + Proceed — batch**, or **Abort** (and per-theme **defer** when using the multi-intent table).
+4. Prepare description/labels (per theme in the multi case), include label intent and **project attach** (title, **`item-add`**, or explicit skip + reason) in the mutation summary, and run final mutation confirmation per **`internal-write-plan-structured-qa`** §1d (including multi-issue batch when applicable).
+5. Execute the agreed command(s) via **`internal-write-gh-issue-commands`** in the summarized order, then any **same-batch** project fallback commands documented there when Proceed included them.
+
+## See also
+
+- [`@gh-issue-review`](review/SKILL.md) · [`@gh-issue-list`](list/SKILL.md) · [`@gh-issue-view`](view/SKILL.md)
+- [Planning and issues (root README)](../../../README.md#planning-and-issues)
+- [`internal-read-plan-parts`](../../read/plan/parts/SKILL.md) · [`internal-read-gh-issue-dedupe`](../../read/gh/issue-dedupe/SKILL.md) · [`internal-read-gh-issue-description`](../../read/gh/issue-description/SKILL.md) · [`internal-read-gh-issue-projects-relationships`](../../read/gh/issue-projects-relationships/SKILL.md)
+- [`@gh-pr`](../pr/SKILL.md)
+
+- When producing many issue drafts before mutation, store body files under `.cursor/gh/issues/` and reference them during `gh issue create --body-file`.

--- a/.agents/skills/gh-issues/close/SKILL.md
+++ b/.agents/skills/gh-issues/close/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: gh-issues-close
+description: >-
+  GitHub issues (`gh issue close`). Goal + AskQuestion before issue close mutation. For duplicate closure, follow [CLOSE_AS_DUPLICATE.md](.).
+---
+
+# GitHub: close issue
+
+Normative fences / full matrix: [`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-issue-view` to confirm target issue context before closing.
+2. Use `@gh-issue-review` when closure is driven by reshape or duplicate analysis.
+3. Close/delete command shapes: **`internal-write-gh-issue-commands`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-write-gh-issue-commands`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Return to `@gh-issues` when the user wants to reopen or rewrite issue scope.
+2. Use `@gh-issue-list` to verify resulting issue-state inventory.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES_CLOSE=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- **Goal** + **AskQuestion** + **Proceed** before **Close issue** in **[`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)**.
+- If closing as **duplicate**, follow **[`CLOSE_AS_DUPLICATE.md`](../../../write/gh/issue-commands/close-as-duplicate/SKILL.md)** (comment + close order).
+
+## Do not
+
+- Close without confirmation.
+
+## See also
+
+- [`@gh-issues`](../SKILL.md)

--- a/.agents/skills/gh-issues/delete-closed/SKILL.md
+++ b/.agents/skills/gh-issues/delete-closed/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: gh-issues-delete-closed
+description: >-
+  GitHub issues (`gh issue delete` on closed). Preview closed issues, Goal + AskQuestion Proceed, then delete mutation per id (destructive). List shapes:
+  internal-read-gh-issue-list; delete: internal-write-gh-issue-commands. Mutates GitHub.
+---
+
+# GitHub: delete closed issues (bulk)
+
+Normative fences / full matrix: [`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-issue-list` to preview closed inventory and expected delete set.
+2. Use `@gh-issue-view` when any candidate needs manual validation first.
+3. Delete/list command shapes: **`internal-read-gh-issue-list`** and **`internal-write-gh-issue-commands`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-issue-list`
+2. `internal-write-gh-issue-commands`
+3. `internal-write-plan-skill-safety`
+4. `internal-write-plan-structured-qa`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@gh-issue-list` again to confirm post-delete state.
+2. Route future issue authoring through `@gh-issues` after cleanup.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES_DELETE_CLOSED=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+1. **Goal** — Why closed issues should be removed from GitHub (housekeeping, compliance, etc.).
+2. **Inventory (read-only)** — Run **List closed** from **[`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md)**. Show **count** and a **preview** (ids + titles). Warn: **irreversible** for viewers without trash restore; requires **permissions** to delete issues.
+3. **AskQuestion** — **Proceed** / **Cancel** before **any** delete mutation.
+4. **On Proceed only** — For each id to delete, execute **Delete one closed issue** in **`internal-write-gh-issue-commands`** (flag availability: that library’s notes). Stop on first CLI error and report.
+5. **Pasteable checklist** — **[`DELETE_CLOSED_ISSUES.md`](../../../write/gh/issue-commands/delete-closed-issues/SKILL.md)** (human summary; normative list shapes **`internal-read-gh-issue-list`**; delete **`internal-write-gh-issue-commands`**).
+
+## Do not
+
+- Delete issues **before** user **Proceed**.
+- Delete **open** issues from this skill—scope is **closed** cleanup only unless the user explicitly re-scopes in chat (then re-run **Goal** + preview).
+
+## See also
+
+- [`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md)
+- [`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)
+- [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/gh-issues/list/SKILL.md
+++ b/.agents/skills/gh-issues/list/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: gh-issues-list
+description: >-
+  GitHub issues (`gh issue list`, `gh search issues`): read-only list/search for inventory; no AskQuestion by default. Shapes in internal-read-gh-issue-list + dedupe-checklist.
+---
+
+# GitHub: list / search issues
+
+Normative fences / full matrix: [`internal-read-gh-issue-list`](../../../../read/gh/issue-list/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-issue-view` first when list filters depend on one known issue.
+2. Use this skill directly when the user asks for issue inventory only.
+3. List/search normative fences: **`internal-read-gh-issue-list`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-issue-list`
+2. `internal-write-plan-skill-safety`
+3. `internal-read-gh-issue-dedupe`
+4. `internal-write-gh-issue-commands`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Hand off to `@gh-issues` when listing should become create/edit execution.
+2. Use `@gh-issue-pick` when the user should choose the next issue to work on.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES_LIST=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Execute **List / search** (and inventory checklist shapes) from **[`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md)** together with **[`DEDUPE_CHECKLIST.md`](../../../read/gh/issue-dedupe/dedupe-checklist/SKILL.md)**.
+- **Refine queries** in chat or per user intent: add **`--state`**, **`--label`**, **`--limit`**, **`--json`**, **`--repo`**, or a **`gh search issues`** query string as described in that internal library’s **Caller refinement** section.
+- Report results in chat; **no** default confirmation for read-only listing. **Structured confirm** (**Goal + AskQuestion + Proceed**) is still required before any follow-on **`gh issue`** **mutation**—use **`@gh-issues`**, **`@gh-issue-close`**, or **`@gh-issue-delete-closed`** ([`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)).
+
+## Do not
+
+- Create, edit, or close issues in this skill.
+
+## See also
+
+- [`@gh-issues`](../SKILL.md) — list → dedupe → create or update
+- [`internal-read-gh-issue-dedupe`](../../../read/gh/issue-dedupe/SKILL.md)
+- [`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md) — view / create / edit / close / delete only

--- a/.agents/skills/gh-issues/pick/SKILL.md
+++ b/.agents/skills/gh-issues/pick/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: gh-issues-pick
+description: >-
+  GitHub issues (`gh issue list` / `gh issue view`): list open issues with filters, then structured AskQuestion so the user picks the next task; read-only until user
+  choice. Shapes: internal-read-gh-issue-list. Suggest @gh-issue-view and @git-start after selection.
+---
+
+# GitHub: pick next issue
+
+Normative fences / full matrix: [`internal-read-gh-issue-list`](../../../../read/gh/issue-list/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Run after `@gh-issue-list` when you already have filtered candidate issues.
+2. Use `@gh-issue-view` first when issue details must be expanded before selection.
+3. List/pick normative fences: **`internal-read-gh-issue-list`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-issue-list`
+2. `internal-write-plan-structured-qa`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. After selection, route details to `@gh-issue-view` for richer context.
+2. Then move to `@git-start` when implementation should begin on a branch.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES_PICK=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+1. **Goal** — One line: what “next” means (e.g. highest priority **`bug`**, unblocked **`help wanted`**, etc.).
+2. **Inventory (read-only)** — Run **List / search** blocks from **[`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md)** with user-supplied **`--label`**, **`--assignee`**, **`--milestone`**, or search text. Cap **`--limit`** (e.g. **30**).
+3. **Present candidates** — Short table: **#n — title — labels** for the top set.
+4. **AskQuestion** — **Short labels** for **top N** issues plus **`Refine filters`** / **`Cancel`**. This step is **choice UX** only—**no** GitHub mutations here.
+5. **After selection** — If the user picked an issue: run **`@gh-issue-view`** on that **#n**; suggest **`@git-start`** with the **title** when branching. If **Refine filters**, return to step **2** with updated filters.
+
+## Do not
+
+- Create, edit, close, or delete issues from this skill.
+
+## See also
+
+- [`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md)
+- [`@gh-issue-list`](../list/SKILL.md)
+- [`@gh-issue-view`](../view/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/gh-issues/review/SKILL.md
+++ b/.agents/skills/gh-issues/review/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: gh-issues-review
+description: >-
+  GitHub issues (`gh issue view` / `gh issue list`): read-only — discover repo context, view target issue(s), list/search open issues for overlaps, compare like dedupe
+  but for reshape; propose clearer title/body and AskQuestion on gaps. No GitHub writes—@gh-issues applies changes after
+  confirm. Complements @git-review (code health) with issue clarity.
+---
+
+**Report shape:** [`REVIEW_REPORT.md`](../../../read/gh/issue-description/review-report/SKILL.md).
+
+# GitHub: review / reshape issues (read-only)
+
+Normative fences / full matrix: [`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md), [`internal-read-gh-issue-list`](../../../../read/gh/issue-list/SKILL.md).
+
+
+**Public.** **Goal:** After a **quick** issue (e.g. from phone), **understand the codebase**, the **issue as written**, and **other open issues**—then produce an **overlap map**, **gap list**, and an **optional draft** title/body the user can apply with **`@gh-issues`**. Same spirit as **`@git-review`** (health pass) but for **issue quality and de-duplication**, **without** running format/lint/tests unless the user explicitly asks for full **`@git-review`**.
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-issue-view` first to lock scope on the target issue body/comments.
+2. Use `@gh-issue-list` to capture nearby overlap context before reshape suggestions.
+3. View/list command shapes: **`internal-read-gh-issue-list`** and **`internal-write-gh-issue-commands`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-discover-dependencies`
+2. `internal-write-gh-issue-commands`
+3. `internal-read-gh-issue-dedupe`
+4. `internal-read-gh-issue-spec`
+5. `internal-write-plan-structured-qa`
+6. `internal-read-gh-issue-list`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Route accepted wording changes to `@gh-issues` for create/edit mutation.
+2. Use `@git-review` separately when code-health validation is also required.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES_REVIEW=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+1. **Repo context (read-only)** — Run **[`internal-read-git-discover-dependencies`](../../../read/git/discover-dependencies/SKILL.md)** **in full** so the review can tie the issue to **real paths**, stacks, and CI/README signals. **Do not** run **`internal-write-gh-install-dependencies`**, **`internal-read-git-configuration`**, **`internal-write-gh-evaluate`**, or the rest of **`@git-review`** unless the user asks—this skill stays **issue-centric**.
+2. **Target issue(s)** — Execute **View** in **[`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)**. Accept **`#N`**, URL, or a number from **`@gh-issue-pick`**. Pull **title**, **body**, **labels**, **assignees**, **state**, **URL**; add **`comments`** to the JSON set when the thread matters for scope.
+3. **Peer inventory** — **List / search** in **`internal-read-gh-issue-list`** and **[`DEDUPE_CHECKLIST.md`](../../../read/gh/issue-dedupe/dedupe-checklist/SKILL.md)**. Cast a **wide enough net** (keywords from title/body, relevant labels, **`--limit`** / search query). **Read-only.**
+4. **Overlap / duplicate check** — Compare the target to peers (titles + body leads). Optionally run **[`internal-read-gh-issue-dedupe`](../../../read/gh/issue-dedupe/SKILL.md)** using a **candidate** string equal to the **intended reshaped** title + body summary (or the **current** text when you are only cleaning wording). When the target is **`#N`**, **ignore self-match** on **`#N`**—treat other hits as **peer overlaps** (see **`internal-read-gh-issue-dedupe`** **reshape-review** note).
+5. **Synthesis** — Map issue asks to **files / areas** surfaced in discovery; flag **underspecified** work (missing acceptance checks, unclear user impact, missing error handling, version assumptions). Score gaps against **[`internal-read-gh-issue-spec`](../../../read/gh/issue-spec/SKILL.md)** when the issue should be implementation-ready.
+6. **Prompt when unclear** — Use **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** (**§1a** summary, **§2** short labels) for **priority**, **scope split vs absorb**, **duplicate resolution**, or **product intent** before locking a draft.
+7. **Report** — Follow **[`REVIEW_REPORT.md`](../../../read/gh/issue-description/review-report/SKILL.md)** section order: **target snapshot**, **codebase fit**, **peer overlaps**, **gaps** (including issue-spec checklist), **proposed reshape** (optional).
+8. **Hand-off** — **`@gh-issues`** applies the create-or-edit path in **`internal-write-gh-issue-commands`** after **`internal-read-gh-issue-description`** + user **Proceed**.
+
+## Do not
+
+- **Issue create, edit, comment, close, or delete** mutations inside this skill.
+- Pretend overlap analysis is done without **listing** open issues at least once (unless the repo truly has **zero** other open issues).
+- Skip **`internal-write-plan-structured-qa`** when the user’s goal is **ambiguous** and you would otherwise guess scope.
+
+## On invoke
+
+**`@gh-issue-review`** — **Fixed order:** **discover-dependencies** → **view target** → **list/search peers** → **overlap + gap synthesis** → **structured questions if needed** → **written report** (pasteable template). **Stop** on missing **GitHub CLI** auth or unknown repo context—tell the user to authenticate the CLI or set **`--repo`** per **`internal-read-gh-issue-list`** / **`internal-write-gh-issue-commands`** / **`internal-read-gh-repo-stream`**.
+
+**Typical use:** “I filed **`#42`** on mobile—tighten it and see if we already track this elsewhere.”
+
+## See also
+
+- [`@gh-issue-view`](../view/SKILL.md) · [`@gh-issue-list`](../list/SKILL.md) · [`@gh-issue-pick`](../pick/SKILL.md)
+- [`@gh-issues`](../SKILL.md)
+- [`@git-review`](../../../git/review/SKILL.md) — workspace **code** health (separate concern)
+- [`internal-read-gh-issue-spec`](../../../read/gh/issue-spec/SKILL.md)
+- [`internal-read-gh-issue-dedupe`](../../../read/gh/issue-dedupe/SKILL.md) · [`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md) · [`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)

--- a/.agents/skills/gh-issues/view/SKILL.md
+++ b/.agents/skills/gh-issues/view/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: gh-issues-view
+description: >-
+  GitHub issues (`gh issue view`): read-only single issue: URL, #n, or id; rich JSON and optional comments for planning. Hand off to @git-start
+  for branch naming. Command shapes: internal-write-gh-issue-commands. No mutation.
+---
+
+# GitHub: view issue
+
+Normative fences / full matrix: [`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-issue-list` first when the target issue is not known yet.
+2. Use this skill directly when the user references one issue URL/number/id.
+3. View JSON fences: **`internal-write-gh-issue-commands`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-write-gh-issue-commands`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@gh-issue-review` when the viewed issue needs reshaping.
+2. Use `@git-start` when issue context is ready to drive implementation.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_ISSUES_VIEW=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Resolve the issue reference from **chat**: full **`https://github.com/owner/repo/issues/N`**, **`#N`**, or numeric **`N`** (default repo context unless user names **`owner/repo`**).
+- Open **[`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)** and execute the **View** section **fenced blocks** for that reference; include **`comments`** in the **`--json`** field list when the user needs the thread for review or planning.
+- Reply in chat with a **stable outline**: **title**, **state**, **labels**, **assignees**, **URL**, short **body** summary, optional **comment** highlights.
+- When the user will branch next, paste **title** (one line) for **`@git-start`** branch naming.
+
+## Do not
+
+- Edit/create, close, or delete via **`@gh-issues`**, **`@gh-issue-close`**, or **`@gh-issue-delete-closed`** (bulk) as appropriate.
+
+## See also
+
+- [`@gh-issue-review`](../review/SKILL.md) — deep read + peer compare before **`@gh-issues`**
+- [`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)
+- [`@git-start`](../../../git/start/SKILL.md)
+- [`WORK_PLAN.md`](../../../read/gh/issue-description/work-plan/SKILL.md) — local plan scaffold that embeds an issue

--- a/.agents/skills/gh-pr-close/SKILL.md
+++ b/.agents/skills/gh-pr-close/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: gh-pr-close
+description: >-
+  Pull requests (`gh pr close`): Goal + AskQuestion before PR close mutation. Mutates GitHub. Does not merge; use only when the user explicitly wants the pull request closed.
+---
+
+# GitHub: close pull request
+
+Normative fences / full matrix: [`internal-write-gh-pr-commands`](../../../../write/gh/pr-commands/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-pr-view` first to confirm target PR state and closure rationale.
+2. Use `@gh-pr-list` first when the user only gives broad PR filters.
+3. Close/view command shapes: **`internal-write-gh-pr-commands`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-write-gh-pr-commands`
+2. `internal-write-plan-structured-qa`
+3. `internal-write-plan-skill-safety`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Return to `@gh-pr` when the user wants to reopen through a new PR workflow.
+2. Use `@gh-pr-list` to verify closure inventory after mutation.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_PR_CLOSE=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- **Goal** + **AskQuestion** + **Proceed** before **Close PR** in **[`internal-write-gh-pr-commands`](../../../write/gh/pr-commands/SKILL.md)** ([`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md) **§3a**, [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)).
+- Confirm **PR number**, **repo** (`--repo` when upstream), and that closing matches user intent (superseded branch, wrong target, duplicate PR).
+- Prefer **`@gh-pr-list`** / **`@gh-pr-view`** first when the PR number is unknown.
+
+## Do not
+
+- Close when the user meant to **merge**, **draft**, or **update** title/body—redirect to **`@gh-pr`** or the web UI.
+
+## See also
+
+- [`@gh-pr`](../SKILL.md)

--- a/.agents/skills/gh-pr-list/SKILL.md
+++ b/.agents/skills/gh-pr-list/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: gh-pr-list
+description: >-
+  Pull requests (`gh pr list`): read-only pull request list for inventory; no AskQuestion by default. Shapes in internal-read-gh-pr-list; narrative hub in list-view-hub/SKILL.md.
+---
+
+# GitHub: list pull requests
+
+Normative fences / full matrix: [`internal-read-gh-pr-list`](../../../../read/gh/pr-list/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-pr-view` when one pull request needs richer detail before further action.
+2. Use this skill directly for read-only PR inventory requests.
+3. List/view normative fences: **`internal-read-gh-pr-list`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-pr-list`
+2. `internal-write-plan-skill-safety`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Hand off to `@gh-pr` when listing should become create/edit execution.
+2. Use `@gh-pr-close` only after explicit close intent is confirmed.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_PR_LIST=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Execute **List** (and related inventory) from **[`internal-read-gh-pr-list`](../../../read/gh/pr-list/SKILL.md)** — run **only** the fenced blocks defined there.
+- **Refine queries** per user intent: add **`--state`** (e.g. **`closed`** for merged+closed), **`--head`**, **`--base`**, **`--limit`**, **`--json`**, **`--repo`**, as in that internal library’s **Caller refinement** section. Optional context: **[`LIST_VIEW_HUB.md`](../../../read/gh/pr-list/list-view-hub/SKILL.md)** (hub, no duplicate fences).
+- Report results in chat; **no** default confirmation for read-only listing. **Structured confirm** is required before any **`gh pr`** / **`gh api`** **mutation** (**`@gh-pr-close`**, **`@gh-pr`**) per **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)**.
+
+## Do not
+
+- Create, edit, merge, or close PRs in this skill.
+
+## See also
+
+- [`@gh-pr-view`](../view/SKILL.md)
+- [`@gh-pr`](../SKILL.md)

--- a/.agents/skills/gh-pr-skills/SKILL.md
+++ b/.agents/skills/gh-pr-skills/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: gh-pr-skills
+description: >-
+  Pull requests (`gh pr` bodies in skill repos): skill-pack PR model: when @gh-pr-list/@gh-pr-view vs full @gh-pr; PR body should highlight skills/** paths and link
+  issues. Read-oriented hand-off skill; create/update stays @gh-pr after @git-pull + @git-review + @git-push.
+---
+
+# Skill-pack: pull requests from Cursor
+
+Normative fences / full matrix: [`internal-read-gh-pr-description`](../../../../read/gh/pr-description/SKILL.md), [`internal-write-gh-pr-commands`](../../../../write/gh/pr-commands/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-pr-list` or `@gh-pr-view` first when PR inventory or one-PR detail should precede the skill-pack narrative.
+2. PR title/body/delta internals for shipping live in **`internal-read-gh-pr-description`** and **`internal-write-gh-pr-commands`** (names only; **`@gh-pr`** owns mutations).
+
+Use this as the **mental model** when most changes live under **`skills/**`** and the **`docs/`** wikis (diagram scaffolds: **`skills/read/git/doc-graphs/diagrams/`** when relevant).
+
+## When to use what
+
+| Need | Skill |
+| --- | --- |
+| See open PRs for a branch | **`@gh-pr-list`** |
+| Inspect one PR (title, body, base, diff stat) | **`@gh-pr-view`** |
+| **Create** or **replace** PR title/body after branch is green and **pushed** | **`@gh-pr`** (**`@git-pull`** → **`@git-review`** → **`@git-push`** → **`internal-read-gh-pr-description`** → PR create/edit mutation) |
+| Close a PR the user explicitly wants gone | **`@gh-pr-close`** |
+
+**Do not** open or replace PRs on GitHub outside **`@gh-pr`**—that skill owns the sync + verify + publish prelude and **`$BASE_GIT`** narrative.
+
+## PR body expectations (skill repos)
+
+- Call out **paths under `skills/`** (especially **`SKILL.md`** files) and **what behavior changed**.
+- Link **GitHub issues** filed with **`@gh-issues`** (or paste **`Fixes #n`** / **`Refs #n`** in the body when appropriate).
+- Reuse **[`PR_ORCHESTRATION.md`](../../../read/gh/pr-content/pr-orchestration/SKILL.md)**, **[`BODY_SKELETON.md`](../../../read/gh/pr-content/pr-body-skeleton/SKILL.md)**, **[`internal-read-gh-pr-content`](../../../read/gh/pr-content/SKILL.md)**.
+
+## Linked issue workflow
+
+- Track work with **`@gh-issue-list`** / **`@gh-issue-view`**, narrow scope, then **`@gh-issues`** when filing.
+- Publish branch + PR with **`@gh-pr`** so the PR description matches **`$BASE_GIT..HEAD`**.
+
+## See also
+
+- [`@gh-pr`](../SKILL.md)
+- [`@gh-pr-list`](../list/SKILL.md) · [`@gh-pr-view`](../view/SKILL.md) · [`@gh-pr-close`](../close/SKILL.md)
+- [`@gh-issues`](../../../gh/issues/SKILL.md)
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use after `@gh-pr-list` or `@gh-pr-view` to ground the PR narrative in real context.
+2. Run `@git-push` first when branch evidence may be stale.
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-pr-content`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Route final PR create/edit to `@gh-pr` after the narrative is ready.
+2. Use `@gh-issues` when PR outcomes need linked issue updates.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_PR_SKILLS=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.

--- a/.agents/skills/gh-pr-view/SKILL.md
+++ b/.agents/skills/gh-pr-view/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: gh-pr-view
+description: >-
+  Pull requests (`gh pr view`, `gh pr diff --stat`): read-only pull request view / optional diff stat for one PR; no AskQuestion by default. Shapes in internal-read-gh-pr-list.
+---
+
+# GitHub: view pull request
+
+Normative fences / full matrix: [`internal-read-gh-pr-list`](../../../../read/gh/pr-list/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-pr-list` first when the target PR is not yet identified.
+2. Use this skill directly when the user references one PR URL/number.
+3. View/diff-stat fences: **`internal-read-gh-pr-list`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-pr-list`
+2. `internal-read-gh-repo-stream`
+3. `internal-write-plan-skill-safety`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@gh-pr` when viewed context should become PR create/edit work.
+2. Use `@gh-pr-close` only when explicit close intent follows the review.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_PR_VIEW=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Execute **View** (and optional diff-stat) from **[`internal-read-gh-pr-list`](../../../read/gh/pr-list/SKILL.md)** — run **only** the fenced blocks defined there.
+- When **`--repo`** is required (fork **`$UPSTREAM`**), align with **[`internal-read-gh-repo-stream`](../../../read/gh/repo-stream/SKILL.md)**.
+- **Structured confirm** before any follow-on **mutation** (**`@gh-pr-close`**, **`@gh-pr`**, …) per **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)**.
+
+## Do not
+
+- Mutate GitHub state from this skill.
+
+## See also
+
+- [`@gh-pr-list`](../list/SKILL.md)
+- [`@gh-pr`](../SKILL.md)

--- a/.agents/skills/gh-pr/SKILL.md
+++ b/.agents/skills/gh-pr/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: gh-pr
+description: >-
+  Pull requests (`gh pr` create/edit on GitHub). Order: full @git-pull → full @git-review → full @git-push → PR lookup +
+  user intent gate → internal-read-gh-pr-description (§5–7: templates, delta, API-first linking + issue scan, title/body)
+  → §9 confirmed PR create/edit and optional gh project item-add. Uses internal-read-gh-repo-stream;
+  internal-write-plan-structured-qa before GitHub mutations. Does NOT merge PR on GitHub.
+---
+
+**Orchestration:** [`PR_ORCHESTRATION.md`](../../read/gh/pr-content/pr-orchestration/SKILL.md).
+
+# PR
+
+Normative fences / full matrix: [`internal-read-gh-pr-description`](../../read/gh/pr-description/SKILL.md), [`internal-write-gh-pr-commands`](../../write/gh/pr-commands/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Run **`@git-pull`** to refresh branch/base context before drafting PR intent.
+2. Run **`@git-review`** so the workspace is green before publish and PR text.
+3. Run **`@git-push`** so local commits reach the remote before PR drafting.
+4. PR description + command shapes: **`internal-read-gh-pr-description`** and **`internal-write-gh-pr-commands`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-pr-preflight-qa`
+2. `internal-read-gh-pr-list`
+3. `internal-read-gh-pr-description`
+4. `internal-read-gh-pr-content`
+5. `internal-read-git-git-diff-summary`
+6. `internal-read-gh-repo-stream`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@gh-pr-view` to validate created/updated PR state and metadata.
+2. Use `@gh-pr-close` only when the user explicitly requests closure.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_PR=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Run PR pre-flight requirement gathering using **[`internal-read-gh-pr-preflight-qa`](../../read/gh/pr-preflight-qa/SKILL.md)** before PR lookup/mutation.
+- Run **full** **[`@git-pull`](../../git/pull/SKILL.md)** first; it owns sync/conflict mechanics and does not publish.
+- Run **full** **[`@git-review`](../../git/review/SKILL.md)** next; it owns install, evaluate (format/lint/test), and §8a docs polish—**no** commit or push.
+- Run **full** **[`@git-push`](../../git/push/SKILL.md)** next; it owns commit-if-needed, branch gate, and publish (plus push-failure recovery).
+- Resolve open-PR inventory and existing-PR house style using **[`internal-read-gh-pr-list`](../../read/gh/pr-list/SKILL.md)** and **[`LIST_VIEW_HUB.md`](../../read/gh/pr-list/list-view-hub/SKILL.md)** (hub only), then run structured user intent selection before setting **`PR_NUM`**.
+- Run **[`internal-read-gh-pr-description`](../../read/gh/pr-description/SKILL.md)** **in full** (**§5–§7** there: templates, §6 delta, **§6.5–6.6** API-first linking ladder + issue hint scan, **§7** title/body + triple pass). **Shape:** **[`internal-read-gh-pr-content`](../../read/gh/pr-content/SKILL.md)** (**[`TITLE_LINE.md`](../../read/gh/pr-content/title-line/SKILL.md)**, **[`BODY_SKELETON.md`](../../read/gh/pr-content/pr-body-skeleton/SKILL.md)**); **diff clustering:** **[`internal-read-git-git-diff-summary`](../../read/git/git-diff-summary/SKILL.md)** + **[`diff-summary.md`](../../read/git/git-diff-summary/delta-narrative/SKILL.md)**.
+- Apply one confirmed PR create/edit action per safety + structured-qa.
+- Set destination, target repo, and head fields per **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)**. Draft body from the full branch delta produced by **internal-read-gh-pr-description**.
+
+## Do not
+
+- Create or edit a PR before **`@git-pull`** + **`@git-review`** + **`@git-push`** succeed.
+- Inline verification commands instead of the ordered **`@git-review`** step (full skill).
+- Merge the PR on GitHub from this skill—title/body only.
+- **`@gh-pr`** when **`BRANCH`** is **`main`** on same-repo with no fork—sync only; **stop** (no PR).
+- Run PR mutations inside **internal-read-gh-pr-description** — only this public skill applies the final confirmed action.
+
+**Chain (fixed order):**
+
+1. **[`@git-pull`](../../git/pull/SKILL.md)** — complete sync/conflict pass; no publish.
+2. **[`@git-review`](../../git/review/SKILL.md)** — full workspace verify (evaluate + §8a); no commit or push.
+3. **[`@git-push`](../../git/push/SKILL.md)** — inventory, **`@git-commit`** when needed, branch gate, **`git push`**.
+4. **This skill continues** — PR lookup, draft title/body through internals, then one confirmed create/edit.
+
+**Destination and PR targets:** See **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)** for destination, target repo, base branch, and PR head rules.
+
+## On invoke
+
+*`@gh-pr`* — **Order is fixed:** **`@git-pull`** → **`@git-review`** → **`@git-push`** → list matching open PRs via internals → **AskQuestion intent gate** (summary in prompt text: **Abort** / **Proceed** / one refine outlet) → resolve **`PR_NUM`** → **[`internal-read-gh-pr-description`](../../read/gh/pr-description/SKILL.md)** (templates → §6 delta → **§6.5–6.6** linking ladder + issue hint scan → **§7** title/body + triple pass) → **§9** final confirmed apply (PR create/edit summary must include **linking ladder**: candidate issues, **project `item-add`** vs **minimal keyword line** vs **UI-only**, and **`project` number/owner** when applicable) → optional same-batch **`gh project item-add`** per **`internal-write-gh-pr-commands`** when **§9** confirmed. **Never** create a PR to discover duplicates. Editing overwrites title/body with fresh content; when **`PR_NUM`** is set, treat the current PR body as a house-style hint only (see **[Existing PR as template](../../read/gh/pr-description/SKILL.md#existing-pr-as-template)**).
+
+**Diff scope:** The PR narrative must reflect **everything** different between **destination** and **current `HEAD`** (merge-aware file list), **not** a subset tied to the “last PR update.”
+
+**After sync/publish:** Draft title/body **only after** **`@git-push`** so local **`HEAD`** matches the remote when a push ran. Delta mechanics belong to **[`internal-read-git-git-diff-summary`](../../read/git/git-diff-summary/SKILL.md)**.
+
+**If the diff looks wrong:** re-review fork vs same-repo classification in **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)**. Re-run **full** **`@git-pull`**, **`@git-review`**, and **`@git-push`**, then continue from PR lookup.
+
+**“Since last commit on destination”:** use the full **`HEAD`** delta after the destination tip; **internal-read-git-git-diff-summary** owns the exact ranges.
+
+## Workflow
+
+### 0. Classify fork vs same-repo and set variables
+
+*`@gh-pr`* — Apply **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)** before PR lookup and drafting. Do **not** re-derive fork/upstream rules inline—keep them consistent with **`@git-main`** / **`@git-pull`** via that library.
+
+If fork intent is clear but the upstream remote is missing, run triage per **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)** **§8**: **Abort**, **Reclassify intent as same-repo and continue with that target**, or **Pause and configure `upstream`, then retry `@gh-pr`**.
+
+### 1. Branch and head ref
+
+*`@gh-pr`* — Use **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)** for branch/head classification. Same-repo **`main`** syncs only and stops after pull/review/push legs; feature branches and fork branches continue to PR lookup/drafting with the head values from that library.
+
+### 1.5 Pre-flight requirements (required)
+
+*`@gh-pr`* — Run **[`internal-read-gh-pr-preflight-qa`](../../read/gh/pr-preflight-qa/SKILL.md)** to confirm source/target branch intent, overlap handling preference (edit existing vs create new), and readiness expectations before any create/edit path.
+
+### 2. Hand off to **`@git-pull`** (required)
+
+> Run the full Cursor skill **[`@git-pull`](../../git/pull/SKILL.md)** end-to-end. It owns fetch/merge/conflict details through **[`internal-read-git-merge-conflicts`](../../read/git/merge-conflicts/SKILL.md)**.
+> If **`@git-pull`** errors, the user aborts, or conflicts stay unresolved → **stop** **`@gh-pr`** here.
+
+### 3. Hand off to **`@git-review`** (required)
+
+> Run the full Cursor skill **[`@git-review`](../../git/review/SKILL.md)** end-to-end. It owns discovery, install, evaluate, and §8a documentation polish—**not** staging, commit, or push.
+> If **`@git-review`** fails, the user aborts, or the tree is not green → **stop** **`@gh-pr`** here (do not **`@git-push`** broken work).
+
+### 4. Hand off to **`@git-push`** (required; owns push recovery)
+
+> Run the full Cursor skill **[`@git-push`](../../git/push/SKILL.md)** end-to-end. It owns working-tree inventory, optional **`@git-commit`**, branch gate, publish confirmation, and **`git push`** behavior.
+> **`@git-push`** owns branch gate + push-failure recovery. If it exits without a successful publish (Abort or unrecoverable error), **stop** **`@gh-pr`** here. If publish succeeds after recovery on a new branch, continue and use the updated branch/head values from **`internal-read-gh-repo-stream`**.
+
+### 5. Resolve existing open PR (before create or before drafting)
+
+*`@gh-pr`* — **Run immediately after §5**, **before** **[`internal-read-gh-pr-description`](../../read/gh/pr-description/SKILL.md)** and before body drafting. Use only **[`internal-read-gh-pr-list`](../../read/gh/pr-list/SKILL.md)** command fences + head/base/repo fields from **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)** to list matching open PRs.
+
+**If zero matches** — keep **`PR_NUM`** empty and continue to **§6–8** for a create path.
+
+**If one or more matches** — **do not** assume **`PR_NUM`**. Run **AskQuestion** with the compact inventory summary embedded in the prompt text (at minimum: count, `#n` + title lines, head→base, target repo). Keep options short and safe-first:
+
+- **Abort** — stop `@gh-pr`; no drafting and no mutation.
+- **Proceed** — choose edit/create intent. For one match, label directly (for example, **Proceed — edit #n** / **Proceed — create new**). For multiple matches, either include one **Proceed — edit #n** option per PR (within sane count) or run one additional narrow AskQuestion to pick the PR.
+- **Refine** — one outlet only per **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)** §5 (prefer `additionalSuggestion` *or* one trailing chat line, not both).
+
+If user selects edit, set **`PR_NUM`** to the selected PR. If user selects create, leave **`PR_NUM`** empty. Mention in the summary that GitHub may reject a duplicate open PR for the same head→base.
+
+### 6–8. Templates, delta, linking ladder + issue scan, title, body, triple pass
+
+*`@gh-pr`* — Read and execute **[`internal-read-gh-pr-description`](../../read/gh/pr-description/SKILL.md)** **in full** (§§5–7, including **§6.5–6.6** and **triple pass**), including **Material template reshape** when a **single** repo template would otherwise be altered by **[merge rules](../../read/gh/pr-description/SKILL.md#merge-rules-all-sources)** without an explicit user pick. Produce finalized **`--title`** and **`--body`** (or body file) for **§9** below.
+
+### 9. Apply — `edit` or `create` (one), optional project attach
+
+*`@gh-pr`* — **After** the triple pass in **internal-read-gh-pr-description**, **before** any PR mutation: run **AskQuestion** where the prompt text itself contains the pending mutation summary (goal, create vs edit, repo, head/base, title line, that body will be replaced, **candidate issues from §6.6 with evidence**, and the chosen **linking ladder**: **project** **`item-add`** (project number + owner) vs **minimal `Refs`/`Fixes`/`Closes` line in body** vs **UI-only** for Development links). Use **Abort** first, **Proceed** to execute exactly as summarized, and one refinement outlet per **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)** §5. This final confirm remains required by **[`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md)** PR mutation rows. Apply exactly one **`gh pr create`/`edit`** only after **Proceed**. When **§9** confirmed **project attach**, run **`gh project item-add`** for the PR URL and each issue URL in the **same Proceed batch** per **[`internal-write-gh-pr-commands`](../../write/gh/pr-commands/SKILL.md)**. Optionally run **`gh pr view --json closingIssuesReferences`** there to verify keyword-based inference.
+
+---
+
+## Notes
+
+*`@gh-pr`*
+- **Prerequisites:** authenticated GitHub CLI and repo root.
+- **Fork:** `upstream` remote required.
+- **Order:** **`@git-pull`** → **`@git-review`** → **`@git-push`** → PR lookup/style → **[`internal-read-gh-pr-description`](../../read/gh/pr-description/SKILL.md)** → confirmed apply.
+- **Push recovery ownership:** branch gating and push-failure triage live in **`@git-push`**. Do not duplicate those prompts in **`@gh-pr`**.
+- **Decision points:** if open PR matches exist, prompt for intent in **§5** before drafting; always run final mutation confirm in **§9** before `gh pr create` / `gh pr edit`.
+- **PR body:** PR lookup resolves **`PR_NUM`**; **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)** supplies target repo and destination. **Multiple** templates → **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)** (no auto-pick). **TL;DR** first, **nested** “what changed,” **list** tradeoffs—**no** **commit counts**, **review route**, or compare-metadata in the posted body. **Issue traceability:** follow **[`internal-read-gh-pr-description`](../../read/gh/pr-description/SKILL.md)** §6.5–7—**no** default “Linked issues” prose section; optional **minimal keyword line** or **`gh project item-add`** only after **§9** user choice (see **`internal-write-gh-pr-commands`**).
+
+## See also
+
+- **[`@gh-pr-skills`](skills/SKILL.md)** — skill-pack PR narrative and when to use list/view vs **`@gh-pr`**.
+- **[`@gh-pr-list`](list/SKILL.md)** · **[`@gh-pr-view`](view/SKILL.md)** — read-only PR list/view (**[`internal-read-gh-pr-list`](../../read/gh/pr-list/SKILL.md)**; hub **[`LIST_VIEW_HUB.md`](../../read/gh/pr-list/list-view-hub/SKILL.md)**).
+- **[`@gh-pr-close`](close/SKILL.md)** — close PRs with structured confirm.
+- **[`internal-read-gh-pr-preflight-qa`](../../read/gh/pr-preflight-qa/SKILL.md)** — pre-flight question bank for branch/overlap ambiguity.
+
+### Hand off (outside **`@gh-pr`**)
+
+> To **only** sync with **`main`** without opening/updating a PR, run **`@git-pull`** then **`@git-push`** alone. **`@gh-pr`** is for when you also want the **GitHub PR** updated from the **full** branch vs **destination** diff.
+
+- For complex PR writing, stage temporary draft fragments under `.cursor/gh/pr/` before final create/edit confirmation.

--- a/.agents/skills/gh-pr/close/SKILL.md
+++ b/.agents/skills/gh-pr/close/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: gh-pr-close
+description: >-
+  Pull requests (`gh pr close`): Goal + AskQuestion before PR close mutation. Mutates GitHub. Does not merge; use only when the user explicitly wants the pull request closed.
+---
+
+# GitHub: close pull request
+
+Normative fences / full matrix: [`internal-write-gh-pr-commands`](../../../../write/gh/pr-commands/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-pr-view` first to confirm target PR state and closure rationale.
+2. Use `@gh-pr-list` first when the user only gives broad PR filters.
+3. Close/view command shapes: **`internal-write-gh-pr-commands`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-write-gh-pr-commands`
+2. `internal-write-plan-structured-qa`
+3. `internal-write-plan-skill-safety`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Return to `@gh-pr` when the user wants to reopen through a new PR workflow.
+2. Use `@gh-pr-list` to verify closure inventory after mutation.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_PR_CLOSE=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- **Goal** + **AskQuestion** + **Proceed** before **Close PR** in **[`internal-write-gh-pr-commands`](../../../write/gh/pr-commands/SKILL.md)** ([`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md) **§3a**, [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)).
+- Confirm **PR number**, **repo** (`--repo` when upstream), and that closing matches user intent (superseded branch, wrong target, duplicate PR).
+- Prefer **`@gh-pr-list`** / **`@gh-pr-view`** first when the PR number is unknown.
+
+## Do not
+
+- Close when the user meant to **merge**, **draft**, or **update** title/body—redirect to **`@gh-pr`** or the web UI.
+
+## See also
+
+- [`@gh-pr`](../SKILL.md)

--- a/.agents/skills/gh-pr/list/SKILL.md
+++ b/.agents/skills/gh-pr/list/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: gh-pr-list
+description: >-
+  Pull requests (`gh pr list`): read-only pull request list for inventory; no AskQuestion by default. Shapes in internal-read-gh-pr-list; narrative hub in list-view-hub/SKILL.md.
+---
+
+# GitHub: list pull requests
+
+Normative fences / full matrix: [`internal-read-gh-pr-list`](../../../../read/gh/pr-list/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-pr-view` when one pull request needs richer detail before further action.
+2. Use this skill directly for read-only PR inventory requests.
+3. List/view normative fences: **`internal-read-gh-pr-list`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-pr-list`
+2. `internal-write-plan-skill-safety`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Hand off to `@gh-pr` when listing should become create/edit execution.
+2. Use `@gh-pr-close` only after explicit close intent is confirmed.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_PR_LIST=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Execute **List** (and related inventory) from **[`internal-read-gh-pr-list`](../../../read/gh/pr-list/SKILL.md)** — run **only** the fenced blocks defined there.
+- **Refine queries** per user intent: add **`--state`** (e.g. **`closed`** for merged+closed), **`--head`**, **`--base`**, **`--limit`**, **`--json`**, **`--repo`**, as in that internal library’s **Caller refinement** section. Optional context: **[`LIST_VIEW_HUB.md`](../../../read/gh/pr-list/list-view-hub/SKILL.md)** (hub, no duplicate fences).
+- Report results in chat; **no** default confirmation for read-only listing. **Structured confirm** is required before any **`gh pr`** / **`gh api`** **mutation** (**`@gh-pr-close`**, **`@gh-pr`**) per **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)**.
+
+## Do not
+
+- Create, edit, merge, or close PRs in this skill.
+
+## See also
+
+- [`@gh-pr-view`](../view/SKILL.md)
+- [`@gh-pr`](../SKILL.md)

--- a/.agents/skills/gh-pr/skills/SKILL.md
+++ b/.agents/skills/gh-pr/skills/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: gh-pr-skills
+description: >-
+  Pull requests (`gh pr` bodies in skill repos): skill-pack PR model: when @gh-pr-list/@gh-pr-view vs full @gh-pr; PR body should highlight skills/** paths and link
+  issues. Read-oriented hand-off skill; create/update stays @gh-pr after @git-pull + @git-review + @git-push.
+---
+
+# Skill-pack: pull requests from Cursor
+
+Normative fences / full matrix: [`internal-read-gh-pr-description`](../../../../read/gh/pr-description/SKILL.md), [`internal-write-gh-pr-commands`](../../../../write/gh/pr-commands/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-pr-list` or `@gh-pr-view` first when PR inventory or one-PR detail should precede the skill-pack narrative.
+2. PR title/body/delta internals for shipping live in **`internal-read-gh-pr-description`** and **`internal-write-gh-pr-commands`** (names only; **`@gh-pr`** owns mutations).
+
+Use this as the **mental model** when most changes live under **`skills/**`** and the **`docs/`** wikis (diagram scaffolds: **`skills/read/git/doc-graphs/diagrams/`** when relevant).
+
+## When to use what
+
+| Need | Skill |
+| --- | --- |
+| See open PRs for a branch | **`@gh-pr-list`** |
+| Inspect one PR (title, body, base, diff stat) | **`@gh-pr-view`** |
+| **Create** or **replace** PR title/body after branch is green and **pushed** | **`@gh-pr`** (**`@git-pull`** → **`@git-review`** → **`@git-push`** → **`internal-read-gh-pr-description`** → PR create/edit mutation) |
+| Close a PR the user explicitly wants gone | **`@gh-pr-close`** |
+
+**Do not** open or replace PRs on GitHub outside **`@gh-pr`**—that skill owns the sync + verify + publish prelude and **`$BASE_GIT`** narrative.
+
+## PR body expectations (skill repos)
+
+- Call out **paths under `skills/`** (especially **`SKILL.md`** files) and **what behavior changed**.
+- Link **GitHub issues** filed with **`@gh-issues`** (or paste **`Fixes #n`** / **`Refs #n`** in the body when appropriate).
+- Reuse **[`PR_ORCHESTRATION.md`](../../../read/gh/pr-content/pr-orchestration/SKILL.md)**, **[`BODY_SKELETON.md`](../../../read/gh/pr-content/pr-body-skeleton/SKILL.md)**, **[`internal-read-gh-pr-content`](../../../read/gh/pr-content/SKILL.md)**.
+
+## Linked issue workflow
+
+- Track work with **`@gh-issue-list`** / **`@gh-issue-view`**, narrow scope, then **`@gh-issues`** when filing.
+- Publish branch + PR with **`@gh-pr`** so the PR description matches **`$BASE_GIT..HEAD`**.
+
+## See also
+
+- [`@gh-pr`](../SKILL.md)
+- [`@gh-pr-list`](../list/SKILL.md) · [`@gh-pr-view`](../view/SKILL.md) · [`@gh-pr-close`](../close/SKILL.md)
+- [`@gh-issues`](../../../gh/issues/SKILL.md)
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use after `@gh-pr-list` or `@gh-pr-view` to ground the PR narrative in real context.
+2. Run `@git-push` first when branch evidence may be stale.
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-pr-content`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Route final PR create/edit to `@gh-pr` after the narrative is ready.
+2. Use `@gh-issues` when PR outcomes need linked issue updates.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_PR_SKILLS=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.

--- a/.agents/skills/gh-pr/view/SKILL.md
+++ b/.agents/skills/gh-pr/view/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: gh-pr-view
+description: >-
+  Pull requests (`gh pr view`, `gh pr diff --stat`): read-only pull request view / optional diff stat for one PR; no AskQuestion by default. Shapes in internal-read-gh-pr-list.
+---
+
+# GitHub: view pull request
+
+Normative fences / full matrix: [`internal-read-gh-pr-list`](../../../../read/gh/pr-list/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-pr-list` first when the target PR is not yet identified.
+2. Use this skill directly when the user references one PR URL/number.
+3. View/diff-stat fences: **`internal-read-gh-pr-list`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-pr-list`
+2. `internal-read-gh-repo-stream`
+3. `internal-write-plan-skill-safety`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@gh-pr` when viewed context should become PR create/edit work.
+2. Use `@gh-pr-close` only when explicit close intent follows the review.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_PR_VIEW=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Execute **View** (and optional diff-stat) from **[`internal-read-gh-pr-list`](../../../read/gh/pr-list/SKILL.md)** — run **only** the fenced blocks defined there.
+- When **`--repo`** is required (fork **`$UPSTREAM`**), align with **[`internal-read-gh-repo-stream`](../../../read/gh/repo-stream/SKILL.md)**.
+- **Structured confirm** before any follow-on **mutation** (**`@gh-pr-close`**, **`@gh-pr`**, …) per **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)**.
+
+## Do not
+
+- Mutate GitHub state from this skill.
+
+## See also
+
+- [`@gh-pr-list`](../list/SKILL.md)
+- [`@gh-pr`](../SKILL.md)

--- a/.agents/skills/gh-projects-delete-closed/SKILL.md
+++ b/.agents/skills/gh-projects-delete-closed/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: gh-projects-delete-closed
+description: >-
+  GitHub Projects (`gh project delete` on closed): preview closed projects, Goal + AskQuestion Proceed, then delete mutation per number (destructive). List shapes:
+  internal-read-gh-project-list; delete: internal-write-gh-project-commands. Mutates GitHub.
+---
+
+# GitHub: delete closed projects (bulk)
+
+Normative fences / full matrix: [`internal-write-gh-project-commands`](../../../../write/gh/project-commands/SKILL.md).
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-projects-order-readonly` first when read-only layering would narrow which closed projects are in scope.
+2. Ensure owner scope is explicit (`--owner "@me"` or org login) before any delete command.
+3. Preview/list hub: **`internal-read-gh-project-list`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-gh-project-list`
+2. `internal-write-gh-project-commands`
+3. `internal-write-plan-skill-safety`
+4. `internal-write-plan-structured-qa`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `internal-read-gh-project-list` again to confirm post-delete state.
+2. Route future issue/PR work through existing `@gh-issues` and `@gh-pr` lanes.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_PROJECTS_DELETE_CLOSED=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+1. **Goal** — Why closed projects should be removed from GitHub (housekeeping, compliance, etc.).
+2. **Inventory (read-only)** — Run list closed inventory from [`internal-read-gh-project-list`](../../../read/gh/project-list/SKILL.md). Show count and a compact preview (owner + number + title). Warn that deletion is irreversible and requires permissions plus `project` auth scope.
+3. **AskQuestion** — **Proceed** / **Cancel** before any delete mutation.
+4. **On Proceed only** — For each project number to delete, execute delete from `internal-write-gh-project-commands`. Stop on first CLI error and report.
+5. **Pasteable checklist** — [`DELETE_CLOSED_PROJECTS.md`](../../../write/gh/project-commands/delete-closed-projects/SKILL.md) (human summary; normative list shapes in `internal-read-gh-project-list`; delete in `internal-write-gh-project-commands`).
+
+## Do not
+
+- Delete projects before user **Proceed**.
+- Delete open projects from this skill—scope is closed cleanup only unless the user explicitly re-scopes in chat (then re-run Goal + preview).
+
+## See also
+
+- [`internal-read-gh-project-list`](../../../read/gh/project-list/SKILL.md)
+- [`internal-write-gh-project-commands`](../../../write/gh/project-commands/SKILL.md)
+- [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/gh-projects-order-readonly/SKILL.md
+++ b/.agents/skills/gh-projects-order-readonly/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: gh-projects-order-readonly
+description: >-
+  GitHub Projects (`gh project item-list`): read-only GitHub Project item list + dependency layering (body-based edges), parallel tracks, cycles, and unresolved
+  refs. Shapes: internal-read-gh-project-item-list. No GitHub mutations.
+---
+
+# GitHub: project item order (read-only)
+
+Normative fences, JSON normalization, edge grammar, and layering algorithm: **[`internal-read-gh-project-item-list`](../../../read/gh/project-item-list/SKILL.md)**.
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@gh-issue-view` when the user needs one issue’s detail before trusting order output on that row.
+2. Use when the user wants a **recommended execution order** or **parallel tracks** for a **GitHub Project** board (issues + other items), without changing GitHub state.
+3. Resolve **`OWNER`** and project **`NUMBER`** first (title match via **`internal-read-gh-project-list`** / user-supplied values).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. **`internal-read-gh-project-list`** — when project **number** is unknown.
+2. **`internal-read-gh-project-item-list`** — list items, normalize, parse edges, emit **layers / cycles / unresolvedEdges / skippedNonIssues** per v1 contract.
+
+## After batch (public, optional, sequential)
+
+1. Offer **`@gh-issue-view`** on a chosen issue from layer 0 when the user wants detail before branching.
+2. Offer **`@git-start`** when the user is ready to implement from an issue anchor.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GH_PROJECT_ORDER_READONLY=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` does **not** authorize GitHub mutations here—this skill stays read-only.
+
+## Do
+
+- Run **`gh project item-list`** and analysis per **[`internal-read-gh-project-item-list`](../../../read/gh/project-item-list/SKILL.md)**; summarize **layers**, **cycles**, and **unresolved** refs clearly.
+- Prefer **`-L 200`** (or documented cap) and say when output may be **truncated**.
+- Treat **PRs/drafts** as **inventory-only** for v1 edge parsing (see internal library).
+
+## Do not
+
+- Reorder, archive, delete, or edit project items via **`gh project item-*`** mutations from this skill.
+- Invent dependency edges not covered by the **v1 body line prefixes** in the internal library.
+
+## See also
+
+- [`internal-read-gh-project-list`](../../../read/gh/project-list/SKILL.md)
+- [`internal-read-gh-issue-projects-relationships`](../../../read/gh/issue-projects-relationships/SKILL.md)
+- [`@gh-project-delete-closed`](../delete-closed/SKILL.md) — separate mutating cleanup lane (owner scope + delete only)

--- a/.agents/skills/git-branch/SKILL.md
+++ b/.agents/skills/git-branch/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: git-branch
+description: >-
+  Branch hygiene workflow: inspect branches, prune stale remotes, delete merged local branches, and optionally rename current branch.
+  No pull request mutations and no implicit push.
+---
+
+**Normative workflow:** [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-branch-workflow).
+
+# Branch (cleanup and hygiene)
+
+Normative fences / full matrix: [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use after `@git-review` when you want branch cleanup on a healthy tree.
+2. Use `@git-main` first if local main alignment is still pending.
+3. Branch hygiene fences: **`internal-read-git-workflows`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-workflows`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@git-start` when branch hygiene should flow into new feature branch creation.
+2. Use `@git-push` when cleaned branch state should be published.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_BRANCH=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Execute **[`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-branch-workflow)** in order.
+- Preview branch impact before delete operations.
+- Use structured confirmation before deleting local branches that are not obviously merged.
+
+## Do not
+
+- Delete the currently checked-out branch.
+- Force-delete unmerged branches without explicit user confirmation.
+- Push, open PRs, or run issue mutations from this skill.
+
+## On invoke
+
+*`@git-branch`* — If the requested action is unclear, ask whether the user wants list/prune/delete/rename first.
+
+## Notes
+
+- This skill complements **`@git-pull`** and **`@git-main`** by keeping branch lists clean.
+- For one-off branch creation from a task, use **`@git-start`**.

--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: git-commit
+description: >-
+  Local savepoint: read-only inventory first; if nothing to commit, no-op without Q&A. Otherwise one Proceed for
+  stage (default git add -A) + commit message + mutating add/commit. No git-review, no docs pass, no push.
+---
+
+# `@git-commit` (local savepoint commit, no push)
+
+Normative fences / full matrix: [`internal-write-git-commit`](../../write/git/commit/SKILL.md).
+
+
+**Public.** **Goal:** record a local commit with **one** explicit **Cancel / Proceed** before mutating, without invoking **`@git-review`**, **`@git-docs`**, or **`@git-push`**.
+
+**Normative shell** — **[`internal-write-git-commit`](../../write/git/commit/SKILL.md)**.
+
+**Default scope:** Unless the user chooses **tracked-only** or **selected paths** in the **single** gate below, staging uses **`git add -A`** at **`TOP`** (full working tree under the repo root; **`.gitignore`** still applies)—the **Stage tracked and untracked** block in **`internal-write-git-commit`**.
+
+---
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@git-review` first when you need verification context before saving.
+2. Use after local edits when you need a savepoint before alignment workflows.
+3. Savepoint commit shapes: **`internal-write-git-commit`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-write-git-commit`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@git-push` when you are ready to publish (orchestrated commit-if-needed + push).
+2. Use `@git-tag` for release tagging after a confirmed savepoint.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_COMMIT=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## On invoke
+
+1. **Preconditions** — Run **Preconditions (read-only)** in **`internal-write-git-commit`**.
+2. **Inventory** — Run **Inspect working tree (read-only)** and summarize staged/unstaged/untracked state.
+3. **Nothing to commit** — If the working tree is **clean** (nothing to stage or commit: no short-status lines that imply pending work), **stop** with a one-line no-op explanation. **Do not** run **AskQuestion**.
+4. **Single gate — Stage + message + Proceed** (**AskQuestion**, only when step 3 does not apply) — One prompt that includes:
+   - **Branch context:** If current branch is **`main`** **and** **`git remote get-url origin`** succeeds, **warn** that **`@git-push`** will steer toward **feature branch + PR** when **`origin`** exists; **recommend** **[`@git-start`](../start/SKILL.md)** or **`git switch -c …`** before committing on **`main`** unless the user explicitly wants a **`main`** savepoint.
+   - **Staging:** Default **`git add -A`** at **`TOP`**. Options in **the same** question: **Abort**, **Proceed — full tree (`git add -A`)**, **Tracked only (`git add -u`)**, **Selected paths** (user names **`PATHS`**; you **export** or restate them before **Proceed**).
+   - **Message:** Confirm **`COMMIT_SUBJECT`** (user supplies or confirms in-chat before **Proceed**).
+   - **Proceed** — Restate staging mode, **`COMMIT_SUBJECT`**, and that **Create commit** runs immediately after.
+5. **Mutations** — Run the matching staging block from **`internal-write-git-commit`**, then **Create commit (mutating)**. If the user chose **Selected paths**, run **Stage selected paths** after **`PATHS`** is set.
+
+**Narrow scope follow-up:** If **Selected paths** or **`add -u`** needs clarification (paths ambiguous), **one** follow-up question is allowed—do **not** restart a multi-round ladder.
+
+---
+
+## Do
+
+- Use this skill for local savepoints before destructive/sync workflows.
+- Keep commit messages short and intent-oriented.
+- Exit early with a no-op when inventory shows nothing to commit.
+
+## Do not
+
+- Claim this commit is verified/green; green is **`@git-review`**, and **`@gh-pr`** runs **`@git-review`** before **`@git-push`** when crafting a PR.
+- Push from this skill.
+- Present this skill as a way to **bypass** **`@git-push`** branch policy when **`origin`** exists.
+
+---
+
+## Verification
+
+- [ ] **Inventory** ran; **no-op** or **single gate** path is documented in the result.
+- [ ] **Proceed** / **Abort** captured before mutating commands (when step 4 ran).
+- [ ] Result includes either commit SHA or a no-op explanation.
+
+---
+
+## See also
+
+- [`internal-write-git-commit`](../../write/git/commit/SKILL.md)
+- [`@git-push`](../push/SKILL.md)
+- [`@git-tag`](../tag/SKILL.md)

--- a/.agents/skills/git-docs/SKILL.md
+++ b/.agents/skills/git-docs/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: git-docs
+description: >-
+  Post-green doc accuracy: edit existing markdown in place only—no new/deleted/moved .md, no split/merge of files.
+  Additive tweaks (bullets, links, facts) when the change set requires it; no-op if docs already match. After @git-review
+  succeeds, or docs-only pass. Does not run internal-write-gh-evaluate. New paths or doc-tree reshaping are normal edits outside this skill.
+---
+
+# `@git-docs` (documentation sync — no structure)
+
+Normative fences / full matrix: [`internal-read-git-repo-layout`](../../read/git/repo-layout/SKILL.md), [`internal-write-gh-documentation`](../../write/gh/documentation/SKILL.md).
+
+
+**Public.** **Goal:** After **`@git-review`** has **succeeded** (or on a **docs-only** pass on a clean tree), check whether **existing** documentation needs **minimal** factual updates so it matches the **current** branch and repo. **Edit only paths that already exist**—**additive** or **surgical** corrections (wrong sentence, missing bullet, link, env var, command). If nothing is missing, **report that docs are already good** and **make no edits** (**no-op**). **Not** for fixing failing tests—loop **`@git-review`** first.
+
+**Canonical layout (read-only here):** **[`internal-read-git-repo-layout`](../../read/git/repo-layout/SKILL.md)** + **[`internal-read-git-doc-wiki`](../../read/git/doc-wiki/SKILL.md)** (light orientation for **`docs/`** depth on **other** repos). **New** narrative paths, mirror folders, moves, splits: **not** this skill—add or reshape files in a regular change set; use **`internal-read-git-readme-tree`** (bootstrap bullets) and **`internal-read-git-repo-layout`** as guides.
+
+**Libraries (orchestration + implicit conventions):** **[`internal-write-gh-documentation`](../../write/gh/documentation/SKILL.md)** (§8a in-place posture + **implicit** **`internal-read-git-doc-*`** bundle), **`internal-read-git-readme-root`**, **`internal-read-git-doc-exemplars`**, **`internal-read-git-doc-graphs`** — use them for **in-place** edits only. **Do not** wait for the user to name **`internal-read-git-doc-table`** / **`internal-read-git-doc-index`** when fixing **`README.md`** or **`docs/**`** tables and indexes—apply those rules as part of this skill (same bundle as **`internal-write-gh-documentation`** / **`internal-read-git-repo-layout`**).
+
+---
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Prefer running after `@git-review` succeeds or in a docs-only pass.
+2. Use `@git-push` orchestration context when docs sync is part of publish prep.
+3. Docs mirror fences: **`internal-read-git-repo-layout`** and **`internal-read-git-doc-wiki`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-repo-layout`
+2. `internal-read-git-doc-wiki`
+3. `internal-write-gh-documentation`
+4. `internal-read-git-repo-classification`
+5. `internal-read-git-doc-reference`
+6. `internal-read-git-doc-user-guide`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Return to `@git-review` if code-health checks still fail.
+2. Use `@gh-pr` after docs updates are ready to ship with branch changes.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_DOCS=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## No structure (hard rules)
+
+- **Do not** **create**, **delete**, **rename**, or **move** **`.md`** files.
+- **Do not** **split** one doc into several or **merge** files.
+- **Do not** **reorganize** the whole section tree for style or preference.
+- **Within** a file, prefer **small** edits (fix a line, **append** a bullet) over rewriting large regions or churning prose.
+- If the **information architecture** or mirror tree is wrong, **say so in chat** and point to **`internal-read-git-repo-layout`** and **`internal-read-git-readme-tree`**—**do not** fix structure inside **`@git-docs`**.
+- If a file is **oversized** and should be split, **say so in chat**—**do not** split here (use a follow-up change set with **`internal-write-plan-skill-safety`** if the edit is large).
+
+---
+
+## On invoke
+
+1. **Goal line** — One sentence (or inherit from **`@git-review`** / **`@gh-pr`** context when this pass follows green verify).
+2. **AskQuestion** (finite modes), per **structured-qa** **§2** — e.g. **Diff-scoped check** (default when following a small code change—infer **relevant** existing docs from the user’s stated paths, **`@git-review`** output, or workspace reads; **do not** embed **`git`** recipes in this skill) · **Wider inventory** (**`docs/**/*.md`**, root **`README.md`**, repo-root **`*.md`**) · **New paths / tree reshape** — not this skill; say so and stop.
+3. **Large in-place edits** (many files, high line count) — **plan preview** + **No**/**Yes** per **skill-safety** + **structured-qa** **§1c** / **§3a**.
+
+---
+
+## Do
+
+1. **Start from the change set** — Use **touched paths** implied by the user, review artifacts, or **`internal-write-gh-documentation`** alignment posture; open the **smallest** set of **existing** doc files that should reflect those changes.
+2. **Tiny / non-doc changes** — If nothing user-facing changed or **existing** docs already mention it, **state that and stop** (**no-op**). **Do not** edit for style alone.
+3. **Wider pass** — When the user asks, walk **`docs/**/*.md`**, root **`README.md`**, and repo-root **`*.md`** (still **in place** only). **Exclude by default** **`skills/**/SKILL.md`** unless the user **explicitly** expands scope (those files follow **skill authoring**).
+4. **Apply** — Patch using the same discipline as **`internal-write-gh-documentation`**: lists, links, commands, optional **colored** mermaid per **`internal-read-git-doc-graphs`** **inside** existing files. **Implicit conventions** — for **`## Contents`**, **tables**, **overview** sections, and **diagrams**, apply **`internal-read-git-doc-index`**, **`internal-read-git-doc-table`**, **`internal-read-git-doc-explanation`**, and **`internal-read-git-doc-graphs`** rules **without** asking the user to cite each library.
+
+## Do not
+
+- Run **`internal-write-gh-evaluate`** — that is **`@git-review`**.
+- **Commit, push, or GitHub PR mutations** — use **`@git-push`** / **`@gh-pr`**.
+- **Promise** bulk doc-tree fixes from this skill alone.
+
+---
+
+## Verification
+
+- [ ] User saw **mode** (diff-scoped vs wider) or explicit scope.
+- [ ] **No-op path** noted when docs already match (**no** edits).
+- [ ] **No structural** file operations this run (no new/deleted/moved **`.md`**).
+- [ ] Tree / new-path needs **called out** in chat when appropriate—not silently “fixed” here.
+- [ ] Caller directed to **`@git-review`** if tests are not green yet.
+
+---
+
+## Pack onboarding (human reference)
+
+Use this section for quick onboarding to the skill pack. The operational rules above remain the contract for `@git-docs`.
+
+### Install and verify
+
+From repo root:
+
+Useful options:
+
+- `--clean` (wipes whole `CURSOR_SKILLS_DIR`, then reinstalls this pack), `--uninstall` (removes only this pack’s folders; confirm with `DELETE` or `CURSOR_SKILLS_UNINSTALL_CONFIRM=yes`), `--verify-only`, `--dry-run`, `--repo DIR`
+- `CURSOR_SKILLS_DIR` to change destination (default `~/.cursor/skills`)
+
+Run checks:
+
+### Standard flow examples
+
+- **Plan to issue:** Cursor Plan (optional) → chat / `.cursor/plan.md` (optional) → `@gh-issues`
+- **Issue to PR:** `@gh-issue-view` -> `@git-start` -> `@gh-pr` (runs **`@git-pull`**, **`@git-review`**, **`@git-push`**, then PR text)
+- **PR vs issue review:** `@gh-pr-view` + `@gh-issue-view`, then `@gh-issue-review` when reshaping is needed
+
+### Execution hand-off pattern
+
+1. Start from the tracked issue instead of raw chat.
+2. Convert issue scope into ordered todos/checkpoints.
+3. Recheck todos against issue acceptance criteria.
+4. Implement, verify, and then publish.
+
+### Model-tier guidance
+
+| Phase | Typical model | Why |
+| --- | --- | --- |
+| Fast planning loops | `composer-2` | Lower-cost iteration while refining scope and examples. |
+| Issue/body polish | `composer-2` | Good for tightening wording and acceptance criteria. |
+| Implementation and verification | `codex-5.3` | Stronger multi-file execution and test handling. |
+
+### Additional docs
+
+- [`README.md`](../../../README.md) — concise visual entry point
+- [`docs/README.md`](../../../docs/README.md) — docs hub
+- [`docs/git.md`](../../../docs/git.md), [`docs/gh.md`](../../../docs/gh.md), [`docs/internal.md`](../../../docs/internal.md)
+
+---
+
+## See also
+
+- [`internal-read-git-repo-classification`](../../read/git/repo-classification/SKILL.md) — optional repo-kind hints for doc inventory scope
+- [`@git-review`](../review/SKILL.md) — verify + §8a light polish
+- [`@git-push`](../push/SKILL.md) — publish orchestration (**`@git-commit`** when needed); does **not** bundle **`@git-docs`**
+- [`internal-read-git-repo-layout`](../../read/git/repo-layout/SKILL.md) — **`skills/`** + **`docs/`** hub contract
+- [`internal-read-git-doc-reference`](../../read/git/doc-reference/SKILL.md) · [`internal-read-git-doc-user-guide`](../../read/git/doc-user-guide/SKILL.md) — legacy **`REFERENCE.md`** / **`USER_GUIDE.md`** migration only

--- a/.agents/skills/git-main/SKILL.md
+++ b/.agents/skills/git-main/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: git-main
+description: >-
+  Align local main to origin/main using the linked workflow and internal working-tree align
+  library. No stash. No push. Embedded in @git-start before new branch.
+---
+
+**Normative workflow:** [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-main-align-workflow).
+
+# Main (checkout `main` → fetch → match canonical remote → clean)
+
+Normative fences / full matrix: [`internal-write-git-working-tree-align`](../../write/git/working-tree-align/SKILL.md), [`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@git-commit` or `@git-stash` first when local work must be preserved.
+2. Use this skill directly when local main should be aligned to canonical main.
+3. Main alignment fences: **`internal-read-git-workflows`** and **`internal-write-git-working-tree-align`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-workflows`
+2. `internal-write-git-working-tree-align`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@git-start` to branch from the freshly aligned base.
+2. Use `@git-push` when aligned work should be published.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_MAIN=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Follow the linked **Normative workflow** end-to-end; it owns the operational sequence for aligning local **`main`**.
+- Use **`origin/main`** as the canonical main ref for alignment in this standalone workflow.
+- Use **[`internal-write-git-working-tree-align`](../../write/git/working-tree-align/SKILL.md)** for dirty-tree handling, reset/clean impact, and confirmations.
+- Stay in **current workspace** repo and report whether **`main`** is aligned when done.
+
+## Do not
+
+- **Stash**—user commits, aborts, or confirms trash per **[`internal-write-git-working-tree-align`](../../write/git/working-tree-align/SKILL.md)**.
+- Publish—**[`@git-push`](../push/SKILL.md)** only.
+- Perform destructive alignment without structured confirm after showing impact (see working-tree-align).
+- Reorder the linked workflow.
+- Run **`@git-pull`** here—feature-branch sync is **`@git-pull`**, not **`@git-main`**.
+
+**When to use:** (1) Standalone—clean **`main`**. (2) Inside **[`@git-start`](../start/SKILL.md)** before creating the new branch.
+
+## Workflow Ownership
+
+- **Order and command recipe:** [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-main-align-workflow).
+- **Dirty tree, destructive align, clean, optional cache pruning:** [`internal-write-git-working-tree-align`](../../write/git/working-tree-align/SKILL.md).
+
+## On invoke
+
+*`@git-main`* — Execute the linked workflow exactly once against **`origin/main`**. Do not publish from this skill.
+
+## Notes
+
+- **Canonical ref:** **`origin/main`**.
+- **Feature branch** sync (merge **`main` into** that branch) → **`@git-pull`**, not **`@git-main`**.
+- **`@git-start`** embeds **this** skill end-to-end.

--- a/.agents/skills/git-project-structure-eval/SKILL.md
+++ b/.agents/skills/git-project-structure-eval/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: git-project-structure-eval
+description: >-
+  Public router for repository structure/readiness evaluation. Runs a read-only internal batch and returns posture + prioritized themes.
+---
+
+# `@git-project-structure-eval` (read-only posture snapshot)
+
+Normative fences / full matrix: [`internal-read-git-repo-classification`](../../read/git/repo-classification/SKILL.md).
+
+
+**Public.** **Goal:** evaluate the current repository structure/readiness in one pass and return a planning-grade posture report without running installs/tests or mutating git/GitHub.
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@git-review` first when posture should include fresh verification context.
+2. Use **Cursor Plan** or chat first when evaluation is only one input to a larger planning loop.
+3. Repo posture batch: **`internal-read-git-repo-classification`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-repo-classification`
+2. `internal-read-git-discover-dependencies` (optional, when available/relevant)
+3. `internal-read-git-project-structure-eval`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use **Cursor Plan** or **`@gh-issues`** Sharpen rounds to resolve ambiguity in prioritized themes.
+2. Use **`@git-start`** once a stable brief or issue anchor is approved.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_PROJECT_STRUCTURE_EVAL=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Keep this skill read-only and orchestration-only.
+- Return the full output contract from `internal-read-git-project-structure-eval`.
+
+## Do not
+
+- Do not run installs/tests here.
+- Do not mutate git or GitHub from this skill.
+- Do not duplicate runnable command fences in this public file.

--- a/.agents/skills/git-pull/SKILL.md
+++ b/.agents/skills/git-pull/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: git-pull
+description: >-
+  Fetch; merge @{u} if tracked; merge canonical main (upstream/main if fork else origin/main); resolve conflicts
+  via internal-read-git-merge-conflicts. Does NOT @git-review or @git-push—run publish in a separate invocation.
+---
+
+**Normative workflow (commands):** [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-pull-workflow).
+
+# Pull (merge + resolve conflicts)
+
+Normative fences / full matrix: [`internal-read-git-merge-conflicts`](../../read/git/merge-conflicts/SKILL.md), [`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md).
+
+
+**Safety / prompts** — Merge commits completing this skill follow the **`@git-pull`** carve-out in **[`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md)** (**Exception: `@git-pull` merge commits**): no extra **AskQuestion** per merge. If the working tree is **ambiguous** before you merge, stop and use open-ended **chat** per **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)** **§4**. **`@git-push`** still owns commit + push confirmation when publishing.
+
+**Conflict resolution** — When merges conflict, execute **[`internal-read-git-merge-conflicts`](../../read/git/merge-conflicts/SKILL.md)** **in full**. Do not reimplement that playbook here.
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@git-commit` or `@git-stash` first if local modifications need protection.
+2. Use this skill when branch tracking/main alignment merge is required.
+3. Pull/merge fences: **`internal-read-git-workflows`** and **`internal-write-plan-skill-safety`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-workflows`
+2. `internal-write-plan-skill-safety`
+3. `internal-write-plan-structured-qa`
+4. `internal-read-git-merge-conflicts`
+5. `internal-read-gh-repo-stream`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@git-review` after pull to validate workspace health.
+2. Use `@git-push` when verified updates should be published.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_PULL=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Execute **[`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-pull-workflow)** **in order** (branch check, fetch, tracking merge, canonical root merge, stop).
+- **`CANONICAL_MAIN_REF` / fork semantics:** **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)**.
+- On conflicts: **[`internal-read-git-merge-conflicts`](../../read/git/merge-conflicts/SKILL.md)** end-to-end.
+
+## Do not
+
+- **`@git-push`**, **full `@git-review`**, or publishing from this skill—next step is **`@git-review`**, **`@git-push`**, or **`@gh-pr`** per the user’s goal.
+- Create or update PRs—that is **`@gh-pr`**.
+- Use **`@git-main`** to sync a **feature** branch—**`@git-main`** is for **local `main`** only; merging **`main` into** the current branch is **`@git-pull`**.
+- Inline duplicate conflict doctrine—use **`internal-read-git-merge-conflicts`**.
+
+## On invoke
+
+*`@git-pull`* — Start immediately. Run the linked **pull-workflow** once; on conflicts, **`internal-read-git-merge-conflicts`**; when merges are complete, finish at workflow **§6**.
+
+## Notes
+
+*`@git-pull`*
+- **Next steps (outside `@git-pull`):** **`@git-review`** — verify install / lint / test / build. **`@git-push`** — commit-if-needed + publish per **`internal-read-git-workflows`** push section (no bundled verify). **`@git-docs`** separately when broader doc accuracy is needed. **`@gh-pr`** — **`@git-pull`**, **`@git-review`**, **`@git-push`**, then PR title/body.
+- See also: **[`internal-read-git-merge-conflicts`](../../read/git/merge-conflicts/SKILL.md)**, **[`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md)**, **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)**.

--- a/.agents/skills/git-push/SKILL.md
+++ b/.agents/skills/git-push/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: git-push
+description: >-
+  Orchestrate publish: read-only working-tree inventory; full @git-commit only when there is something to commit;
+  one publish Proceed (branch gate + push + failure triage). No @git-review or @git-docs here—use @git-review alone
+  or via @gh-pr when opening/updating a PR.
+---
+
+**Normative workflows:** **[`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-push-workflow)**.
+
+# Push (commit if needed → publish)
+
+Normative fences: [`internal-write-git-commit`](../../write/git/commit/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use **`@git-pull`** first if upstream changes may not be merged locally.
+2. Use when implementation changes are ready to **record and publish** (not for full verify—see **`@git-review`**).
+3. **Full verify** (install, format, lint, test, §8a docs polish) is **[`@git-review`](../review/SKILL.md)**. For pull requests, **`@gh-pr`** runs **`@git-review`** before this skill in its fixed order.
+4. Publish workflow fences: **`internal-read-git-workflows`** and **`internal-write-plan-skill-safety`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-workflows`
+2. `internal-write-plan-skill-safety`
+3. `internal-write-plan-structured-qa`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use **`@gh-pr`** after publish completes to create or update PR metadata (**`@gh-pr`** runs **`@git-pull`** → **`@git-review`** → **`@git-push`** then PR work—do not skip ahead).
+2. Use **`@git-review`** when you need a full workspace health pass without opening a PR.
+3. Use **`@git-docs`** when docs accuracy requires a broader post-green pass.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_PUSH=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- **§1 (read-only):** Run a **working-tree inventory** (same spirit as **Inspect working tree** in [`internal-write-git-commit`](../../write/git/commit/SKILL.md): e.g. `git status --short`; add `git diff` / `git diff --cached` when useful). If the branch has an upstream, note **ahead/behind** (e.g. `git rev-list --left-right --count HEAD...@{u}` when `@{u}` resolves).
+- Run **complete** **[`@git-commit`](../commit/SKILL.md)** (**§2**) **only when** that inventory shows **something to commit** (non-empty short status: staged, unstaged, or untracked changes). If the tree is clean, **skip §2** entirely (no **`@git-commit`** hand-off). A clean tree with **unpushed commits** still proceeds to **§3** without §2.
+- **§3** — Follow publish steps in **`push-workflow`** after **one** structured **Proceed** for **branch intent + push** (plus **[`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md)** + **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)** **§3a**). Do **not** stack extra micro-confirms on top of what **`@git-commit`** already resolved; **§3b** triage runs only when **`git push`** fails.
+- **§3a — Branch gate (`origin`-aware):** Read **`origin`** with **`git remote get-url origin`** (or equivalent). **If `origin` exists** and the current branch is **`main`**, **recommend** **Create + switch to a new branch** from current **`HEAD`**, then **`git push -u`**, then **[`@gh-pr`](../../gh/pr/SKILL.md)** for GitHub review. Treat **Proceed on `main`** as an **explicit, non-default** path (hotfix / maintainer override) with clear risk wording. **If `origin` is missing**, default to **Proceed on current branch** (including **`main`**) in one gate—no branch+PR pressure; publishing may be impossible or local-only; state that honestly.
+- **§3b** — If push fails, run failure triage per **`structured-qa` §8** (safe-first options with explicit next actions), then continue only on a selected recovery path.
+
+## Do not
+
+- Run **`@git-commit`** when the §1 inventory is **clean** (nothing to stage or commit)—skip §2 instead.
+- Substitute ad-hoc format/lint/test commands for **[`@git-review`](../review/SKILL.md)** when the user asked for full verify—the matrix lives there (**[`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md)** via **`@git-review`**).
+- Merge **`main`** or author PR bodies here—**[`@git-pull`](../pull/SKILL.md)**, **[`@gh-pr`](../../gh/pr/SKILL.md)** after push. Branch creation belongs to **`@git-start`** by default; **`@git-push`** may create/switch a recovery branch only inside **§3a/§3b** push handling.
+- Assume **`@git-docs`** runs inside this skill; run **[`@git-docs`](../docs/SKILL.md)** separately when documentation updates are requested.
+
+**When another skill publishes:** **`@git-start`** → **`@git-push`** on new branch. **`@gh-pr`** → **`@git-pull`** then **`@git-review`** then **`@git-push`** then PR text. **`@git-main`** / **`@git-pull`** alone do **not** push. Verify without push: **`@git-review`** alone.
+
+## On invoke
+
+*`@git-push`* — Run steps **1 → 2 → 3** in order. Run the **§1 read-only inventory** first; call **`@git-commit`** only when that inventory shows work to commit. During §3, use **one** branch+publish **Proceed** when push succeeds on the first attempt; use **§3b** only on failure.
+
+## Workflow
+
+### 1. Working-tree inventory (read-only)
+
+> **`git status --short`** (and short diffs if useful); optionally **`git rev-list --left-right --count HEAD...@{u}`** when upstream exists. This step does **not** run **`@git-review`**.
+
+### 2. **`@git-commit`** only if needed
+
+> **If** there is **nothing to commit** (clean index and working tree), **skip** **`@git-commit`** and go to **§3**. **Else** execute the **entire** **[`@git-commit`](../commit/SKILL.md)** — single add+commit gate per that skill.
+
+### 3. Publish
+
+*`@git-push`* — Execute publish steps in **`push-workflow`** (one **Proceed** for branch intent + **`git push`**, then scratch cleanup when applicable). Ephemeral scratch dirs: **[`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md)** (**Exception: ephemeral scratch paths in `@git-push`**).
+
+### 3a. Branch pre-push gate
+
+*`@git-push`* — In §3 preamble, surface current **`BRANCH`** and whether **`origin`** exists. **With `origin` on `main`:** **AskQuestion** once: **Abort**, **Create + switch to new branch from current `HEAD` then push** (**recommended**), or **Proceed on `main`** (non-default; name the risk). **Without `origin`:** prefer a single **Proceed / Abort** for publish intent on the current branch (including **`main`**).
+
+### 3b. Push failure recovery loop
+
+*`@git-push`* — If push returns non-zero, do not hard-stop immediately. Run failure triage per **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)** **§8** with compact context summary above the prompt (branch, remote, concise error, next-step effects). Keep safe-first options: **Abort**, **Create/switch recovery branch + push `-u`**, **Retry current push**. Offer force-like paths (for example `--force-with-lease`) only as an explicit risk option with separate confirm per **[`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md)** triggers.
+
+## Notes
+
+*`@git-push`*
+- Run from the repo root.
+- Run **[`@git-docs`](../docs/SKILL.md)** as a separate invocation when documentation updates are requested.
+- After a successful push, to open or refresh a PR → **`@gh-pr`** (full chain: **`@git-pull`** → **`@git-review`** → **`@git-push`** → PR metadata).

--- a/.agents/skills/git-rebase/SKILL.md
+++ b/.agents/skills/git-rebase/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: git-rebase
+description: >-
+  Rebase current branch onto canonical main (or another target) with conflict resolution via internal-read-git-merge-conflicts.
+  No push in this skill; publish separately with @git-push after review.
+---
+
+**Normative workflow:** [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-rebase-workflow).
+
+# Rebase (current branch onto target)
+
+Normative fences / full matrix: [`internal-read-git-merge-conflicts`](../../read/git/merge-conflicts/SKILL.md), [`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@git-pull` first when canonical main should be merged before rewriting history.
+2. Use after preserving local work if rewrite risk requires a safety savepoint.
+3. Use this skill when rebasing current branch onto canonical main/target is desired.
+4. Rebase/conflict fences: **`internal-read-git-workflows`** and **`internal-read-git-merge-conflicts`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-workflows`
+2. `internal-read-git-merge-conflicts`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@git-review` after rebase to validate workspace health.
+2. Use `@git-push` for publish flow once rebase results are confirmed.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_REBASE=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Execute **[`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-rebase-workflow)** in order.
+- Use **`origin/main`** as the default target when rebasing onto repository main.
+- If conflicts occur, run **[`internal-read-git-merge-conflicts`](../../read/git/merge-conflicts/SKILL.md)** as the conflict playbook and continue rebase until complete.
+
+## Do not
+
+- Rebase `main` itself in this skill flow; use **`@git-main`** to align local `main`.
+- Push rewritten history from this skill; publishing belongs to **`@git-push`** after user confirmation.
+- Mix merge and rebase strategies in one invocation unless the user explicitly requests it.
+
+## On invoke
+
+*`@git-rebase`* — Determine target (`canonical main` by default). If unclear, ask for the target branch/ref before running workflow steps.
+
+## Notes
+
+- After a successful rebase, run **`@git-review`** before publishing, or use **`@gh-pr`** (which runs **`@git-review`** before **`@git-push`**).
+- Rebase rewrites commits; confirm intent when branch history is already shared.

--- a/.agents/skills/git-reset/SKILL.md
+++ b/.agents/skills/git-reset/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: git-reset
+description: >-
+  Stay on current branch; fetch --all; align to $TARGET (tracking/upstream/origin) via reset --hard + git clean after confirm.
+  No stash. No push. No merge main—use @git-pull. Leaf: no hand-off to other git-* / gh-*.
+---
+
+**Normative workflow:** [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-reset-align-workflow).
+
+# Reset (stay on branch → keep or trash → discover → confirm → reset → clean)
+
+Normative fences / full matrix: [`internal-write-git-working-tree-align`](../../write/git/working-tree-align/SKILL.md), [`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@git-commit` first when any local work needs preservation before reset.
+2. Use when hard alignment is explicitly requested and local edits can be discarded.
+3. Reset/working-tree fences: **`internal-read-git-workflows`** and **`internal-write-git-working-tree-align`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-workflows`
+2. `internal-write-git-working-tree-align`
+3. `internal-write-plan-structured-qa`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@git-pull` when merge-based sync is preferred over destructive alignment.
+2. Use `@git-review` to recheck workspace health after reset completes.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_RESET=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Execute **[`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-reset-align-workflow)** **in order** (validate tree, stay on branch, fetch, resolve **`$TARGET`**, align, verify).
+- Resolve **`$TARGET`** from local refs, tracking refs, or explicit origin refs provided by the user.
+- Dirty tree and **hard reset / clean**: **[`internal-write-git-working-tree-align`](../../write/git/working-tree-align/SKILL.md)** (**§1–§4**, **`MODE=split`**, **`ALIGN_REF="$TARGET"`**). Optional non-git prunes: that library **§5**. Prompts per **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)**.
+- **Recommendation:** use a high-reasoning model for conflict-prone cleanup decisions.
+
+## Do not
+
+- **Stash**—preserve work by commit, abort, or confirmed destroy only.
+- **`@git-push`**, merge **`main`** into branch—use **`@git-pull`** / **`@git-push`** for that.
+- Align (**hard reset**, **clean**, container prunes) **without** user confirmation after showing impact.
+
+**Leaf:** does **not** hand off to other **`gh-*`** skills.
+
+## On invoke
+
+*`@git-reset`* — **Do not** run destructive align steps without **user confirmation** after you show what will happen.
+
+**Never** use **stash** in this skill.
+
+## Notes
+
+- **No stash:** preserving work is **commit** or **abort**; this skill only **aligns** to **`$TARGET`** after explicit **trash** consent when the tree was dirty.
+- Do not use if merge/rebase is in progress unless resolved first.
+- Solo **`@git-reset`** only aligns **current** branch to **`$TARGET`**; it never checks out another branch.

--- a/.agents/skills/git-revert/SKILL.md
+++ b/.agents/skills/git-revert/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: git-revert
+description: >-
+  Create safe inverse commits for one or more existing commits, including merge-commit revert handling.
+  Does not reset history and does not push automatically.
+---
+
+**Normative workflow:** [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-revert-workflow).
+
+# Revert (safe undo with new commits)
+
+Normative fences / full matrix: [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@git-review` first when you need current failure evidence before revert.
+2. Use after identifying exact commit SHAs that need safe inverse commits.
+3. Revert workflow fences: **`internal-read-git-workflows`** (names only; Execution batch runs it).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-workflows`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@git-review` again to verify behavior after revert commits are created.
+2. Use `@git-push` when reverted history is ready to publish.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_REVERT=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Execute **[`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-revert-workflow)** in order.
+- Prefer revert for shared/published history instead of reset-based rewriting.
+- Confirm target commit set and order before applying multi-commit reverts.
+
+## Do not
+
+- Use hard reset here; this skill is commit-based undo only.
+- Push automatically; hand off to **`@git-push`** when the user wants to publish.
+- Revert unknown merge commits without confirming parent selection.
+
+## On invoke
+
+*`@git-revert`* — Ask for commit hash/range (and merge parent when needed) if not explicitly provided.
+
+## Notes
+
+- For local-only discard workflows, use **`@git-reset`** instead.
+- For conflict handling during revert, use the same conflict discipline as **`@git-pull`** and complete the revert sequence.

--- a/.agents/skills/git-review/SKILL.md
+++ b/.agents/skills/git-review/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: git-review
+description: >-
+  Make the current workspace healthy: internal-read-git-discover-dependencies → install-dependencies → configuration →
+  evaluate (format, lint, tests; prefer fixing failing code and unformatted sources) → internal-write-gh-documentation (§8a).
+  No git add, commit, or push. Command matrix in internal-write-gh-evaluate + internal-read-git-configuration.
+---
+
+# `@git-review` (workspace health → report)
+
+Normative fences / full matrix: [`internal-read-git-discover-dependencies`](../../read/git/discover-dependencies/SKILL.md), [`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md).
+
+
+**Public.** **Goal:** the tree **as it is now** works — dependencies installed, **sources formatted**, **lint clean**, **tests passing**, then **§8a** **light** polish of **existing** **`docs/**`** + minimal root **`README.md`** (parity with repo + CI—**not** bulk regen). **Not** staging, **commit**, or **publish**—use **`@git-commit`** and **`@git-push`** for savepoints and publish; **`@gh-pr`** runs this skill before **`@git-push`** when opening or updating a PR.
+
+Run each **internal** skill below **in full**, in order. Details live in linked files—**not** duplicated here.
+
+| Step | Internal skill |
+| --- | --- |
+| 1–2 | [`internal-read-git-discover-dependencies`](../../read/git/discover-dependencies/SKILL.md) |
+| 3 | [`internal-write-gh-install-dependencies`](../../write/gh/install-dependencies/SKILL.md) |
+| — | [`internal-read-git-configuration`](../../read/git/configuration/SKILL.md) |
+| 4–7 | [`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md) |
+| 8a | [`internal-write-gh-documentation`](../../write/gh/documentation/SKILL.md) |
+| 9 | Report (this skill only) |
+
+```mermaid
+flowchart LR
+  classDef intH fill:#004d40,color:#fff
+  classDef int1 fill:#00695c,color:#fff
+  classDef int2 fill:#00897b,color:#fff
+  classDef int3 fill:#4db6ac,color:#111
+  classDef intT fill:#b2dfdb,color:#111
+  D[discover-deps] --> I[install-deps] --> C[configuration] --> E[evaluate]
+  E --> DOC[documentation 8a]
+  class D intT
+  class I int3
+  class C int2
+  class E intH
+  class DOC int1
+```
+
+**Failure:** Stop on first failure; **skip step 8a** if Evaluate failed.
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@git-pull` first when local branch might be behind upstream/main.
+2. Use before publish workflows when workspace health needs a full verification pass.
+3. Discover/install/evaluate stack: **`internal-read-git-discover-dependencies`** → **`internal-write-gh-install-dependencies`** (names only; Execution batch runs below).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-discover-dependencies`
+2. `internal-write-gh-install-dependencies`
+3. `internal-read-git-configuration`
+4. `internal-write-gh-evaluate`
+5. `internal-write-gh-documentation`
+6. `internal-write-plan-skill-safety`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@git-docs` for broader post-green in-place docs accuracy updates.
+2. Use `@git-push` when you are ready to publish verified changes.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_REVIEW=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do not
+
+- **Stage, commit, or push** — use **`@git-push`** when you want to publish from this workspace.
+- Fetch / merge / reset — use **`@git-pull`**, **`@git-main`**, **`@git-reset`**.
+- Skip internals or run checks outside **`internal-write-gh-evaluate`**.
+
+**Also used by:** **`@gh-pr`** runs this **same** pipeline **before** **`@git-push`** in the PR chain—**`@git-review`** by itself does **not** stage, commit, or push.
+
+## Report §9
+
+Summarize: discovery, prepare, evaluate (pass/fail; call out **format fixes**, **lint fixes**, **test/code fixes** applied), **§8a** documentation pass (yes/no; paths touched briefly).
+
+## Notes
+
+- **Issue clarity** (reshape / duplicates / thin phone drafts) is **`@gh-issue-review`** + **`@gh-issues`**—**not** this pipeline unless you explicitly run **`@git-review`** for code health.
+- **`internal-write-gh-install-dependencies`** (step 3) runs **destructive** wipes only after **structured confirm** (**[`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md)** + **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)** **§3a**).
+- Standalone **`@git-push`** does **not** run this pipeline; ad-hoc checks there do **not** replace **`internal-write-gh-evaluate`** when the user asked for full verify.
+- **`@gh-pr`** assumes **full** **`@git-review`** completed successfully **before** **`@git-push`** in its fixed order, then PR description work follows.
+- **Bulk `docs/`** regen and stripping **`skills/**/README.md`** is **outside** this pack’s skills—do it in normal edits with **`internal-read-git-repo-layout`**, **`internal-read-git-readme-tree`** (read-only bootstrap notes), and **`internal-write-plan-skill-safety`** as needed. **§8a** is **light** polish on **existing** paths during verify. **Full** post-green doc accuracy (**in-place** only; may **no-op**) is **`@git-docs`** after green—**not** a substitute for green evaluate. This pipeline **does not** replace those skills.

--- a/.agents/skills/git-start/SKILL.md
+++ b/.agents/skills/git-start/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: git-start
+description: >-
+  Full @git-main → new branch from derived name → full @git-push. Branch naming from Jira/activity/issue number in chat;
+  use @gh-issue-view separately for live GitHub issue titles. Does NOT reimplement @git-main; does NOT open PR (@gh-pr).
+  User may skip push if explicit.
+---
+
+**Normative workflow:** [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-start-workflow).
+
+# Start (main → new branch from a task)
+
+Normative fences / full matrix: [`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md), [`internal-write-git-working-tree-align`](../../write/git/working-tree-align/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use after issue context is clear (for example from `@gh-issue-view`).
+2. Use `@git-main` first if you only need standalone main alignment.
+3. Start-branch workflow fences: **`internal-read-git-workflows`** and **`internal-write-plan-structured-qa`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-workflows`
+2. `internal-write-plan-structured-qa`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use `@git-push` publish flow for subsequent commit/push orchestration.
+2. Use `@gh-pr` when the branch is ready for pull request creation/edit.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_START=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Derive **`$BRANCH`** from Jira key, GitHub issue, or kebab-case activity.
+- Run **full** **[`@git-main`](../main/SKILL.md)** then create the branch and run **full** **[`@git-push`](../push/SKILL.md)** on the new branch—**order and branch-creation recipe** in **`start-workflow`**, not reimplemented here.
+- **Default:** publish via **`@git-push`** unless the user explicitly cancels publish.
+
+## Do not
+
+- Reimplement **`@git-main`** (fetch / reset / clean)—delegate to that skill.
+- Open or update a PR—use **`@gh-pr`** when ready.
+- Skip **`@git-push`** without user saying so (default is publish).
+
+**Expected context (one of):**
+- **Jira** — Ticket key (e.g. `TIS-503`, `PROJ-123`) or link. Branch name: lowercase with hyphen, e.g. `tis-503`, `proj-123`, or `tis-503-short-description` if a short description is given.
+- **GitHub issue** — Issue number or URL (e.g. `#42`, `https://github.com/owner/repo/issues/42`). Branch name: `42` or `42-short-slug` (e.g. `42-fix-login`) from the issue title if available.
+- **Activity / instruction** — Short phrase (e.g. "add user login", "refactor auth"). Branch name: **kebab-case** slug, e.g. `add-user-login`, `refactor-auth`. No spaces; keep it short.
+
+## On invoke
+
+*`@git-start`* — Execute **[`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-start-workflow)** end-to-end. If the user did not give a ticket, issue, or activity, ask: "What's the Jira ticket, GitHub issue, or activity for this branch?" If you are on **`main`** with **uncommitted changes**, **`@git-main`** will **not** stash: user must **commit**, **abort**, or **explicitly confirm trash** inside **`@git-main`**. Prefer **commit** before **`@git-start`** if they need to keep the work.
+
+## Branch name examples
+
+- **Jira** — input `TIS-503` → branch `tis-503`
+- **Jira + short description** — input `TIS-503 add login` → branch `tis-503-add-login`
+- **GitHub issue** — input `#42` → branch `42` or `42-fix-login` (from issue title when available)
+- **GitHub issue URL** — e.g. `…/issues/17` → branch `17` or `17-refactor-api`
+- **Activity phrase** — `add user login` → `add-user-login`; `Fix bug in parser` → `fix-bug-in-parser`
+
+## Notes
+
+*`@git-start`*
+- Run from the repo root. Prerequisites: **`git`** only. Optional: **`@gh-issue-view`** before this skill if the branch name should reflect the live GitHub issue title.
+- **Do not** run **`@git-main`** again in other skills when the user asked for **`@git-start`**—**`@git-start`** already includes it.
+- **`@git-main`** aligns local **`main`** to **`origin/main`** for this workflow.
+- Open-ended prompts (missing ticket, invalid branch name) follow **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)**.
+- To **only** refresh **local** **`main`** without a new branch, invoke **`@git-main`** alone—not **`@git-start`**. To publish **`main`**, run **`@git-push`** after **`@git-main`**.
+- For a PR: **`@gh-pr`** (**`@git-pull`** → **`@git-review`** → **`@git-push`** → PR text). For **verify only** (no push): **full** **`@git-review`**.

--- a/.agents/skills/git-stash/SKILL.md
+++ b/.agents/skills/git-stash/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: git-stash
+description: >-
+  Stash and restore local changes safely when you need a clean tree for other workflows. Supports push/list/show/pop/apply/drop/clear
+  with explicit confirmation before destructive stash deletions. No push, no PR, no branch creation.
+---
+
+**Normative workflow:** [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-stash-workflow).
+
+# Stash (save local work temporarily)
+
+Normative fences / full matrix: [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md).
+
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use `@git-commit` first when a savepoint should exist before parking edits in stash.
+2. Use before clean-tree workflows when local edits should be temporarily parked.
+3. Use this skill directly for stash lifecycle operations with explicit safety gates.
+4. Workflow gates: **`internal-read-git-workflows`** and **`internal-write-plan-skill-safety`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-read-git-workflows`
+2. `internal-write-plan-skill-safety`
+3. `internal-write-plan-structured-qa`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Resume with `@git-pull`, `@git-main`, or `@git-reset` after stashing if needed.
+2. Use `@git-review` after applying/pop to revalidate workspace state.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_STASH=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## Do
+
+- Execute **[`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-stash-workflow)** in order for stash save/inspect/restore operations.
+- Use **structured confirmation** before destructive stash operations (`drop`, `clear`) per **[`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)**.
+- Prefer explicit stash labels tied to issue/branch context so later recovery is predictable.
+
+## Do not
+
+- Use this skill as a replacement for commits when work is ready to keep.
+- Run **`@git-push`**, **`@gh-pr`**, or branch orchestration from here.
+- Clear stashes without a preview of stash entries and user confirmation.
+
+## On invoke
+
+*`@git-stash`* — If the user intent is not explicit (`save`, `pop`, `apply`, `drop`, `clear`, or `list`), ask which stash action they want first.
+
+## Notes
+
+- This skill complements **`@git-main`**, **`@git-pull`**, and **`@git-reset`** when the working tree must be clean.
+- For long-lived or shared work, prefer a normal commit on a branch over stash storage.

--- a/.agents/skills/git-tag/SKILL.md
+++ b/.agents/skills/git-tag/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: git-tag
+description: >-
+  Optional full @git-push before @git-main when origin exists and the repo is dirty, ahead of
+  upstream, or the user wants publish-first; then sync main, annotated yyyy-mm-dd tag, and push tag
+  to origin with fewer Q&A gates. Local tag only is an explicit opt-out.
+---
+
+# `@git-tag` (optional publish-first, sync main, label, push tag — confirm first)
+
+Normative fences / full matrix: [`internal-write-git-tag`](../../write/git/tag/SKILL.md).
+
+
+**Public.** **Goal:** **Persist** an **annotated** tag **`refs/tags/${TAG}`** (default **`${TAG}`** = **`${DATE}`**, **ISO yyyy-mm-dd**, local timezone) at **`GIT_TAG_TARGET`** (default **`HEAD`**) after synchronizing local **`main`**, then **publish** that tag to **`origin`** when **`origin`** exists and the user confirms—only after **[`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)** and explicit **Proceed**. **Local tag only** is an explicit **opt-out**. This skill **owns** all **tag mutations** (**keep vs replace** local, **skip vs force** remote tag push). **`@git-zip`** does **not** run tag mutating fences; it **hands off** here when a tag must be created or repointed, then exports a **`.zip`** via **`internal-write-git-zip`**. **Collisions:** if the tag **already exists locally**, confirm **keep vs replace** before mutations. If **`origin`** already has the tag and the user wants **push**, confirm **skip vs force**. If **`origin`** is **missing**, **local tag only** still succeeds.
+
+**Normative shell** — **[`internal-write-git-tag`](../../write/git/tag/SKILL.md)**. **Tag push** is **`git push`** — **[`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md)** (**online mutation**): **Goal + summary + Proceed** before any **Push** block (normal or **force**).
+
+**Public vs internal tree (this skill as root)**
+
+- **Public children (orchestration):** **[`@git-push`](../push/SKILL.md)** (**conditional** — run **full** hand-off when **publish-first** read-only checks fire; see **On invoke**), **[`@git-main`](../main/SKILL.md)** (sync local `main` to canonical remote), **[`@git-commit`](../commit/SKILL.md)** (**optional** — when the tree is dirty, **`origin` is missing** or the user needs a savepoint **without** running **`@git-push`** first).
+- **Optional user-run sibling:** **[`@git-reset`](../reset/SKILL.md)** when you explicitly need **hard discard** alignment on the current branch before switching to `main`—invoke it yourself; this skill does **not** embed reset fences (reset stays a **leaf** public skill).
+- **Internal leaves:** **`internal-write-git-tag`** (Create / Replace / Push fences), plus **`internal-write-plan-structured-qa`**, **`internal-write-plan-skill-safety`** in the Execution batch below.
+
+---
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use **`@git-main`** alignment context when the tag should be anchored from synced **`main`**.
+2. Use **`@git-push`** when branch work may need verify+publish **before** tagging (see **On invoke** publish-first check).
+3. Tag **mutation** fences: **`internal-write-git-tag`** (names only; Execution batch runs them).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file):
+
+1. `internal-write-plan-structured-qa`
+2. `internal-write-git-tag`
+3. `internal-write-plan-skill-safety`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use **`@git-zip`** when the tagged tree should be exported as a **GitHub-style** **`.zip`** (after this skill completes; **`@git-zip`** orchestrates **`internal-write-git-zip`** only for export).
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_TAG=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## On invoke
+
+1. **Preconditions** — Run **Preconditions (read-only)** in **`internal-write-git-tag`**. If **`git rev-parse`** fails, **stop**. Default **`TAG="${DATE}"`**; if the user chose a different tag name in **chat** for this run, restate it and ensure the agent **`export TAG=...`** before **Inspect** / **Create** / **Replace** / **Push** blocks so fences resolve **`TAG="${TAG:-$DATE}"`**.
+2. **Branch gate** — Read current branch first. If not on `main`, run structured Q&A: **Abort**, **Commit current branch work first (`@git-commit`) then continue**, or **Continue without commit**.
+3. **Publish-first read-only check** — Evaluate **without mutating**: does **`git remote get-url origin`** succeed? Is **`git status --short`** non-empty **or** (when upstream exists) is **`HEAD`** **ahead** of **`@{u}`** (`git rev-list --left-right --count HEAD...@{u}` left count > 0) **or** did the user explicitly ask to **publish before tag**?
+   - **If `origin` exists** **and** any of the above is true → run **full [`@git-push`](../push/SKILL.md)** once **before** **`@git-main`**. If **`@git-push`** fails, **stop** (do not tag on a failed publish leg).
+   - **Else** → skip **`@git-push`** with a one-line reason (clean / no remote / nothing ahead).
+4. **Preflight savepoint (when step 3 skipped)** — If the working tree is still dirty and the user needs a local savepoint before syncing **`main`**, run **`@git-commit`** (no push).
+5. **Sync prelude** — Run full **[`@git-main`](../main/SKILL.md)** once so local `main` matches canonical remote **`main`** in this standalone workflow.
+6. **Read-only inventory** — Run **Inspect local tag**, and if **`origin`** resolves run **Inspect remote tag**; if **`origin`** is missing, note tag push is unavailable without adding a remote (not a hard error for local-only). Then run **Inspect previous reachable tag** and **Inspect commits since previous tag**.
+7. **Goal line** — One sentence (e.g. anchor synced `main` **`HEAD`** with **`TAG`**, **recommended:** publish the tag to **`origin`** when the remote exists).
+8. **Summary block** (**structured-qa** **§1a**) — Bullets: **`TOP`**, current **`BRANCH`**, **`TAG`**, **`GIT_TAG_TARGET`** (default **`HEAD`**), local exists/missing (+ short SHA if present), remote line or “no **`origin`**” / “remote tag missing”, previous tag marker, and a capped commit list (**`${PREV_TAG}..HEAD`** when available).
+
+**Post-merge note:** If the tag must point at **released** **`main`**, ensure **`origin/main`** already contains the merge (PR merged or equivalent) **before** step 5—otherwise **`@git-main`** aligns to **`main`** without your local feature commits.
+
+---
+
+## Q&A (fewer gates)
+
+### Gate 1 — Tag publish intent
+
+**Question:** “Publish tag to **`origin`** when the remote exists (**recommended**), or **local tag only**?”
+
+- **`Local tag + push to origin`** (**recommended** when **`origin`** exists) — After **Gate 4 — Proceed**, ensure local tag then push per **Gate 3** / non-force as applicable. If **`origin`** is **missing** and the user chose this option, run structured triage per **`structured-qa` §8**: **Abort**, **Continue as local tag only**, or **Pause and configure `origin`, then retry**.
+- **`Local tag only`** — Local tag steps only; **never** push the tag.
+- **`Cancel`**
+
+### Gate 2 — Local tag already exists (skip if inspect shows **local:missing**)
+
+**Question:** “Tag exists locally. **Keep** or **repoint** to **`GIT_TAG_TARGET`**?”
+
+- **`Keep existing`** — No local tag mutation this run (skip **Create** / **Replace**).
+- **`Replace — repoint tag (force local)`** — After **Gate 4**, run **Replace local annotated tag (force)** in **`internal-write-git-tag`**.
+- **`Cancel`**
+
+### Gate 3 — Remote tag + push (skip unless Gate 1 = **`Local tag + push to origin`** **and** **Inspect remote tag** shows **`refs/tags/${TAG}`**)
+
+**Question:** “Remote already has this tag. **Skip push** or **force push**?”
+
+- **`Skip push`**
+- **`Force push — overwrite remote tag`** — After **Gate 4**, run **Push one tag to `origin` (force)**.
+- **`Cancel`**
+
+If the remote **does not** have the tag yet, **skip Gate 3**; after local ensure, use **Push one tag to `origin`** (non-force) when Gate 1 included push.
+
+### Gate 4 — Proceed (when Gate 1 ≠ **`Cancel`** and no prior **Cancel**)
+
+Restate **`TAG`**, **`GIT_TAG_TARGET`**, which **Create** / **Replace** / **Push** / **Push (force)** steps will run, and **`origin`** URL if pushing.
+
+**Question:** “Run selected tag actions now?” — **`Cancel`** / **`Proceed`**
+
+**`Proceed`** — Run **`internal-write-git-tag`** in order (skip steps the user declined):
+
+1. **Local** — If **local missing**: **Create annotated tag only if missing**. If **local exists** and **Gate 2** = **Replace**: **Replace local annotated tag (force)**. If **local exists** and **Gate 2** = **Keep**: skip local mutating blocks.
+2. **Push** (only when Gate 1 = **`Local tag + push to origin`** and **`origin`** exists) — If **Gate 3** = **Force push**: **Push one tag to `origin` (force)**. Else if **Gate 3** = **Skip push**: skip. Else (**remote tag missing**): **Push one tag to `origin`**.
+
+---
+
+## Do
+
+- Use **date-only** tag names by default: **`yyyy-mm-dd`**, aligned with **`internal-write-git-tag`** defaults.
+- Verify **`origin`** with **read-only** **`git remote get-url origin`** before any **push** summary claims a publish path.
+- Run **Gate 2** whenever the local tag exists **before** **Gate 4**, so the user picks **keep** vs **replace**.
+- When **`@git-push`** ran in **On invoke** step 3, do **not** duplicate branch publish logic here—this skill handles **tag** push only after **`@git-main`**.
+
+## Do not
+
+- Run **Replace local** or **Push … (force)** without an explicit user choice in **Gate 2** / **Gate 3**.
+- Skip the ordered prelude (**branch gate → optional `@git-push` → optional `@git-commit` → `@git-main`**) unless the user explicitly asks for a different flow.
+- **Embed** runnable **`bash`** fences in **this** file beyond what authoring needs — use **`internal-write-git-tag`** only.
+
+---
+
+## Verification
+
+- [ ] Preconditions and default **`TAG`** (or override) were shown.
+- [ ] Prelude (**publish-first `@git-push`**, optional **`@git-commit`**, **`@git-main`**) completed or explicitly skipped with reason.
+- [ ] **`origin`** was checked before offering tag **push**.
+- [ ] Previous tag + commit summary was shown before **Gate 4**.
+- [ ] **Gate 2** ran when local tag pre-existed; **Gate 3** ran when push + remote tag existed.
+- [ ] **Gate 4** **Proceed** / **Cancel** recorded before **Create** / **Replace** / **Push** blocks.
+
+---
+
+## See also
+
+- [`internal-write-git-tag`](../../write/git/tag/SKILL.md) — **Run** blocks (**mutations**; **`@git-tag`** only)
+- [`@git-push`](../push/SKILL.md) — optional **publish-first** prelude when checks fire
+- [`@git-commit`](../commit/SKILL.md) — local savepoint when **`@git-push`** did not run and the tree is dirty
+- [`@git-main`](../main/SKILL.md) — align local `main` before tagging
+- [`@git-reset`](../reset/SKILL.md) — optional **user-run** hard alignment (**leaf** skill)
+- [`@git-zip`](../zip/SKILL.md) — **`@git-tag`** then **`internal-write-git-zip`**
+- [`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)
+- [`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md)

--- a/.agents/skills/git-zip/SKILL.md
+++ b/.agents/skills/git-zip/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: git-zip
+description: >-
+  Orchestrate @git-tag (when a tag is needed) then export a GitHub-style .zip via internal-write-git-zip
+  from refs/tags/TAG only, or export from an existing tag after read-only verification. No tag mutations
+  in this skill. Runnable export blocks: internal-write-git-zip.
+---
+
+# `@git-zip` (label via `@git-tag`, then export `.zip` — confirm first)
+
+Normative export fences: [`internal-write-git-zip`](../../write/git/zip/SKILL.md). Read-only tag checks (when verifying an existing tag): same **Inspect** shapes as [`internal-write-git-tag`](../../write/git/tag/SKILL.md) — **no** Create / Replace / Push from this skill.
+
+
+**Public.** **Goal:** Produce **one** **`.zip`** file **like GitHub “Source code (zip)”** — **`git archive`** of **tracked files** at **`refs/tags/${TAG}`** only (default **`TAG=${DATE}`**, **no** **`.git`**, **no** untracked files), basename **`${PROJECT}-${DATE}.zip`**. This skill **orchestrates only**: hand off **tag create/replace/push** to **[`@git-tag`](../tag/SKILL.md)**, then run **`internal-write-git-zip`**. It does **not** run **`internal-write-git-tag`** **mutating** fences.
+
+**Depends on [`@git-tag`](../tag/SKILL.md)** whenever the tag must be created, repointed, or pushed—**`@git-zip`** does not duplicate **`@git-tag`** Q&A or tag mutation steps.
+
+**Normative shell** — **`git archive`**: **[`internal-write-git-zip`](../../write/git/zip/SKILL.md)**. Naming and flow: **[`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-zip-workflow)**. **Writes** outside the repo root by default (parent directory)—**[`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md)** (**writes outside git workspace root**): **Proceed** must restate exact paths.
+
+**Full clone backup** (includes **`.git`**) is **not** this skill’s default — see **`internal-write-git-zip`** **Optional full-tree backup** only if the user explicitly wants it.
+
+---
+
+## Before batch (public, optional, sequential)
+
+Run these only when they improve context for this invocation:
+
+1. Use **`@git-tag`** first when the export should follow a **new or repointed** date tag on synced **`main`**.
+2. Use when the user already has **`refs/tags/${TAG}`** and only needs **read-only** verification plus **`.zip`** export.
+3. Export runnable blocks: **`internal-write-git-zip`** only (names only; Execution batch runs them after **Proceed**).
+
+## Execution batch (internal, sequential)
+
+Run this internal sequence in order (no runnable command fences in this public file). **Do not** list **`internal-write-git-tag`** for **mutations**—tag writes run only under **`@git-tag`**.
+
+1. `internal-write-plan-structured-qa`
+2. `internal-write-git-zip`
+3. `internal-read-git-workflows`
+4. `internal-write-plan-skill-safety`
+
+## After batch (public, optional, sequential)
+
+Choose follow-up based on outcome:
+
+1. Use release or handoff workflows that consume the produced **`.zip`** artifact.
+2. If the tag was not pushed and should be on **`origin`**, run **`@git-tag`** (or complete an interrupted **`@git-tag`** run) before relying on a remote **`.zip`** mirror.
+
+## Q&A bypass ENV
+
+- `SKIP_QA_GIT_ZIP=true` bypasses routine Q&A for this specific public skill.
+- Default behavior is unset/false, which keeps normal Q&A active.
+- Shared `SKIP_QA_WRITE=true` can bypass routine write-flow Q&A where the owning workflow allows it.
+- High-risk or destructive confirmations still require explicit user confirmation.
+
+## On invoke
+
+1. **Preconditions** — Run **Preconditions (read-only)** in **`internal-write-git-zip`** for **`TOP`**, **`PROJECT`**, **`DATE`**. Set **`DEST_DIR`** (default: parent of **`TOP`**). Set **`TAG="${DATE}"`** unless the user overrides **`TAG`** in chat; restate **`refs/tags/${TAG}`** as the export ref.
+2. **Remote (optional)** — Run **Check `origin` exists** from **`internal-write-git-tag`** when you need **Inspect remote tag** or **Fetch remote tags** for the summary. Skip if the user will run **`@git-tag`** immediately (that skill performs its own **`origin`** checks).
+3. **Tag inventory** — Run **Inspect local tag** for **`${TAG}`**. On the **existing-tag** path only, optionally run **Inspect remote tag** after **Check `origin` exists** succeeds.
+4. **Summary block** (**structured-qa §1a**) — include **`TOP`**, **`DEST_DIR`**, default zip path **`${DEST_DIR}/${PROJECT}-${DATE}.zip`**, **`ARCH_REF=refs/tags/${TAG}`**, local tag line, and (if checked) whether the tag exists on **`origin`**.
+
+---
+
+## Q&A (required order)
+
+### Round 0 — Export path
+
+**Question:** “How should **`@git-zip`** obtain **`refs/tags/${TAG}`** before export?”
+
+- **`Run @git-tag` then export `.zip`** (**default**) — Hand off fully to **`@git-tag`** (optional publish-first **`@git-push`**, **`@git-main`**, label, tag-push per that skill’s gates). After it completes, set **`ARCH_REF=refs/tags/${TAG}`** and run **Plain archive** from **`internal-write-git-zip`**.
+- **`Export .zip from existing tag`** — User confirms **`TAG`** (explicit name; default **`${DATE}`**). Run **Inspect local tag** (and optional **Inspect remote tag**); **abort** if local tag is missing unless the user switches to **`Run @git-tag`**. **No** Create / Replace / Push from this skill. Set **`ARCH_REF=refs/tags/${TAG}`** and run **Plain archive** from **`internal-write-git-zip`**.
+- **`Abort`**
+
+### Round 1 — Proceed
+
+Restate **`ARCH_REF`** (always **`refs/tags/${TAG}`**) and the zip path.
+
+**Question:** “Ready to export **`.zip`**?”
+
+- **`Abort`** — **Stop**; no export write.
+- **`Review`** — Return to the **Summary block** (**On invoke** §4); adjust **`DEST_DIR`**, **`TAG`**, or Round 0 choice **without** running **Plain archive** yet.
+- **`Proceed`** —
+  - **`Run @git-tag` then export `.zip`** — Run **`@git-tag`** first. Then set **`ARCH_REF=refs/tags/${TAG}`** and run **Plain archive** from **`internal-write-git-zip`**.
+  - **`Export .zip from existing tag`** — Set **`ARCH_REF=refs/tags/${TAG}`** after read-only verification. Run **Plain archive** from **`internal-write-git-zip`**.
+
+---
+
+## Do
+
+- Show **real example paths** before **Proceed**.
+- Follow **structured-qa** **§1a** → **§2** → **§5**.
+- Keep **`ARCH_REF`** as **`refs/tags/${TAG}`** for **`@git-zip`** public paths.
+
+## Do not
+
+- **Branch push**, **commits**, **tag create/replace/push**, or **GitHub PR** mutations from this skill—use **`@git-tag`** / **`@git-push`** / **`@gh-pr`** as appropriate.
+- **Embed** runnable **`bash`** fences here — use **`internal-write-git-zip`** only for **`git archive`** (and optional full-tree backup there if explicitly requested).
+- Default to **full-tree `zip` including `.git`** unless the user explicitly asked for **Optional full-tree backup** in **`internal-write-git-zip`**.
+
+---
+
+## Verification
+
+- [ ] User saw **example path** for **`.zip`**.
+- [ ] **`ARCH_REF`** is **`refs/tags/${TAG}`** (matches Round 0 choice).
+- [ ] Any **tag mutation** ran under **`@git-tag`**, not from **`@git-zip`**.
+- [ ] **Proceed** was captured before **Plain archive** (including after any **Review** loop).
+
+---
+
+## See also
+
+- [`@git-tag`](../tag/SKILL.md) — **tag-only** flow (**mutations** + **`@git-main`** prelude)
+- [`internal-write-git-zip`](../../write/git/zip/SKILL.md) — **`git archive`** (**export** leaf)
+- [`internal-write-git-tag`](../../write/git/tag/SKILL.md) — read-only **Inspect** / **Check `origin`** shapes for verification; **mutations** only when **`@git-tag`** runs these blocks
+- [`internal-read-git-workflows`](../../read/git/workflows/SKILL.md#git-zip-workflow)
+- [`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md)
+- [`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md)

--- a/.agents/skills/internal-read-gh-issue-dedupe-dedupe-checklist/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-dedupe-dedupe-checklist/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: internal-read-gh-issue-dedupe-dedupe-checklist
+description: >-
+  Read-only: issue dedupe checklist (defers list shapes to internal-read-gh-issue-list). Parent internal-read-gh-issue-dedupe.
+---
+
+# Issue dedupe checklist
+
+Used by **`internal-read-gh-issue-dedupe`** and **`@gh-issues`** / **`@gh-issue-review`**.
+
+1. **List / search open issues** — use **only** the **List / search** and **Search** sections of [`internal-read-gh-issue-list`](../issue-list/SKILL.md) (`gh issue list`, `gh search issues`, flags, limits). **Do not** invent alternate **`gh`** shapes in this checklist.
+2. **Single candidate (default)** — Compare **titles** and first lines of **bodies** for near-duplicates against that inventory; note issue numbers. Output: **safe to create** / **likely duplicate #n** / **ambiguous — user must choose** (no **`gh`** writes in this phase).
+3. **Multi-candidate (`@gh-issues` multi-intent only)** — (a) **Theme list** — stable ids, working title, one-line intent per theme (after clustering in the router). (b) **Single inventory** — reuse the issue set from step 1 for every theme; do **not** repeat a full list pass unless a theme needs an extra targeted **`gh search issues`** (large backlog). (c) **Per-theme compare** — same title/body skim as step 2, independently per row. (d) **Aggregate user choice** — table: theme → verdict → proposed **edit #n** or **create**; flag rows that should **merge** before mutation (same **`likely_duplicate #n`** or same root cause). No **`gh`** writes in this phase.
+4. **`@gh-issue-review`** — same list/compare mechanics for **reshape** context; when reviewing **`#N`**, ignore **self** on **`#N`** when interpreting overlaps (see **`internal-read-gh-issue-dedupe`** reshape note).

--- a/.agents/skills/internal-read-gh-issue-dedupe/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-dedupe/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: internal-read-gh-issue-dedupe
+description: >-
+  Read-only: list/search open issues, flag near-duplicates vs one or more candidate title+body rows; no gh writes.
+  Pasteable checklist: ./dedupe-checklist/SKILL.md. Callers: @gh-issues, @gh-issue-review.
+---
+
+# Internal: Issue dedupe (`internal-read-gh-issue-dedupe`)
+
+**Read-only library.** Compare **one or more candidate** issues (each: title + summary lines) to **open** issues using **`gh`**. **No** `gh issue create`, **no** comments, **no** closes.
+
+**Consumers:** **`@gh-issues`**, **`@gh-issue-review`** (overlap pass), optionally humans.
+
+## Do
+
+1. Follow **[`dedupe-checklist/SKILL.md`](./dedupe-checklist/SKILL.md)** (**§1** defers all **`gh issue list`** / **`gh search issues`** shapes to **`internal-read-gh-issue-list`**—**do not** duplicate flags here).
+2. Emit a short verdict **per candidate**: **`safe_to_create`** | **`likely_duplicate #n`** | **`ambiguous`** (list candidate numbers + one-line reason each). For a **single** candidate, one verdict is enough.
+
+**Reshape-review (optional caller: `@gh-issue-review`).** When the **candidate** text describes **refining existing issue `#N`**, treat a hit on **`#N` itself** as **self**, not a duplicate signal—only **other** numbers are **peer overlaps** or **likely duplicate** targets. Verdict labels stay the same; interpret **`likely_duplicate #m`** as “**`#m`** collides with the reshaped scope.”
+
+## `@gh-issues` orchestration order
+
+Use this sequence when `@gh-issues` routes create-or-update behavior.
+
+### Single candidate (default)
+
+1. **List / search** — run `@gh-issue-list` (or equivalent via [`internal-read-gh-issue-list`](../issue-list/SKILL.md) + [`dedupe-checklist/SKILL.md`](./dedupe-checklist/SKILL.md)) to inventory open issues before any write.
+2. **Dedupe verdict** — evaluate candidate title + body summary through this skill and return `safe_to_create` | `likely_duplicate #n` | `ambiguous`.
+3. **Branch**
+   - `likely_duplicate #n` (or `ambiguous` resolved to a single `#n`) -> treat as update path in `@gh-issues`.
+   - `safe_to_create` -> continue create path in `@gh-issues`.
+
+### Multi-candidate (optional `@gh-issues`)
+
+After **`@gh-issues`** has **partitioned themes** (chat and/or **[`internal-read-plan-parts`](../../plan/parts/SKILL.md)** + plan hub files):
+
+1. **List / search once** — same inventory pass as single-candidate step 1; reuse the same open-issue set for every theme. Optionally add a focused **`gh search issues`** query per theme only when the default list is too large to compare fairly.
+2. **Per-theme verdict** — for each theme, compare its working title + one-line intent to that inventory; emit `safe_to_create` | `likely_duplicate #n` | `ambiguous` **per row**. **Never** skip this for a theme that will end in **create**.
+3. **Merge similar themes before publish** — when two rows point at the same **`likely_duplicate #n`** or are clearly the same root cause, default to **one** issue (merge rows in the summary table); user confirms.
+4. **Aggregate** — hand off a table (theme → verdict → proposed **edit #n** or **create**) to **`@gh-issues`** for structured Q&A and one **Proceed — batch** per **`internal-write-plan-structured-qa`**.
+
+If clustering collapses to **one** theme, use **only** the single-candidate subsection above.
+
+Optional first pass: run `@gh-issue-review` on an existing issue when the body is weak and needs codebase + overlap analysis before deciding update vs create.
+
+## Do not
+
+- Mutate GitHub state.
+- Duplicate **`gh issue list`** / **`gh search issues`** recipes outside **`internal-read-gh-issue-list`** — the **checklist** template links there too.
+
+## See also
+
+- **[`internal-read-gh-issue-list`](../issue-list/SKILL.md)** — normative list/search **`gh`** lines.
+- [`@gh-issues`](../../../gh/issues/SKILL.md) · [`@gh-issue-review`](../../../gh/issues/review/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/internal-read-gh-issue-dedupe/dedupe-checklist/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-dedupe/dedupe-checklist/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: internal-read-gh-issue-dedupe-dedupe-checklist
+description: >-
+  Read-only: issue dedupe checklist (defers list shapes to internal-read-gh-issue-list). Parent internal-read-gh-issue-dedupe.
+---
+
+# Issue dedupe checklist
+
+Used by **`internal-read-gh-issue-dedupe`** and **`@gh-issues`** / **`@gh-issue-review`**.
+
+1. **List / search open issues** — use **only** the **List / search** and **Search** sections of [`internal-read-gh-issue-list`](../issue-list/SKILL.md) (`gh issue list`, `gh search issues`, flags, limits). **Do not** invent alternate **`gh`** shapes in this checklist.
+2. **Single candidate (default)** — Compare **titles** and first lines of **bodies** for near-duplicates against that inventory; note issue numbers. Output: **safe to create** / **likely duplicate #n** / **ambiguous — user must choose** (no **`gh`** writes in this phase).
+3. **Multi-candidate (`@gh-issues` multi-intent only)** — (a) **Theme list** — stable ids, working title, one-line intent per theme (after clustering in the router). (b) **Single inventory** — reuse the issue set from step 1 for every theme; do **not** repeat a full list pass unless a theme needs an extra targeted **`gh search issues`** (large backlog). (c) **Per-theme compare** — same title/body skim as step 2, independently per row. (d) **Aggregate user choice** — table: theme → verdict → proposed **edit #n** or **create**; flag rows that should **merge** before mutation (same **`likely_duplicate #n`** or same root cause). No **`gh`** writes in this phase.
+4. **`@gh-issue-review`** — same list/compare mechanics for **reshape** context; when reviewing **`#N`**, ignore **self** on **`#N`** when interpreting overlaps (see **`internal-read-gh-issue-dedupe`** reshape note).

--- a/.agents/skills/internal-read-gh-issue-description-issue-body-skeleton/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-description-issue-body-skeleton/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-gh-issue-description-issue-body-skeleton
+description: >-
+  Read-only: GitHub issue body markdown skeleton. Parent internal-read-gh-issue-description.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for issue body skeleton guidance.
+

--- a/.agents/skills/internal-read-gh-issue-description-review-report/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-description-review-report/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-gh-issue-description-review-report
+description: >-
+  Read-only: issue review / reshape report scaffold. Parent internal-read-gh-issue-description.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for issue review-report guidance.
+

--- a/.agents/skills/internal-read-gh-issue-description-work-plan/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-description-work-plan/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-gh-issue-description-work-plan
+description: >-
+  Read-only: local plan scaffold embedding an issue. Parent internal-read-gh-issue-description.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for issue work-plan guidance.
+

--- a/.agents/skills/internal-read-gh-issue-description/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-description/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: internal-read-gh-issue-description
+description: >-
+  Read-only: discover GitHub/local issue templates vs pack body skeleton; when merge would materially reshape
+  repo template, structured AskQuestion (keep / blend / pack). Caller: gh-issues. Does not run gh.
+---
+
+# Internal: Issue description (templates vs pack)
+
+**Read-only library.** Run **after** **[`internal-read-gh-issue-dedupe`](../issue-dedupe/SKILL.md)** when the user wants a **tracked** issue, **before** drafting final **title/body** for the chosen create-or-edit path in **`@gh-issues`**. **Pack pasteable:** **[`issue-body-skeleton/SKILL.md`](./issue-body-skeleton/SKILL.md)**.
+
+**This library does not** run **`gh`** or **`AskQuestion`**. The **caller** runs **AskQuestion** when this file says **material reshape** applies, then **`gh`** after **`internal-write-plan-skill-safety`** confirm.
+
+---
+
+## 1. Discover issue templates
+
+### Step A — `gh repo view` (required when `gh` works)
+
+The **caller** executes the **`gh repo view … --json issueTemplates`** line(s) from **[`internal-read-gh-repo-forms-json`](../repo-forms-json/SKILL.md)** § **Issue templates** (default row unless the caller already chose the **upstream** row for fork parity). **Do not** duplicate those commands here.
+
+**Parse** **`issueTemplates`** (field may be **absent** on older **`gh`** builds—treat as empty and continue to **Step B**).
+
+- **One or more YAML/form** templates (`.github/ISSUE_TEMPLATE/**`) may appear as **names** only—if **no** usable **markdown body**, continue to **Step B**.
+- If **API returns usable markdown** for **exactly one** template → set **`$ISSUE_TEMPLATE_SOURCE`** = `github-api`, **`$ISSUE_TEMPLATE_BODY`** = that body.
+- **Two or more** usable markdown bodies → **template selection Q&A** per **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** (one option per template + **“Pack skeleton only”** → empty body, pack shape only).
+- **Empty / missing** → **Step B**.
+
+### Step B — Local files (when Step A yields nothing usable)
+
+Search the **current** clone:
+
+- **`.github/ISSUE_TEMPLATE.md`**, **`.github/issue_template.md`**
+- **`.github/ISSUE_TEMPLATE/*.md`** (ignore **`config.yml`** for body text)
+- **`docs/issue_template.md`** (optional convention)
+
+Use **`git ls-files`** + glob.
+
+- **Exactly one** **`.md`** → **`$ISSUE_TEMPLATE_SOURCE`** = `local`; **`$ISSUE_TEMPLATE_BODY`** = contents.
+- **Two or more** → **template selection Q&A** (same as PR **multiple templates** pattern).
+- **None** → **`$ISSUE_TEMPLATE_SOURCE`** = `canonical`; **`$ISSUE_TEMPLATE_BODY`** = **empty**.
+
+### Step C — Pack only
+
+**`$ISSUE_TEMPLATE_SOURCE`** = **`canonical`**; **`$ISSUE_TEMPLATE_BODY`** = **empty**. Draft body from **[`issue-body-skeleton/SKILL.md`](./issue-body-skeleton/SKILL.md)** and quality-check against **[`internal-read-gh-issue-spec`](../issue-spec/SKILL.md)**.
+
+---
+
+## 2. Material reshape vs pack skeleton
+
+When **`$ISSUE_TEMPLATE_BODY`** is **non-empty**, compare its **headings / required sections** to the pack **`body-skeleton`**. If applying the pack skeleton would **replace** the repo template’s top-level structure (e.g. force **Context / Proposal** where the template uses **Bug report** sections), treat as **material**.
+
+**Before** merging shapes, the **caller** runs **AskQuestion** (short labels), **separate** from the final **`gh issue create`** / **`gh issue edit`** confirm:
+
+1. **Keep repo template** — substance only inside existing sections.
+2. **Blend** — keep repo headings; add **non-duplicative** pack sections the template omits (minimal).
+3. **Pack skeleton** — draft from **`body-skeleton.md`**; ignore repo template **shape** (keep links/checklists from repo only if user asks in chat).
+
+Set **`$ISSUE_BODY_SHAPE_MODE`** to **`keep`** | **`blend`** | **`pack`** for the caller.
+
+When **`$ISSUE_TEMPLATE_SOURCE`** is **`canonical`**, set **`$ISSUE_BODY_SHAPE_MODE`** = **`pack`** with **no** extra modal.
+
+---
+
+## 3. Hand off
+
+Return to **`@gh-issues`**: draft **title** per **[`TITLE_LINE.md`](../pr-content/TITLE_LINE.md)**; draft **body** using **`$ISSUE_TEMPLATE_BODY`**, **`$ISSUE_TEMPLATE_SOURCE`**, and **`$ISSUE_BODY_SHAPE_MODE`**; then run **Goal** + **Proceed** before `gh`.
+
+## See also
+
+- **[`internal-read-gh-repo-forms-json`](../repo-forms-json/SKILL.md)** — **`gh repo view --json`** shapes for templates.
+- **[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** — PR-side discovery + merge rules (mirror concepts).
+- **[`internal-read-gh-issue-dedupe`](../issue-dedupe/SKILL.md)** — duplicate search before writes.
+- **[`internal-read-gh-issue-labels`](../issue-labels/SKILL.md)** — optional label proposals after title/body exist.

--- a/.agents/skills/internal-read-gh-issue-description/issue-body-skeleton/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-description/issue-body-skeleton/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-gh-issue-description-issue-body-skeleton
+description: >-
+  Read-only: GitHub issue body markdown skeleton. Parent internal-read-gh-issue-description.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for issue body skeleton guidance.
+

--- a/.agents/skills/internal-read-gh-issue-description/review-report/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-description/review-report/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-gh-issue-description-review-report
+description: >-
+  Read-only: issue review / reshape report scaffold. Parent internal-read-gh-issue-description.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for issue review-report guidance.
+

--- a/.agents/skills/internal-read-gh-issue-description/work-plan/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-description/work-plan/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-gh-issue-description-work-plan
+description: >-
+  Read-only: local plan scaffold embedding an issue. Parent internal-read-gh-issue-description.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for issue work-plan guidance.
+

--- a/.agents/skills/internal-read-gh-issue-labels-label-decorate/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-labels-label-decorate/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: internal-read-gh-issue-labels-label-decorate
+description: >-
+  Read-only: gh label list/match/create command shapes. Parent internal-read-gh-issue-labels.
+---
+
+# Issue labels — decorate (examples)
+
+Used by **[`internal-read-gh-issue-labels`](./SKILL.md)** and **`@gh-issues`**.
+
+**Inventory (read-only):**
+
+```bash
+gh label list --json name,description,color --limit 200
+```
+
+---
+
+## Example A — Map to existing labels
+
+**Input (chat):** “Add label guidance for skills pack; touch `skills/read/gh/` and templates.”
+
+**Draft title:** `Document issue label heuristics for skill repos`
+
+**Draft body (excerpt):** “… acceptance: label list command, 0–3 labels, confirm before `gh label create` …”
+
+**Step:** Existing labels include `documentation`, `enhancement`.
+
+**Output (proposal table):**
+
+| Candidate | Action | GitHub label |
+| --- | --- | --- |
+| docs / templates | reuse | `documentation` |
+| feature work | reuse | `enhancement` |
+
+**Attach (preview, not run by agent until confirm):** use the canonical create shapes in **[`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md#create-issue-after-proceed)** and pass `--label "documentation,enhancement"` after the structured proceed gate.
+
+---
+
+## Example B — One new label, then attach
+
+**Input:** “Track flaky CI on `gh-pr` skill; file an issue.”
+
+**Draft title:** `Flaky CI when running gh-pr orchestration tests`
+
+**Existing labels:** `bug`, `ci` (no `area:gh`).
+
+**Step:** Propose **`ci`** + **`bug`**; suggest **`area:gh`** as **new** (repo has other `area:*` labels).
+
+**Output:**
+
+| Candidate | Action | Notes |
+| --- | --- | --- |
+| CI | reuse | `ci` |
+| defect | reuse | `bug` |
+| domain | **create** | `gh label create area:gh --color ededed --description "GitHub PR CLI skills"` → **structured confirm** first |
+
+**Then create issue:** use the same canonical create shapes in **[`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md#create-issue-after-proceed)** with `--label "ci,bug,area:gh"` after confirm.
+
+---
+
+## Do not
+
+- Attach **more than three** labels without explicit user ask.
+- Create labels that only duplicate an existing name with different spelling.

--- a/.agents/skills/internal-read-gh-issue-labels/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-labels/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: internal-read-gh-issue-labels
+description: >-
+  Read-only: list repo labels, propose 0–3 candidates from title/body, match or suggest gh label create; command
+  shapes in label-decorate/SKILL.md. Caller: gh-issues. Does not run gh writes or AskQuestion.
+---
+
+# Internal: Issue labels (`internal-read-gh-issue-labels`)
+
+**Read-only library.** After **[`internal-read-gh-issue-description`](../issue-description/SKILL.md)** has set shape and you have a **draft title + body** (or the user supplied them), use this playbook to propose **GitHub labels**. **No** `gh label create`, **no** `gh issue create` / `edit` flags—**callers** run **AskQuestion** / structured confirm per **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)**.
+
+**Pack artifact:** **[`label-decorate/SKILL.md`](./label-decorate/SKILL.md)**.
+
+**Consumers:** **`@gh-issues`**, optionally humans.
+
+---
+
+## 1. Inventory existing labels
+
+Run the **Inventory (read-only)** command block in **[`label-decorate/SKILL.md`](./label-decorate/SKILL.md)** (same auth as other `gh` skills).
+
+Treat **exact name matches** (case-sensitive per GitHub) as **reuse**. Prefer **existing** labels over inventing new ones.
+
+---
+
+## 2. Propose 0–3 candidates
+
+From **title + first paragraph / acceptance criteria** in the body:
+
+1. **Area / domain** — e.g. paths `skills/gh/`, `docs/` → tokens like `area:skills`, `area:docs` only if the repo already uses that pattern; otherwise use **one** short area token consistent with existing names.
+2. **Type** — `bug`, `enhancement`, `documentation` only if an **existing** label matches or the repo uses GitHub defaults.
+3. **Stop at three** — do not spam labels; omit if nothing fits.
+
+**Naming hygiene** (new labels only—see **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** §2 for “short label” spirit):
+
+- Lowercase, **hyphens** not spaces; **no** emoji in label names.
+- Prefer **one** new label over three near-duplicates.
+
+---
+
+## 3. Match vs create
+
+For each **candidate**:
+
+- **Fuzzy match** an existing label (substring, plural/singular, `docs` vs `documentation`) → **map** to the existing name in the proposal table.
+- **No reasonable match** → mark **`needs_create`** with a one-line **description** and a neutral **`--color`** (e.g. `ededed` or repo palette if documented).
+
+**Caller:** If any **`needs_create`**, summarize **`gh label create NAME --color … --description "…"`** and obtain **structured confirm** before running **`gh label create`**. Then pass **`--label a,b`** on **`gh issue create`** or **`gh issue edit --add-label`** (confirm already required for those mutations).
+
+---
+
+## 4. Hand off
+
+Return to **`@gh-issues`**: attach labels in the chosen create-or-edit mutation path when the user Proceeds with a non-empty set; skip labels when the user declines.
+
+## See also
+
+- **[`internal-read-gh-issue-dedupe`](../issue-dedupe/SKILL.md)** — run **before** description for new issues.
+- **[`internal-read-gh-issue-description`](../issue-description/SKILL.md)** — templates vs pack body.

--- a/.agents/skills/internal-read-gh-issue-labels/label-decorate/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-labels/label-decorate/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: internal-read-gh-issue-labels-label-decorate
+description: >-
+  Read-only: gh label list/match/create command shapes. Parent internal-read-gh-issue-labels.
+---
+
+# Issue labels — decorate (examples)
+
+Used by **[`internal-read-gh-issue-labels`](./SKILL.md)** and **`@gh-issues`**.
+
+**Inventory (read-only):**
+
+```bash
+gh label list --json name,description,color --limit 200
+```
+
+---
+
+## Example A — Map to existing labels
+
+**Input (chat):** “Add label guidance for skills pack; touch `skills/read/gh/` and templates.”
+
+**Draft title:** `Document issue label heuristics for skill repos`
+
+**Draft body (excerpt):** “… acceptance: label list command, 0–3 labels, confirm before `gh label create` …”
+
+**Step:** Existing labels include `documentation`, `enhancement`.
+
+**Output (proposal table):**
+
+| Candidate | Action | GitHub label |
+| --- | --- | --- |
+| docs / templates | reuse | `documentation` |
+| feature work | reuse | `enhancement` |
+
+**Attach (preview, not run by agent until confirm):** use the canonical create shapes in **[`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md#create-issue-after-proceed)** and pass `--label "documentation,enhancement"` after the structured proceed gate.
+
+---
+
+## Example B — One new label, then attach
+
+**Input:** “Track flaky CI on `gh-pr` skill; file an issue.”
+
+**Draft title:** `Flaky CI when running gh-pr orchestration tests`
+
+**Existing labels:** `bug`, `ci` (no `area:gh`).
+
+**Step:** Propose **`ci`** + **`bug`**; suggest **`area:gh`** as **new** (repo has other `area:*` labels).
+
+**Output:**
+
+| Candidate | Action | Notes |
+| --- | --- | --- |
+| CI | reuse | `ci` |
+| defect | reuse | `bug` |
+| domain | **create** | `gh label create area:gh --color ededed --description "GitHub PR CLI skills"` → **structured confirm** first |
+
+**Then create issue:** use the same canonical create shapes in **[`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md#create-issue-after-proceed)** with `--label "ci,bug,area:gh"` after confirm.
+
+---
+
+## Do not
+
+- Attach **more than three** labels without explicit user ask.
+- Create labels that only duplicate an existing name with different spelling.

--- a/.agents/skills/internal-read-gh-issue-list/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-list/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: internal-read-gh-issue-list
+description: >-
+  Normative gh issue list and gh search issues inventory shapes. Read-only. Callers add --state, --label, --limit, --json,
+  and --repo flags per goal; mutation lives in internal-write-gh-issue-commands. Used by internal-read-gh-pr-description §6.6.
+---
+
+# Internal: GitHub issue list (`internal-read-gh-issue-list`)
+
+**Library.** **Sole** normative **`gh issue list`** and **`gh search issues`** fences for this pack. Consumed by **`@gh-issue-list`**, **`@gh-issues`** (inventory), **`@gh-issue-pick`**, **`@gh-issue-delete-closed`** (preview), **`@gh-issue-review`** (peer list), **`internal-read-gh-issue-dedupe`**, **`internal-read-gh-pr-description`** §6.6 (optional issue validation during **`@gh-pr`**), and **[`DEDUPE_CHECKLIST.md`](../issue-dedupe/DEDUPE_CHECKLIST.md)**.
+
+**Mutations** (**`gh issue create`/`edit`/`close`/`delete`**, …) live in **[`internal-write-gh-issue-commands`](../../write/gh/issue-commands/SKILL.md)**—never run those from this file.
+
+## Cadence (read-only)
+
+**Faster in inventory-only flows** — This library **only** hits GitHub for **read** list/search. **Parents** that are read-only (**`@gh-issue-list`**, **`@gh-issue-review`** peer pass, …) may use it **without** an extra **AskQuestion** from this file. **Do not** infer that **Proceed** is satisfied for a later **`gh issue`** **mutation**—that lives in **`internal-write-gh-issue-commands`** behind the right **`@gh-*`** skill.
+
+## Online changes and paths outside the repo
+
+- **This file is read-only** — listing/searching issues on GitHub does **not** replace **Goal + structured confirm** for any follow-on **`gh`** write.
+- **Inventory stays lightweight** — no mandatory **Abort / Review / Proceed** stack for routine reads; mutation parents own **Proceed** per **`internal-write-plan-skill-safety`** / **`internal-write-plan-structured-qa`** **§1e** before writes.
+- **Parent skills** that call **`internal-read-gh-issue-list`** and then **mutate** GitHub or **write outside the git workspace root** must apply **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** before those writes.
+- **Master-confirm rule** — even with **`SKIP_QA_*`** / **`SKIP_QA_WRITE`**, follow-on high-risk writes still require session-level confirm in the owning mutation skill.
+
+## Caller refinement (flags)
+
+Use the fenced shapes below as **bases**. **Callers** add flags for the task at hand, for example:
+
+- **`--state open`** | **`closed`** | **`all`**
+- **`--label "name"`** (repeat **`--label`** if **`gh`** supports it for your version)
+- **`--limit N`** (cap chat output)
+- **`--json field1,field2,…`** (machine-readable inventory)
+- **`--repo owner/repo`** when not using default **`gh`** context (**fork/upstream:** **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)**)
+
+## List / search (typical open inventory)
+
+```bash
+gh issue list --state open --limit 30
+```
+
+**Filter by label:**
+
+```bash
+gh issue list --state open --label "bug" --limit 30
+```
+
+**Search (broader)** — pass explicit **`owner/repo`** when not using default context:
+
+```bash
+gh search issues --repo owner/repo --state open --limit 30 "QUERY"
+```
+
+## List closed (inventory before bulk delete)
+
+```bash
+gh issue list --state closed --limit 200 --json number,title,state
+```
+
+## See also
+
+- **[`internal-write-gh-issue-commands`](../issue-commands/SKILL.md)** — **`gh issue view`**, create, edit, close, delete.
+- **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)** — **`--repo`** targets.
+- [`@gh-issue-list`](../../../gh/issues/list/SKILL.md) · [`@gh-issue-delete-closed`](../../../gh/issues/delete-closed/SKILL.md)
+- [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md) · [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/internal-read-gh-issue-preflight-qa/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-preflight-qa/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: internal-read-gh-issue-preflight-qa
+description: >-
+  Read-only question bank for @gh-issues pre-flight. Helps gather goal, examples, counterexamples, and
+  verification details before dedupe and mutation.
+---
+
+# Issue pre-flight Q&A
+
+Use this before any issue create/edit mutation.
+
+## Gather (deducible first)
+
+- Candidate title intent from user prompt and repository context.
+- Existing related issue numbers/titles from list/search.
+- Existing labels that might apply.
+- Whether the user is carrying **multiple independent themes** (long multi-section paste, many unrelated bullets, or a plan hub: **`.cursor/plan.md`** / linked **`.cursor/plans/<slug>.md`**) — see **[`internal-read-plan-parts`](../../plan/parts/SKILL.md)** and **`@gh-issues`** [Multi-intent clustering](../../../gh/issues/SKILL.md#multi-intent-clustering-optional).
+
+## Clarify (ask when ambiguous)
+
+- Goal: what outcome should be true after completion?
+- Examples: concrete "today vs desired" cases.
+- Counterexamples: explicitly out-of-scope or invalid behavior.
+- Constraints: compatibility, regressions to avoid, rollout risks.
+- Verification: acceptance and regression checks.
+
+## Iteration / ship gate (normative for `@gh-issues`)
+
+After each refinement pass, once requirements and draft intent are summarized, **before** list/dedupe, the caller must offer a single structured choice (AskQuestion per [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md), safe-first when ordering matters):
+
+- **Abort** — stop or park; do not run inventory/dedupe for publish.
+- **Sharpen** — another Q&A round (optionally Cursor’s built-in Plan or chat); then re-summarize and ask again.
+- **Ship** — candidate is good enough to continue the pipeline (list → dedupe → description → mutation confirm).
+
+Repeat until **Ship** or **Abort**. Readiness hints may cite [`internal-read-plan-confidence`](../../plan/confidence/SKILL.md); keep them optional, not mandatory scoring.
+
+## Multi-topic and plan hubs
+
+When a **plan hub** or **long multi-topic** paste is present, optionally use structured AskQuestion (same § as the ship gate) to confirm **one combined issue** vs **multiple themes** to ship after **Ship** (so **Sharpen** can split sections in **`.cursor/plan.md`** or chat before dedupe). Default remains one narrative until the user or router opts into the multi-intent path in **`@gh-issues`**.
+
+## AskQuestion shape
+
+- Present a concise summary in the prompt text.
+- Keep options safe-first (Abort first).
+- Use one refinement outlet only.
+
+## See also
+
+- [`internal-read-gh-issue-spec`](../issue-spec/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)
+- [`internal-read-plan-parts`](../../plan/parts/SKILL.md)
+- [`@gh-issues`](../../../gh/issues/SKILL.md)

--- a/.agents/skills/internal-read-gh-issue-projects-relationships/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-projects-relationships/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: internal-read-gh-issue-projects-relationships
+description: >-
+  Read-only: discover repo-scoped GitHub Projects for issue and PR mutation, normative gh shapes for attaching issues and
+  pull requests to projects, and issue relationship playbook (body links, duplicates, parent/sub-issues). Callers add
+  --repo and owner flags per target; mutations live in internal-write-gh-issue-commands and internal-write-gh-pr-commands.
+---
+
+# Internal: Issue projects + relationships (`internal-read-gh-issue-projects-relationships`)
+
+**Read-only.** Consumed by **`@gh-issues`** (plan + mutation summary), **`@gh-pr`** (via **`internal-read-gh-pr-description`** §6.5–6.6), **[`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)** (normative attach fences), and **[`internal-write-gh-pr-commands`](../../../write/gh/pr-commands/SKILL.md)** (PR **`item-add`**). **No `gh` mutations** in this file.
+
+**Project list shapes** — **[`internal-read-gh-project-list`](../project-list/SKILL.md)** (auth + `gh project list` bases).
+
+**Fork / PR target repo** — resolve **`owner/repo`** for issues the same way **`@gh-issues`** resolves the mutation target (see **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)** when the issue is filed on **`$PR_TARGET_REPO`** rather than the fork root). **Project discovery `--owner`** must match the **login that owns the repository** where the issue is created (first segment of **`nameWithOwner`** for that repo).
+
+**Pull requests (`@gh-pr`)** — use the same **`PR_TARGET_REPO`** for **`https://github.com/OWNER/REPO/pull/<N>`** URLs passed to **`gh project item-add --url`**. Run **`item-add` for the PR** after **`gh pr create`** (or **`gh pr edit`**) returns a PR number; then **`item-add` per confirmed issue** URL on that same **`OWNER/REPO`**. Do not substitute the fork’s **`github.com/FORK_OWNER/repo`** host in URLs when issues and PR are tracked on the **upstream** destination unless the issue genuinely lives on the fork.
+
+---
+
+## 1. Auth and capability probes
+
+**`gh issue create`**, **`gh issue edit --add-project`**, **`gh project list`**, and **`gh project item-add`** need the **`project`** scope for project features. **`gh auth status`** shows current scopes.
+
+If a command fails with missing **`project`** (or GraphQL mentions **`read:project`** / **`project`** scope), refresh:
+
+```bash
+gh auth refresh -s project
+```
+
+**GitHub Enterprise Server** may lack Projects v2 features or ship older **`gh`** flags. When **`gh issue create --help`** does not list **`--project`**, or **`gh project list`** errors with an unsupported API message, **stop** automated attach, record the error in chat, and fall back to **web UI** (Issues + Projects) or an operator-run attach.
+
+---
+
+## 2. Discover projects for the issue target repo
+
+1. Resolve **`TARGET_REPO`** — `owner/repo` passed to **`gh issue create` / `gh issue edit`** (default: current **`gh`** context; else **`--repo owner/repo`**).
+2. Load owner login:
+
+```bash
+gh repo view --json nameWithOwner --repo owner/repo
+```
+
+Use **`owner.login`** from **`gh repo view --json owner,nameWithOwner --repo owner/repo`** when you need the owner object explicitly.
+
+3. List candidate projects for that owner (open projects first; add **`--closed`** only when grooming closed boards):
+
+```bash
+gh project list --owner OWNER_LOGIN --limit 50 --format json
+```
+
+4. **Choose a project title** for **`--project` / `--add-project`**:
+   - **One unambiguous title** in the list → use it in the mutation summary and in **[`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)** fences.
+   - **Several titles match** the user’s intent (or duplicate titles) → **structured AskQuestion** in **`@gh-issues`**: pick one project, **skip** attach for this run, or **abort** until clarified.
+   - **No projects** or **`gh project list` fails** after auth → **skip** project attach; state **why** (no boards, scope, or GHE limitation)—not a silent success.
+
+The CLI does not always expose “this repo’s linked project” as a single field without GraphQL. Treat **owner-scoped listing + user disambiguation** as the supported pack workflow unless the user supplies an exact **`--project "Title"`** override.
+
+---
+
+## 3. Relationship playbook (issues)
+
+### 3.1 Cross-links in the body
+
+Use **`#123`** (same repo) or full **`https://github.com/owner/repo/issues/N`** (cross-repo) for **human-readable** context, release notes, and search. Body links **do not** replace GitHub duplicate closure or project membership—they document intent only.
+
+### 3.2 Duplicate vs “mentioned in body”
+
+To close a duplicate with correct GitHub semantics, use **`@gh-issue-close`** and **[`close-as-duplicate`](../../../write/gh/issue-commands/close-as-duplicate/SKILL.md)**: comment pointing at the canonical issue, then **`gh issue close`**. Do not rely on body text alone to mark duplicates.
+
+### 3.3 Parent / sub-issue / “blocked by”
+
+Product support (sub-issues, dependency graphs, **blocked by**) varies by **github.com** vs **GHES** and ship channel. If **`gh`** has no stable sub-issue flags for your version, use **web UI** or API where your token allows, and keep a **body fallback** (“Parent: #12”, “Blocked by: #34”) so agents stay consistent when automation is unavailable.
+
+### 3.4 Interaction with **`@gh-issue-close`**
+
+Relationship edits that **close** or **reopen** issues stay in **`@gh-issue-close`** and **`internal-write-gh-issue-commands`** close paths. **`@gh-issues`** owns **create/edit** content and **additive** project attach—not bulk close/reopen.
+
+---
+
+## 4. Pull requests and projects (`@gh-pr`)
+
+**Goal:** Put the **PR** and any **confirmed issues** on the same GitHub Project board using supported **`gh project item-add`** calls (see **[`internal-write-gh-pr-commands`](../../../write/gh/pr-commands/SKILL.md)**).
+
+1. Resolve **`PR_TARGET_REPO`** as **`owner/repo`** on the **destination** (upstream when **`STREAM_MODE=fork`**) per **`internal-read-gh-repo-stream`** §3.
+2. Resolve **`PROJECT_NUMBER`** and **`OWNER_LOGIN`** the same way as §2 of this file (**`gh project list`**, user override, or structured pick).
+3. After the PR exists, add the PR, then each issue:
+
+```text
+https://github.com/OWNER/REPO/pull/<PR_NUMBER>
+https://github.com/OWNER/REPO/issues/<ISSUE_NUMBER>
+```
+
+4. **Auth:** same **`project`** scope and GHES caveats as §1.
+
+**Do not** confuse this with the PR **Development** sidebar link—**`item-add`** is **project membership**, not a substitute for closing keywords when merge-time close semantics are required (see §6.5 of **`internal-read-gh-pr-description`**).
+
+---
+
+## See also
+
+- **[`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)** — create, edit, project attach, close.
+- **[`internal-write-gh-pr-commands`](../../../write/gh/pr-commands/SKILL.md)** — PR create/edit + optional **`item-add`** for PR URLs.
+- **[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** — §6.5–6.6 linking ladder + issue hint scan.
+- **[`internal-read-gh-project-list`](../project-list/SKILL.md)** — `gh project list` inventory.
+- **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)** — **`$PR_TARGET_REPO`** / fork vs same-repo.
+- **[`@gh-issues`](../../../gh/issues/SKILL.md)** · **[`@gh-issue-close`](../../../gh/issues/close/SKILL.md)** · **[`@gh-pr`](../../../gh/pr/SKILL.md)**

--- a/.agents/skills/internal-read-gh-issue-spec/SKILL.md
+++ b/.agents/skills/internal-read-gh-issue-spec/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: internal-read-gh-issue-spec
+description: >-
+  Read-only contract for high-quality implementation-ready issue bodies: required sections, quality bar,
+  anti-ambiguity examples, non-regression expectations, and verification guidance.
+---
+
+# Internal: Issue spec contract
+
+**Read-only library.** This is the canonical issue-body quality contract for this pack when a repository does not impose a stronger issue template.
+
+## Do
+
+- Draft issue bodies with these required sections:
+  1. Goal/outcome.
+  2. Current situation.
+  3. Examples today vs desired.
+  4. Scope of change.
+  5. Non-regression/compatibility.
+  6. Verification (acceptance + regression tests).
+  7. Worked examples/edge cases.
+  8. Risks/open questions.
+- Prefer concrete examples over abstract prose.
+- Preserve existing behavior requirements explicitly when extending a feature.
+- Make verification executable by a future implementer without guessing.
+- When planning surfaces **finite** implementation forks before publish, prefer **AskQuestion** (structured multiple-choice) per **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** **§1** so the user picks in the Q&A UI instead of parsing A/B/C prose alone; align pre-flight gates with **[`internal-read-gh-issue-preflight-qa`](../issue-preflight-qa/SKILL.md)**.
+
+## Do not
+
+- Publish vague issue bodies that omit examples or regression expectations.
+- Treat this as a mutation workflow; publishing remains owned by `@gh-issues`.
+
+## Quality bar (done criteria)
+
+- Goal is specific enough that success can be judged.
+- Current and desired behavior each include at least one example.
+- Change surface is bounded (in scope/out of scope clear).
+- Non-regression expectations are explicit.
+- Verification includes both acceptance and regression intent.
+- Major ambiguity points are resolved or documented as open questions.
+
+## Exemplars
+
+### Exemplar: extend calculator operations
+
+- **Goal:** add `multiply` and `divide` while preserving `sum` and `subtract` behavior.
+- **Current example:** `2 + 3 -> 5`, `8 - 3 -> 5`, `2 * 3 -> unsupported operation`.
+- **Desired example:** `2 * 3 -> 6`, `8 / 2 -> 4`, `8 / 0 -> stable validation error`.
+- **Scope:** parser/evaluator support for `*` and `/`, divide-by-zero guard, no API schema break.
+- **Verification:** acceptance tests for multiply/divide, regression tests for sum/subtract, negative tests for divide-by-zero.
+- **Open questions:** precision policy (float/decimal, rounding behavior).
+
+### Exemplar: issue router upgrade
+
+- **Goal:** when intent is vague, route through planning first, then run deterministic create-or-update.
+- **Current example:** vague prompt jumps straight into create/update logic.
+- **Desired example:** vague prompt -> Cursor Plan (or chat) -> stable issue artifact -> list -> dedupe -> edit/create.
+- **Scope:** wording and routing updates only; no new API mutations; dedupe logic unchanged.
+- **Verification:** dry-run both paths (vague intent path and ready artifact path) and validate links.
+- **Open questions:** keep router wording concise while preserving clarity.
+
+## See also
+
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md) — **§1** finite choices and prompt shape when offering alternatives in Cursor.
+
+## Consumers
+
+- [`internal-read-plan-core-github-issue-profile`](../../plan/core/github-issue-profile/SKILL.md)
+- [`@gh-issue-review`](../../../../gh/issues/review/SKILL.md)
+- [`internal-read-gh-issue-description-issue-body-skeleton`](../issue-description/issue-body-skeleton/SKILL.md)

--- a/.agents/skills/internal-read-gh-pr-body-sections-section-patterns/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-body-sections-section-patterns/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: internal-read-gh-pr-body-sections-section-patterns
+description: >-
+  Read-only: canonical PR body sections and examples. Parent internal-read-gh-pr-body-sections. No default Linked issues
+  prose; optional minimal closing-keyword line only when @gh-pr §9 chose the keyword path.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for PR section patterns.
+
+## Issue and project linkage (with `@gh-pr`)
+
+- **Do not** add a standing **“Linked issues”** markdown section by default. Candidate issues and the **linking ladder** ( **`gh project item-add`**, minimal **`Refs`/`Fixes`/`Closes`** line, or **UI-only**) are confirmed in **`@gh-pr`** **§9** per **[`internal-read-gh-pr-description`](../../pr-description/SKILL.md)** §6.5–7.
+- **Minimal keyword line:** GitHub’s documented programmatic path for merge-time **closing** inference is **closing keywords in the PR body** (see **`internal-write-gh-pr-commands`**). At most **one** short trailing line when the user explicitly chose that path—**no** multi-paragraph issue prose in the PR description for traceability alone.

--- a/.agents/skills/internal-read-gh-pr-body-sections/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-body-sections/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: internal-read-gh-pr-body-sections
+description: >-
+  Read-only: PR title/body markdown patterns and canonical section structure. Caller: internal-read-gh-pr-description.
+  Does not run gh or git.
+---
+
+# Internal: Pull request body sections (`internal-read-gh-pr-body-sections`)
+
+**Read-only library.** **Static** PR **substance**: section headings, canonical body rules, example skeleton, title rules. Full copy-paste reference: **[`section-patterns/SKILL.md`](./section-patterns/SKILL.md)**.
+
+**[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** owns **template discovery** (**§5** — GitHub API via **`internal-read-gh-repo-forms-json`**, local files), **`git` delta** (**§6**), **API-first linking + issue hint scan** (**§6.5–6.6**), **title/body + triple pass** (**§7**), and hand-off to **`@gh-pr`** §9. **Do not** duplicate **§5** **`gh repo view`** lines here.
+
+---
+
+## Do
+
+- When **`$PR_TEMPLATE_SOURCE`** is **`canonical`**, draft the body from **`section-patterns/SKILL.md`** only.
+- When merging a repo or GitHub template, **map** content into those headings while keeping **TL;DR** first.
+
+## Do not
+
+- Run **`gh pr create`**, **`gh pr edit`**, or **AskQuestion** for PR mutation — parent **`@gh-pr`** §9.
+
+---
+
+## See also
+
+- [`internal-read-gh-pr-content`](../pr-content/SKILL.md) — title/body shape (**`title-line`**, **`pr-body-skeleton`**)
+- [`internal-read-gh-pr-description`](../pr-description/SKILL.md) — discovery, §6 delta, §6.5–7 linking + title/body
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md) — template pick when multiple templates
+- [`@gh-pr`](../../../gh/pr/SKILL.md)

--- a/.agents/skills/internal-read-gh-pr-body-sections/section-patterns/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-body-sections/section-patterns/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: internal-read-gh-pr-body-sections-section-patterns
+description: >-
+  Read-only: canonical PR body sections and examples. Parent internal-read-gh-pr-body-sections. No default Linked issues
+  prose; optional minimal closing-keyword line only when @gh-pr §9 chose the keyword path.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for PR section patterns.
+
+## Issue and project linkage (with `@gh-pr`)
+
+- **Do not** add a standing **“Linked issues”** markdown section by default. Candidate issues and the **linking ladder** ( **`gh project item-add`**, minimal **`Refs`/`Fixes`/`Closes`** line, or **UI-only**) are confirmed in **`@gh-pr`** **§9** per **[`internal-read-gh-pr-description`](../../pr-description/SKILL.md)** §6.5–7.
+- **Minimal keyword line:** GitHub’s documented programmatic path for merge-time **closing** inference is **closing keywords in the PR body** (see **`internal-write-gh-pr-commands`**). At most **one** short trailing line when the user explicitly chose that path—**no** multi-paragraph issue prose in the PR description for traceability alone.

--- a/.agents/skills/internal-read-gh-pr-content-pr-body-skeleton/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-content-pr-body-skeleton/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: internal-read-gh-pr-content-pr-body-skeleton
+description: >-
+  Read-only: PR body markdown skeleton. Parent internal-read-gh-pr-content. Optional minimal Refs/Fixes line only when
+  @gh-pr §9 confirmed keyword path; no default Linked issues block.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for PR body skeleton guidance.
+
+## Skeleton (canonical / normalized)
+
+Use **[`internal-read-gh-pr-body-sections/section-patterns`](../pr-body-sections/section-patterns/SKILL.md)** for heading names. Typical flow: **TL;DR** → **What changed** (nested bullets) → tradeoffs / risks.
+
+**Issue linkage:** omit a dedicated **Linked issues** heading. If **`@gh-pr`** **§9** confirmed the **keyword path**, append **at most one line** at the end of the body, for example `Refs #42` or `Fixes #42` (never multiple **`Fixes`** without explicit user confirmation). Otherwise rely on **Projects** (**`gh project item-add`**) and/or **UI** per **`internal-write-gh-pr-commands`**.

--- a/.agents/skills/internal-read-gh-pr-content-pr-orchestration/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-content-pr-orchestration/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: internal-read-gh-pr-content-pr-orchestration
+description: >-
+  Read-only: @gh-pr orchestration prose. Parent internal-read-gh-pr-content.
+---
+
+# PR orchestration (`@gh-pr`)
+
+**Fixed order:** **`@git-pull`** → **`@git-review`** → **`@git-push`** → list matching open PRs / resolve vars → **AskQuestion intent gate** (summary in prompt; abort/proceed/refine) → resolve `PR_NUM` → **`internal-read-gh-pr-description`** (full: §5 templates, §6 delta, **§6.5–6.6** API linking ladder + issue hint scan, **§7** title/body + triple pass) → **AskQuestion mutation gate** (summary must include **linking ladder** choice: project **`item-add`**, minimal body keywords, or UI-only, plus candidate issues) → **`gh pr create` / `gh pr edit`** → optional **`gh project item-add`** + optional **`gh pr view --json closingIssuesReferences`** per **`internal-write-gh-pr-commands`** when confirmed in that gate.
+
+**Inventory (optional):** run **`@gh-pr-list`** / **`@gh-pr-view`** using [`internal-read-gh-pr-list`](../pr-list/SKILL.md) (and [list/view hub](../pr-list/list-view-hub/SKILL.md)) when you need open PR numbers, URLs, or a quick **`gh pr diff --stat`** before drafting with **`@gh-pr`**.
+
+**Variables:** set **`BASE_GIT`**, **`PR_TARGET_REPO`**, etc. per [`internal-read-gh-repo-stream`](../repo-stream/SKILL.md) — do not re-derive fork rules inline.
+
+**After publish/recovery:** `@git-push` may complete on a different branch after failure triage (for example create/switch recovery branch). Re-apply [`internal-read-gh-repo-stream`](../repo-stream/SKILL.md) before PR lookup/drafting so head/base vars reflect the current branch.
+
+**Intent gate before drafting:** after lookup, if matches exist, ask user whether to edit one, create new, or abort. Keep the compact inventory summary inside AskQuestion prompt text and follow [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md) for safe-first options and single refinement outlet.
+
+**Do not** run `gh pr create` before pull, review, and push succeed. **Do not** inline `npm test` / full **`@git-review`** instead of the ordered **`@git-review`** hand-off in **`@gh-pr`**—**`@git-push`** does **not** own verify.
+
+**PR text:** [PR body skeleton](../pr-body-skeleton/SKILL.md), [title line](../title-line/SKILL.md). **Issue/project linkage:** **[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** §6.5–6.6 + **`internal-write-gh-pr-commands`** (optional **`gh project item-add`**, verification JSON). **Delta git commands:** **`internal-read-git-git-diff-summary`** only (invoked from **`internal-read-gh-pr-description`**). Final create/edit still requires a separate mutation AskQuestion with summary in prompt text before the write.

--- a/.agents/skills/internal-read-gh-pr-content-title-line/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-content-title-line/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-gh-pr-content-title-line
+description: >-
+  Read-only: PR and issue title line rules. Parent internal-read-gh-pr-content.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for PR title-line guidance.
+

--- a/.agents/skills/internal-read-gh-pr-content/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-content/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: internal-read-gh-pr-content
+description: >-
+  Read-only: canonical PR title + body shape; child skills title-line/ and pr-body-skeleton/. Orchestration stays in
+  internal-read-gh-pr-description + internal-read-gh-pr-body-sections. Callers: @gh-pr. Does not write files.
+---
+
+# Internal: PR content shape (`internal-read-gh-pr-content`)
+
+**Read-only library.** **What** the **title** and **body** should look like. **Child skills:**
+
+- **[`title-line/SKILL.md`](./title-line/SKILL.md)** — PR and issue **titles**
+- **[`pr-body-skeleton/SKILL.md`](./pr-body-skeleton/SKILL.md)** — PR body markdown shape
+
+**Template discovery:** **[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** §5 (orchestration + local globs); **`gh repo view --json`** lines: **[`internal-read-gh-repo-forms-json`](../repo-forms-json/SKILL.md)**. **`git` delta commands:** **[`internal-read-git-git-diff-summary`](../../git/git-diff-summary/SKILL.md)** (§6 hand-off). **API-first linking + issue hint scan:** **`internal-read-gh-pr-description`** §6.5–6.6. **Full section prose:** **[`internal-read-gh-pr-body-sections/section-patterns/SKILL.md`](../pr-body-sections/section-patterns/SKILL.md)**.
+
+---
+
+## Ownership
+
+| Topic | Owner |
+| --- | --- |
+| Title line rules + body section order | **This skill** + **[`title-line/SKILL.md`](./title-line/SKILL.md)** + **`pr-body-sections/section-patterns`** |
+| **`gh repo view --json`** (templates API) | **`internal-read-gh-repo-forms-json`** |
+| Local template globs + merge / reshape | **`internal-read-gh-pr-description`** §5 |
+| **`git log` / `git diff`** vs **`$BASE_GIT`** | **`internal-read-git-git-diff-summary`** (§6 of **`internal-read-gh-pr-description`**) |
+| API-first linking ladder + issue hint scan (read-only) | **`internal-read-gh-pr-description`** §6.5–6.6 |
+| Title/body prose assembly + triple pass | **`internal-read-gh-pr-description`** §7 |
+| Example markdown shape only | **[`pr-body-skeleton/SKILL.md`](./pr-body-skeleton/SKILL.md)** |
+
+## See also
+
+- [`internal-read-git-git-diff-summary`](../../git/git-diff-summary/SKILL.md)
+- [`@gh-pr`](../../../gh/pr/SKILL.md)

--- a/.agents/skills/internal-read-gh-pr-content/pr-body-skeleton/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-content/pr-body-skeleton/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: internal-read-gh-pr-content-pr-body-skeleton
+description: >-
+  Read-only: PR body markdown skeleton. Parent internal-read-gh-pr-content. Optional minimal Refs/Fixes line only when
+  @gh-pr §9 confirmed keyword path; no default Linked issues block.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for PR body skeleton guidance.
+
+## Skeleton (canonical / normalized)
+
+Use **[`internal-read-gh-pr-body-sections/section-patterns`](../pr-body-sections/section-patterns/SKILL.md)** for heading names. Typical flow: **TL;DR** → **What changed** (nested bullets) → tradeoffs / risks.
+
+**Issue linkage:** omit a dedicated **Linked issues** heading. If **`@gh-pr`** **§9** confirmed the **keyword path**, append **at most one line** at the end of the body, for example `Refs #42` or `Fixes #42` (never multiple **`Fixes`** without explicit user confirmation). Otherwise rely on **Projects** (**`gh project item-add`**) and/or **UI** per **`internal-write-gh-pr-commands`**.

--- a/.agents/skills/internal-read-gh-pr-content/pr-orchestration/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-content/pr-orchestration/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: internal-read-gh-pr-content-pr-orchestration
+description: >-
+  Read-only: @gh-pr orchestration prose. Parent internal-read-gh-pr-content.
+---
+
+# PR orchestration (`@gh-pr`)
+
+**Fixed order:** **`@git-pull`** → **`@git-review`** → **`@git-push`** → list matching open PRs / resolve vars → **AskQuestion intent gate** (summary in prompt; abort/proceed/refine) → resolve `PR_NUM` → **`internal-read-gh-pr-description`** (full: §5 templates, §6 delta, **§6.5–6.6** API linking ladder + issue hint scan, **§7** title/body + triple pass) → **AskQuestion mutation gate** (summary must include **linking ladder** choice: project **`item-add`**, minimal body keywords, or UI-only, plus candidate issues) → **`gh pr create` / `gh pr edit`** → optional **`gh project item-add`** + optional **`gh pr view --json closingIssuesReferences`** per **`internal-write-gh-pr-commands`** when confirmed in that gate.
+
+**Inventory (optional):** run **`@gh-pr-list`** / **`@gh-pr-view`** using [`internal-read-gh-pr-list`](../pr-list/SKILL.md) (and [list/view hub](../pr-list/list-view-hub/SKILL.md)) when you need open PR numbers, URLs, or a quick **`gh pr diff --stat`** before drafting with **`@gh-pr`**.
+
+**Variables:** set **`BASE_GIT`**, **`PR_TARGET_REPO`**, etc. per [`internal-read-gh-repo-stream`](../repo-stream/SKILL.md) — do not re-derive fork rules inline.
+
+**After publish/recovery:** `@git-push` may complete on a different branch after failure triage (for example create/switch recovery branch). Re-apply [`internal-read-gh-repo-stream`](../repo-stream/SKILL.md) before PR lookup/drafting so head/base vars reflect the current branch.
+
+**Intent gate before drafting:** after lookup, if matches exist, ask user whether to edit one, create new, or abort. Keep the compact inventory summary inside AskQuestion prompt text and follow [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md) for safe-first options and single refinement outlet.
+
+**Do not** run `gh pr create` before pull, review, and push succeed. **Do not** inline `npm test` / full **`@git-review`** instead of the ordered **`@git-review`** hand-off in **`@gh-pr`**—**`@git-push`** does **not** own verify.
+
+**PR text:** [PR body skeleton](../pr-body-skeleton/SKILL.md), [title line](../title-line/SKILL.md). **Issue/project linkage:** **[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** §6.5–6.6 + **`internal-write-gh-pr-commands`** (optional **`gh project item-add`**, verification JSON). **Delta git commands:** **`internal-read-git-git-diff-summary`** only (invoked from **`internal-read-gh-pr-description`**). Final create/edit still requires a separate mutation AskQuestion with summary in prompt text before the write.

--- a/.agents/skills/internal-read-gh-pr-content/title-line/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-content/title-line/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-gh-pr-content-title-line
+description: >-
+  Read-only: PR and issue title line rules. Parent internal-read-gh-pr-content.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for PR title-line guidance.
+

--- a/.agents/skills/internal-read-gh-pr-description/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-description/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: internal-read-gh-pr-description
+description: >-
+  Read-only: PR template discovery (§5), delta (§6), API-first issue/linking ladder + issue hint scan (§6.5–6.6), title/body + triple-pass (§7).
+  Caller @gh-pr after §5; parent §9 mutates. Does not run gh pr create/edit.
+---
+
+# Internal: PR description
+
+**Read-only.** Run after **`@gh-pr`** **§5** (**`PR_NUM`**, **`$BASE_GIT`**, branch/upstream vars per **`internal-read-gh-repo-stream`**). When open PR matches existed in §5, treat **`PR_NUM`** as user-confirmed intent from that AskQuestion gate. **Does not** mutate GitHub or own **Proceed** for PR apply—that is **`@gh-pr`** **§9** (**`internal-write-plan-skill-safety`** + **`internal-write-plan-structured-qa`** **§3a**).
+
+**Single owners (do not duplicate):** **`gh repo view --json pullRequestTemplates`** → **[`internal-read-gh-repo-forms-json`](../repo-forms-json/SKILL.md)** · local globs / **`section-patterns`** → **[`internal-read-gh-pr-body-sections`](../pr-body-sections/SKILL.md)** · **delta commands** → **[`internal-read-git-git-diff-summary`](../../git/git-diff-summary/SKILL.md)** + **[`delta-narrative/SKILL.md`](../../git/git-diff-summary/delta-narrative/SKILL.md)** · **linking ladder + issue hint scan** → **§6.5–6.6** (this file) + **[`internal-read-gh-issue-projects-relationships`](../issue-projects-relationships/SKILL.md)** + **[`internal-read-gh-issue-list`](../issue-list/SKILL.md)** · **title + section order** → **[`internal-read-gh-pr-content`](../pr-content/SKILL.md)** + **[`title-line`](../pr-content/title-line/SKILL.md)**, **[`pr-body-skeleton`](../pr-content/pr-body-skeleton/SKILL.md)** · **PR/project mutations after Proceed** → **[`internal-write-gh-pr-commands`](../../write/gh/pr-commands/SKILL.md)**.
+
+---
+
+## 5. Discover PR templates
+
+Run **after §4**, **before §6**. **Step A** always first (**`gh`** JSON); **B** if no usable template; **C** if still none.
+
+**Multiple templates:** structured pick per **`internal-write-plan-structured-qa`** (one option per template + **Canonical only** → **`$PR_TEMPLATE_SOURCE`** = **`canonical`**, empty body).
+
+### Step A — GitHub API (required)
+
+**Execute** (do not copy-paste from here): same-repo vs fork command from **`internal-read-gh-repo-forms-json`** § **Pull request templates** using **`PR_TARGET_REPO`** / **`$UPSTREAM`** from **`internal-read-gh-repo-stream`** §3.
+
+- Parse **`pullRequestTemplates`** (length probe in repo-forms-json optional; read full entries when non-empty).
+- **One** object → **`github-api`** + body markdown.
+- **≥2** → template Q&A.
+- **`[]` / missing** → Step B. **`gh`** error after retry → B + note.
+
+### Step B — Local files
+
+Globs and filenames: **`internal-read-gh-pr-body-sections`** (do not maintain a second list here). Discover with **`git ls-files`** + glob. **One** file → **`local`**; **≥2** → Q&A; **none** → Step C.
+
+### Step C — Canonical
+
+**`$PR_TEMPLATE_SOURCE`** = **`canonical`**, **`$PR_TEMPLATE_BODY`** empty — scaffold from **[Body — canonical structure](#body--canonical-structure)** via **`internal-read-gh-pr-body-sections/section-patterns/SKILL.md`**.
+
+### Merge rules (all sources)
+
+**Non-canonical body:** template owns headings/checklists; canonical rules govern **substance** (prepend **TL;DR** / **What changed** when template has no short opener—unless template forbids; strip checklist items that only duplicate **Files changed**).
+
+**Material template reshape:** **`internal-write-plan-structured-qa`** **AskQuestion** — **Keep / Blend / Pack canonical** — when applying the rules above would **reorder/remove** template-defined headings (**separate** from **`@gh-pr`** §9 PR mutation).
+
+---
+
+## 6. PR delta
+
+Run **`internal-read-git-git-diff-summary`** **in full**. **§7** “What changed” must track that output—no parallel **`git`** recipes here.
+
+---
+
+## 6.5 Linking: API ladder (read-only orientation)
+
+Use this ladder when deciding what to put in the **§9** mutation summary (and therefore what **`@gh-pr`** may run after **Proceed**). **Do not** imply undocumented GitHub APIs for the PR **Development** sidebar link.
+
+1. **Projects (board) — supported `gh` writes**  
+   After the PR exists, **`gh project item-add <PROJECT_NUMBER> --owner OWNER --url <URL>`** accepts **pull request or issue** URLs. Discovery, auth (**`project`** scope), and owner/repo rules live in **[`internal-read-gh-issue-projects-relationships`](../issue-projects-relationships/SKILL.md)** and **[`internal-read-gh-project-list`](../project-list/SKILL.md)**. Normative fences for the PR path live in **[`internal-write-gh-pr-commands`](../../write/gh/pr-commands/SKILL.md)** (same **Proceed** batch as **`gh pr create`/`edit`** when the user confirmed project attach). Issue-only attach patterns stay in **[`internal-write-gh-issue-commands`](../../write/gh/issue-commands/SKILL.md)**.
+
+2. **PR ↔ issue (closing / `closingIssuesReferences` semantics)**  
+   GitHub’s documented programmatic path for merge-time **closing** behavior is **closing keywords in the PR body** (or manual UI). There is **no** official REST/GraphQL write today for the web-only Development picker; proposed CLI flags remain **blocked** on the platform ([`cli/cli#11405`](https://github.com/cli/cli/issues/11405)). If the user refuses **any** issue text in the body, record **Projects + post-create verification + UI** only—do not invent hidden endpoints. See also [Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+3. **Read-only verification**  
+   After create/edit, parents may run **`gh pr view`** with JSON including **`closingIssuesReferences`** (see **`internal-write-gh-pr-commands`**) to confirm what GitHub already inferred—**read** only.
+
+---
+
+## 6.6 Issue hint scan (read-only)
+
+Collect **candidate issue numbers** and evidence for **`@gh-pr`** **§9** (project **`--url`** targets, optional minimal keyword line, or UI-only). **Do not** add a default **“Linked issues”** prose block to the PR body from this scan alone.
+
+**Evidence order (strongest first):**
+
+1. Explicit **`#nnn`** or **`Fixes` / `Refs` / `Closes`** in user chat or pasted intent.
+2. **Branch name** tokens (for example `issue-42`, `fix/123-short-title`, `…-#42-…`). Prefer explicit **`#`** patterns over naive long digit runs from paths.
+3. **Commit messages** on **`$BASE_GIT..HEAD`** — use full bodies, not only **`git log -1`**, so branch-wide **`Fixes #n`** / **`Refs #n`** surface; recipes in **[`internal-read-git-git-diff-summary/delta-narrative`](../../git/git-diff-summary/delta-narrative/SKILL.md)** (**Issue keywords in commit range**).
+4. **Optional `gh`** validation or disambiguation on **`PR_TARGET_REPO`** (same **`owner/repo`** as the PR destination—**forks:** use **`$UPSTREAM`**, not the fork root). Shapes: **[`internal-read-gh-issue-list`](../issue-list/SKILL.md)** (`gh issue list`, `gh search issues` with **`--repo`** as needed).
+
+**Heuristics:** If candidates disagree, defer to **`@gh-pr`** **§9** **AskQuestion**—do not auto-pick **`Fixes`** for multiple issues; default narrative is **`Refs`**-style **only when** the user explicitly chose minimal keyword lines for several refs.
+
+**Hand-off:** Pass a compact table or list (issue #, evidence source, suggested link mode: **project only** / **minimal keyword** / **UI**) to **`@gh-pr`** **§9**; **`internal-write-gh-pr-commands`** owns executable fences after **Proceed**.
+
+---
+
+## 7. Title + body + triple pass
+
+- Draft per **`internal-read-gh-pr-content`**, **`$PR_TEMPLATE_SOURCE`/`$PR_TEMPLATE_BODY`**, and **`section-patterns`** when canonical. **Full replace** vs **`$BASE_GIT`**; no compare-header noise (SHAs, commit counts).
+- **Issue linkage in the posted body:** **No** default **“Linked issues”** markdown section from §6.6. **Default:** omit **`Refs` / `Fixes` / `Closes`** lines from the draft body. Add **at most one minimal trailing line** of **`Refs #n` / `Fixes #n` / `Closes #n`** only when the user already chose the **keyword path** in chat **or** the draft is being revised **after** **`@gh-pr`** **§9** narrowed linkage (see §6.5 and **`internal-write-gh-pr-commands`**). For multiple candidates without a clear choice, keep keywords **out** of the body and carry candidates in the **§9** prompt (project **`item-add`**, keywords, or UI-only). See **[`internal-read-gh-pr-body-sections/section-patterns`](../pr-body-sections/section-patterns/SKILL.md)** and **[`pr-body-skeleton`](../pr-content/pr-body-skeleton/SKILL.md)**.
+- **Triple pass:** (1) TL;DR + outline cover §6 themes by concern? (2) form (lists, tables only when tiny)? (3) claims match §6 **and** any optional keyword line matches the **§9** mutation summary (issue numbers + **`Refs`** vs **`Fixes`/`Closes`**) before **`gh pr`** runs? Hand title/body to **`@gh-pr`** §9.
+
+### Existing PR as template
+
+When **`PR_NUM`** is set: reuse **voice** / **headings** / **emoji cadence** from the open PR body only—rebuild **facts** from §6; do not treat the old body as authority for paths or behavior.
+
+### Title
+
+**[`title-line`](../pr-content/title-line/SKILL.md)** — plain text, no emoji.
+
+### Body — canonical structure
+
+**[`internal-read-gh-pr-body-sections/section-patterns/SKILL.md`](../pr-body-sections/section-patterns/SKILL.md)** — normative when **`canonical`** or when normalizing.
+
+---
+
+## Do not
+
+- PR mutation or **Proceed** for **`gh pr create`/`edit`** (parent §9).
+- Skip **`internal-read-gh-repo-forms-json`** when Step A applies and **`gh`** is expected.
+
+## See also
+
+- [`internal-read-gh-repo-forms-json`](../repo-forms-json/SKILL.md)
+- [`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)
+- [`internal-read-gh-issue-list`](../issue-list/SKILL.md)
+- [`internal-read-gh-issue-projects-relationships`](../issue-projects-relationships/SKILL.md)
+- [`internal-write-gh-pr-commands`](../../write/gh/pr-commands/SKILL.md)
+- [`@gh-pr`](../../../gh/pr/SKILL.md)

--- a/.agents/skills/internal-read-gh-pr-list-list-view-hub/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-list-list-view-hub/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: internal-read-gh-pr-list-list-view-hub
+description: >-
+  Read-only: PR list/view narrative hub (no duplicate gh fences). Parent internal-read-gh-pr-list.
+---
+
+# PR list / view hub
+
+**Normative command fences** live in [`internal-read-gh-pr-list`](./SKILL.md). **PR mutations** (`gh pr create`, `gh pr edit`, `gh pr close`) live in [`internal-write-gh-pr-commands`](../../../write/gh/pr-commands/SKILL.md).
+
+**Fork / upstream:** set **`--repo`** when viewing or listing against **`$UPSTREAM`** per [`internal-read-gh-repo-stream`](../repo-stream/SKILL.md).
+
+| Task | Skill | Internal shapes |
+| --- | --- | --- |
+| Inventory / pick a PR | **`@gh-pr-list`** | **`internal-read-gh-pr-list`** — add **`--state`**, **`--head`**, **`--base`**, **`--limit`**, **`--json`**, **`--repo`** per caller |
+| Inspect one PR | **`@gh-pr-view`** | **`internal-read-gh-pr-list`** **View** / **`gh pr diff --stat`** |
+| Close a PR | **`@gh-pr-close`** | **`internal-write-gh-pr-commands`** **Close PR** (after **Proceed**) |
+
+**Do not** use this hub to **replace** **`@gh-pr`** for **`gh pr create`** / **`gh pr edit`**—those stay behind **`@git-pull`** + **`@git-review`** + **`@git-push`** + **`internal-read-gh-pr-description`**.
+
+When `@gh-pr` finds non-empty matching inventory, it may run an intent AskQuestion (edit existing vs create new vs abort) before drafting; command fences still stay in **`internal-read-gh-pr-list`**.
+
+**Safety:** Any **online mutation** or **write outside the git workspace root** requires **Goal + structured confirm** per **`internal-write-plan-skill-safety`** before execution.

--- a/.agents/skills/internal-read-gh-pr-list/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-list/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: internal-read-gh-pr-list
+description: >-
+  Normative gh pr list, gh pr view, and gh pr diff --stat read-only shapes. Callers add --state, --head, --base, --limit,
+  --json, and --repo per goal; PR mutations live in internal-write-gh-pr-commands.
+---
+
+# Internal: GitHub pull request list / view (`internal-read-gh-pr-list`)
+
+**Library.** **Sole** normative **`gh pr list`**, **`gh pr view`**, and read-only **`gh pr diff --stat`** fences for this pack. Consumed by **`@gh-pr-list`**, **`@gh-pr-view`**, **`@gh-pr`** (PR number lookup), and **`internal-write-gh-pr-commands`**.
+
+**Mutations** (**`gh pr create`**, **`gh pr edit`**, **`gh pr close`**) live in **[`internal-write-gh-pr-commands`](../../write/gh/pr-commands/SKILL.md)**—never run those from this file.
+
+## Cadence (read-only)
+
+**Faster in inventory-only flows** — This library **only** hits GitHub for **read** list/view/diff-stat. **Parents** that are read-only (**`@gh-pr-list`**, **`@gh-pr-view`**, **`@gh-pr`** lookup, …) may use it **without** an extra **AskQuestion** from this file. **Do not** infer **Proceed** for **`gh pr close`** or **`gh pr create`/`edit`**—those use **`internal-write-gh-pr-commands`** or **`@gh-pr`** with their own confirms.
+
+## Online changes and paths outside the repo
+
+- **This file is read-only** — listing/viewing PRs does **not** replace **Goal + structured confirm** for any follow-on **`gh`** / API write.
+- **Inventory stays lightweight** — no mandatory **Abort / Review / Proceed** stack for routine reads; mutation parents own **Proceed** per **`internal-write-plan-skill-safety`** / **`internal-write-plan-structured-qa`** **§1e** before writes.
+- **Parent skills** that call **`internal-read-gh-pr-list`** and then **mutate** GitHub or **write outside the git workspace root** must apply **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** before those writes.
+- **Master-confirm rule** — even with **`SKIP_QA_*`** / **`SKIP_QA_WRITE`**, follow-on high-risk writes still require session-level confirm in the owning mutation skill.
+
+## Caller refinement (flags)
+
+**Callers** compose the right flags for the question, for example:
+
+- **`--state open`** | **`closed`** | **`merged`** | **`all`** (see **`gh pr list --help`** for your **`gh`** version)
+- **`--head`** / **`--base`** (branch filters)
+- **`--limit N`**
+- **`--json field1,field2,…`**
+- **`--repo owner/repo`** (**fork/upstream:** **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)**)
+
+## List (current repo)
+
+Open PRs for the **current branch** (same-repo):
+
+```bash
+gh pr list --head "$(git branch --show-current)" --state open --json number,title,url --limit 20
+```
+
+All open PRs (cap output in chat):
+
+```bash
+gh pr list --state open --limit 30
+```
+
+**Closed, not merged** (optional read-only inventory):
+
+```bash
+gh pr list --state closed --limit 200 \
+  --json number,title,state,mergedAt,url \
+  --jq 'map(select(.mergedAt == null))'
+```
+
+Use **`--repo owner/repo`** when not using default **`gh`** context.
+
+**Merged only** (housekeeping/reporting where merged history is needed):
+
+```bash
+gh pr list --state merged --limit 200 --json number,title,state,mergedAt,url
+```
+
+## View (single PR)
+
+By number:
+
+```bash
+gh pr view 42 --json title,body,state,url,headRefName,baseRefName
+```
+
+Body-focused JSON (house-style hint for **`@gh-pr`**):
+
+```bash
+gh pr view 42 --json title,body
+```
+
+**GraphQL id** (for GraphQL APIs that accept pull request node ids):
+
+```bash
+gh pr view <N> --json id,number,title,state
+```
+
+Optional diff stat:
+
+```bash
+gh pr diff 42 --stat
+```
+
+## Example — PR from current branch
+
+**Input:** “Do I already have a PR from this branch?”
+
+```bash
+BRANCH=$(git branch --show-current)
+gh pr list --head "$BRANCH" --base main --state open --json number,title,url
+```
+
+**Output (sample JSON line):** `{"number":7,"title":"Add issue label playbook","url":"https://github.com/org/repo/pull/7"}`
+
+## Example — view before edit
+
+**Input:** “Show PR 7 title and base.”
+
+```bash
+gh pr view 7 --json number,title,baseRefName,headRefName,state
+```
+
+## See also
+
+- **[`internal-write-gh-pr-commands`](../../write/gh/pr-commands/SKILL.md)** — **`gh pr create`**, **`gh pr edit`**, and **`gh pr close`**.
+- **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)** — **`--repo`**, head/base for **`@gh-pr`**.
+- [`@gh-pr-list`](../../../gh/pr/list/SKILL.md) · [`@gh-pr-view`](../../../gh/pr/view/SKILL.md)
+- **[`list-view-hub/SKILL.md`](./list-view-hub/SKILL.md)** — narrative hub (no duplicate fences).
+- [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md) · [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/internal-read-gh-pr-list/list-view-hub/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-list/list-view-hub/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: internal-read-gh-pr-list-list-view-hub
+description: >-
+  Read-only: PR list/view narrative hub (no duplicate gh fences). Parent internal-read-gh-pr-list.
+---
+
+# PR list / view hub
+
+**Normative command fences** live in [`internal-read-gh-pr-list`](./SKILL.md). **PR mutations** (`gh pr create`, `gh pr edit`, `gh pr close`) live in [`internal-write-gh-pr-commands`](../../../write/gh/pr-commands/SKILL.md).
+
+**Fork / upstream:** set **`--repo`** when viewing or listing against **`$UPSTREAM`** per [`internal-read-gh-repo-stream`](../repo-stream/SKILL.md).
+
+| Task | Skill | Internal shapes |
+| --- | --- | --- |
+| Inventory / pick a PR | **`@gh-pr-list`** | **`internal-read-gh-pr-list`** — add **`--state`**, **`--head`**, **`--base`**, **`--limit`**, **`--json`**, **`--repo`** per caller |
+| Inspect one PR | **`@gh-pr-view`** | **`internal-read-gh-pr-list`** **View** / **`gh pr diff --stat`** |
+| Close a PR | **`@gh-pr-close`** | **`internal-write-gh-pr-commands`** **Close PR** (after **Proceed**) |
+
+**Do not** use this hub to **replace** **`@gh-pr`** for **`gh pr create`** / **`gh pr edit`**—those stay behind **`@git-pull`** + **`@git-review`** + **`@git-push`** + **`internal-read-gh-pr-description`**.
+
+When `@gh-pr` finds non-empty matching inventory, it may run an intent AskQuestion (edit existing vs create new vs abort) before drafting; command fences still stay in **`internal-read-gh-pr-list`**.
+
+**Safety:** Any **online mutation** or **write outside the git workspace root** requires **Goal + structured confirm** per **`internal-write-plan-skill-safety`** before execution.

--- a/.agents/skills/internal-read-gh-pr-preflight-qa/SKILL.md
+++ b/.agents/skills/internal-read-gh-pr-preflight-qa/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: internal-read-gh-pr-preflight-qa
+description: >-
+  Read-only question bank for @gh-pr pre-flight. Ensures source/target branch intent, readiness, and
+  overlap handling are clarified before create/edit mutations.
+---
+
+# PR pre-flight Q&A
+
+Use this before PR create/edit mutation.
+
+## Gather (deducible first)
+
+- Source branch (`HEAD`) and target base branch.
+- Existing matching PRs by head/base/title.
+- Repo stream context (same-repo vs fork).
+
+## Clarify (ask when ambiguous)
+
+- Should this update an existing PR or open a new PR?
+- If existing PR matches, which PR number should be edited?
+- Is branch state ready to ship (green checks expected)?
+- Any explicit reason to keep draft/WIP instead of ready-for-review?
+
+## AskQuestion shape
+
+- Summarize match evidence in the prompt text.
+- Offer safe-first choices: Abort / Edit existing / Create new.
+- Use one refinement outlet only.
+
+## See also
+
+- [`internal-read-gh-pr-list`](../pr-list/SKILL.md)
+- [`internal-read-gh-pr-description`](../pr-description/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)
+- [`@gh-pr`](../../../../gh/pr/SKILL.md)

--- a/.agents/skills/internal-read-gh-project-item-list/SKILL.md
+++ b/.agents/skills/internal-read-gh-project-item-list/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: internal-read-gh-project-item-list
+description: >-
+  Normative gh project item-list shapes, normalized item fields, v1 body-based dependency edges, Kahn-style topological
+  layers with cycle and unresolved-edge reporting. Read-only. Behavioral parity with tests/check-project-order-fixtures.py.
+---
+
+# Internal: GitHub project item list + order analysis (`internal-read-gh-project-item-list`)
+
+**Library.** **Sole** normative **`gh project item-list`** fences for this pack plus the **v1 dependency / layering contract** consumed by **`@gh-project-order-readonly`**.
+
+**Mutations** (**`gh project item-edit`**, **`item-archive`**, **`item-delete`**, reorder APIs, …) are **out of scope** for v1—never run them from this file. Inventory-only reads and in-chat analysis only.
+
+## Behavioral parity (automated)
+
+Layering, cycle detection, and unresolved-edge classification **must match** the stdlib checker **[`tests/check-project-order-fixtures.py`](../../../../tests/check-project-order-fixtures.py)** (fixtures under **`tests/fixtures/project-order/`**). If prose and code diverge, **fix the SKILL or the checker** so they agree.
+
+## Cadence (read-only)
+
+This library is read-only and needs **no** **Proceed** gate for listing or analysis. Do **not** imply permission to run any **`internal-write-gh-project-commands`** fence from this file.
+
+## Auth scope
+
+`gh project` commands require token scope **`project`**. Verify with:
+
+```bash
+gh auth status
+```
+
+If needed:
+
+```bash
+gh auth refresh -s project
+```
+
+## Resolve project number (owner scope)
+
+Use **[`internal-read-gh-project-list`](../project-list/SKILL.md)** when the user names a board by title or you need to disambiguate **`NUMBER`** + **`OWNER`**.
+
+```bash
+gh project list --owner "@me" --limit 50 --format json
+```
+
+## List items on a project (normative base)
+
+```bash
+gh project item-list <NUMBER> --owner "@me" --format json --limit 200
+```
+
+### Caller refinement (flags)
+
+- `--owner "@me"` or `--owner ORG_LOGIN`
+- `--limit N` (CLI default is low; prefer **`-L 200`** or documented cap for boards)
+- `--format json` (required for machine parsing)
+- `--query '…'` when supported (see `gh project item-list --help`); GHES may omit advanced query
+
+### Compact preview (jq)
+
+```bash
+gh project item-list 1 --owner "@me" --format json -L 50 --jq '.items[] | {title: .title, type: .content.type, number: .content.number, repo: .repository}'
+```
+
+## JSON shape (normative expectations)
+
+Hosts and CLI versions vary; treat these as **required for analysis** when present:
+
+- Top-level **`items`** — array of project items.
+- Per item (typical Projects v2 via CLI):
+  - **`id`** — project item node id (stable within the project).
+  - **`title`** — display title (may mirror content).
+  - **`repository`** — `owner/name` string when the item is linked to a repo object.
+  - **`content`** — object when the item wraps GitHub content:
+    - **`type`** — e.g. `Issue`, `PullRequest`, or draft types.
+    - **`number`** — issue/PR number when applicable.
+    - **`body`** — issue/PR body text used for **v1 edge parsing** (may be empty).
+    - **`title`** — content title when distinct from top-level title.
+
+When **`content.body`** is missing, treat **`body` as empty** for edge parsing (no inferred edges).
+
+## Normalization contract (in-chat)
+
+For each item, derive:
+
+| Field | Rule |
+| --- | --- |
+| **`id`** | Prefer CLI `id`; else stable synthetic key from `(repo,number,type)` for reporting. |
+| **`kind`** | Lowercased mapping: issue-like → **`issue`**; PR → **`pull_request`**; draft-only → **`draft`**; unknown → **`unknown`**. |
+| **`repo`** | `owner/name` from `repository` when present; else **unknown** (skip same-repo `#` edges; see unresolved). |
+| **`number`** | Integer when `content.number` exists for issues/PRs; else **null**. |
+| **`title`** | Prefer `content.title` then item `title`. |
+| **`body`** | `content.body` or empty string. |
+
+## v1 dependency edges (body lines only)
+
+**Source of truth:** explicit **line prefixes** in the issue body (same-repo **`#n`** references only). Aligns with **[`internal-read-gh-issue-projects-relationships`](../issue-projects-relationships/SKILL.md)** §3.3 body fallback guidance.
+
+### Accepted prefixes (case-insensitive)
+
+Each line is evaluated independently; leading/trailing whitespace ignored:
+
+1. **`Blocked by: …`**
+2. **`Parent: …`**
+3. **`Depends on: …`**
+
+After the colon, collect every **`#<digits>`** token as a referenced issue number **in the same repository as the item** (v1 does not parse cross-repo URLs).
+
+### Semantics (prerequisite graph)
+
+- **`Blocked by: #N`** on issue **X** means **N** is a prerequisite of **X** → directed edge **`N → X`** (complete **N** before **X**).
+- **`Depends on: #N`** → **`N → X`**.
+- **`Parent: #N`** on child **X** → **`N → X`** (parent precedes child work in v1 ordering).
+
+### Missing targets
+
+If **`#N`** is parsed but **N** is not an **issue on the same project board** (normalized issue set), record **`unresolvedEdges`** with `{ from: X, to: N, reason: "target_not_on_board" }` and **do not** add that edge to the graph.
+
+References on lines that **do not** match the three prefixes are **ignored** for edges (free text may mention `#123` without creating a dependency).
+
+## Pull requests and drafts (v1)
+
+- Include them in **inventory** and reporting groups.
+- **Do not** auto-parse PR/draft bodies for dependency edges in v1 (unclear semantics vs issues). List under **`skippedNonIssues`** (or equivalent prose) so absence of edges is explicit.
+
+## Algorithm (Kahn layers + cycles)
+
+1. **Nodes** — all **issues** on the board (`kind == issue` with a `number`).
+2. **Edges** — only for references that resolved to on-board issues (`N → X`).
+3. **In-degree** — count incoming edges inside the node set.
+4. **Layers** — repeatedly take every node with **in-degree 0**, remove them, decrement in-degrees of successors. Each removal wave is one **parallel track** (items in a layer may proceed concurrently).
+5. **Order within a layer** — stable **item-list order** (the order items appeared in **`gh project item-list`** JSON) to break ties.
+6. **Cycles** — if remaining nodes exist and **no** in-degree-0 node exists, **Kahn stalls**. Emit one cycle group as those remaining nodes **sorted by item-list order** (v1 treats the entire stall set as one reported cycle component for readability on small boards).
+
+## Output schema (report to chat)
+
+| Key | Meaning |
+| --- | --- |
+| **`layers`** | Ordered list of layers; each layer is issue **numbers** (or `id` + title if numbers absent). |
+| **`cycles`** | List of stall components (issue numbers) when cyclic; empty when DAG resolved completely. |
+| **`unresolvedEdges`** | Parsed refs that could not become edges. |
+| **`skippedNonIssues`** | PRs/drafts/other items not fed into the issue DAG (v1). |
+
+## Large boards
+
+Prefer **`-L 200`** (or document a cap). When truncated, state **truncation** in chat and avoid implying a complete graph.
+
+## Worked examples (mental / fixture-backed)
+
+Fixture JSON lives under **`tests/fixtures/project-order/`**; expected outputs are asserted in **`tests/check-project-order-fixtures.py`**.
+
+- **`no-edges.json`** — independent issues; single layer preserving list order.
+- **`dag.json`** — chain `1 → 2 → 3` via `Blocked by` / `Depends on`; three singleton layers.
+- **`cycle.json`** — mutual prerequisite lines; **no** complete layering; one **cycle** group `[1, 2]`.
+- **`missing-ref.json`** — `Blocked by: #999` when **999** not on board → **unresolvedEdges**; remaining issues stay in one layer with stable order.
+
+## See also
+
+- **[`internal-read-gh-project-list`](../project-list/SKILL.md)** — `gh project list` inventory.
+- **[`internal-read-gh-issue-projects-relationships`](../issue-projects-relationships/SKILL.md)** — project attach + relationship playbook.
+- **[`@gh-project-order-readonly`](../../../gh/projects/order-readonly/SKILL.md)** — public read-only entry.
+- **[`internal-write-gh-project-commands`](../../../write/gh/project-commands/SKILL.md)** — mutating project CLI fences (do not invoke from this read path).

--- a/.agents/skills/internal-read-gh-project-list/SKILL.md
+++ b/.agents/skills/internal-read-gh-project-list/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: internal-read-gh-project-list
+description: >-
+  Normative gh project list inventory shapes. Read-only. Callers add --owner, --closed, --limit, and --format/--jq
+  flags per goal; mutation lives in internal-write-gh-project-commands.
+---
+
+# Internal: GitHub project list (`internal-read-gh-project-list`)
+
+**Library.** **Sole** normative **`gh project list`** fences for this pack. Consumed by **`@gh-project-delete-closed`** for preview/inventory before any delete mutation.
+
+**Mutations** (**`gh project delete`**) live in **[`internal-write-gh-project-commands`](../../../write/gh/project-commands/SKILL.md)**—never run those from this file.
+
+## Cadence (read-only)
+
+This library is read-only and can run without a mutation confirm. Do **not** infer that **Proceed** is satisfied for any follow-on **`gh project delete`** command.
+
+## Auth scope
+
+`gh project` commands require token scope **`project`**. Verify with:
+
+```bash
+gh auth status
+```
+
+If needed, add scope:
+
+```bash
+gh auth refresh -s project
+```
+
+## Caller refinement (flags)
+
+Use the fenced shapes below as bases. Callers add flags for the task at hand:
+
+- `--owner "@me"` or `--owner ORG_LOGIN`
+- `--limit N`
+- `--closed` (includes closed projects in the result set)
+- `--format json` (structured preview output)
+- `--jq '…'` to filter for closed-only views and compact previews
+
+## List projects for an owner
+
+```bash
+gh project list --owner "@me" --limit 30 --format json
+```
+
+## List including closed candidates
+
+```bash
+gh project list --owner "@me" --closed --limit 100 --format json
+```
+
+## Closed-only compact preview (owner + number + title)
+
+```bash
+gh project list --owner "@me" --closed --limit 100 --format json --jq '.projects[] | select(.closed == true) | {owner: .owner.login, number: .number, title: .title}'
+```
+
+## See also
+
+- **[`internal-read-gh-issue-projects-relationships`](../issue-projects-relationships/SKILL.md)** — attach issues to projects from `@gh-issues` (read-only playbook + discovery).
+- **[`internal-write-gh-project-commands`](../../../write/gh/project-commands/SKILL.md)** — `gh project delete` command shapes.
+- **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** — required before any project deletion flow.

--- a/.agents/skills/internal-read-gh-repo-forms-json/SKILL.md
+++ b/.agents/skills/internal-read-gh-repo-forms-json/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: internal-read-gh-repo-forms-json
+description: >-
+  Read-only: sole normative gh repo view --json shapes for issueTemplates and pullRequestTemplates. Callers own
+  JSON parsing, merge rules, and AskQuestion. Does not replace internal-read-gh-repo-stream for fork/same-repo refs.
+---
+
+# Internal: `gh repo view` forms JSON (`internal-read-gh-repo-forms-json`)
+
+**Read-only library.** **Single owner** of the **`gh repo view … --json …`** invocations used to load **GitHub-hosted** issue and pull-request templates from the API. **Callers** (**[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** §5 Step A, **[`internal-read-gh-issue-description`](../issue-description/SKILL.md)** §1 Step A) **run** these lines in the shell and **parse** output in their own sections—**do not** paste duplicate **`gh`** recipes into other **`SKILL.md`** files or **`docs/**`**.
+
+**Prerequisites:** **`$UPSTREAM`**, **`PR_TARGET_REPO`**, and same-repo vs fork semantics live in **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)** §3—this file does **not** repeat that table.
+
+---
+
+## Pull request templates (`pullRequestTemplates`)
+
+Pick the **host** the same way **`internal-read-gh-pr-description`** §5 expects (same-repo → current **`gh`** context; fork → upstream **`owner/repo`** string):
+
+| Case | Command |
+| --- | --- |
+| **Same-repo** | `gh repo view --json pullRequestTemplates` |
+| **Fork** | `gh repo view "$UPSTREAM" --json pullRequestTemplates` |
+
+On GitHub Enterprise, set **`GH_HOST`** (or your **`gh`** host config) so the command hits the right server.
+
+**Optional length probe** (still read **full** template entries when length **> 0**):
+
+```bash
+gh repo view … --json pullRequestTemplates --jq '(.pullRequestTemplates | length)'
+```
+
+Use **`…`** as **`"$UPSTREAM"`** or omit for default context—**consistent** with the table row you chose.
+
+---
+
+## Issue templates (`issueTemplates`)
+
+| Case | Command |
+| --- | --- |
+| **Default** (templates for the **current** **`gh`** repository context—typical when filing on the checkout) | `gh repo view --json issueTemplates` |
+| **Upstream host** (fork workflow: load upstream’s template set—same **`$UPSTREAM`** string as the PR table) | `gh repo view "$UPSTREAM" --json issueTemplates` |
+
+**Optional length probe:**
+
+```bash
+gh repo view … --json issueTemplates --jq '(.issueTemplates | length)'
+```
+
+---
+
+## Combined fetch (same host only)
+
+When both JSON keys are needed in **one** round trip for the **same** host:
+
+```bash
+gh repo view … --json issueTemplates,pullRequestTemplates
+```
+
+**Callers** still split **PR-only** vs **issue-only** parsing and merge rules—this file supplies **commands** only.
+
+---
+
+## Do not
+
+- Copy these **`bash`** fences into **`internal-read-gh-pr-description`**, **`internal-read-gh-issue-description`**, or **`docs/**`**—link here.
+- Re-document **`$UPSTREAM`** / **`PR_TARGET_REPO`**—use **`internal-read-gh-repo-stream`**.
+
+## See also
+
+- **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)** — variables for **`gh repo view`**
+- **[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** — PR template body parsing, §6 delta, §6.5–6.6 linking ladder + issue scan, §7 title/body
+- **[`internal-read-gh-issue-description`](../issue-description/SKILL.md)** — issue template parsing and reshape rules

--- a/.agents/skills/internal-read-gh-repo-stream/SKILL.md
+++ b/.agents/skills/internal-read-gh-repo-stream/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: internal-read-gh-repo-stream
+description: >-
+  Read-only library: classify fork vs same-repo, canonical main ref, PR target repo, BASE_GIT, and PR head/base for gh
+  and git callers (no network I/O in this file). No fetch, merge, or gh pr create—callers run their own commands. Used by
+  @git-main, @git-pull, @gh-pr, @git-reset.
+---
+
+# Internal: Git repo stream (fork vs same-repo)
+
+**Read-only.** Discover **where canonical `main` lives** and **where a pull request is opened** (rules for **`git`** remotes/branches **and** **`gh --repo`** targets). Do **not** run `git fetch`, merges, `git reset`, or `gh pr create` here—parent skills own those steps.
+
+**Consumers:** **[`@git-main`](../../../git/main/SKILL.md)** (`CANONICAL_MAIN`), **[`@git-pull`](../../../git/pull/SKILL.md)** (`ROOT_BRANCH`), **[`@gh-pr`](../../../gh/pr/SKILL.md)** (`$BASE_GIT`, `$UPSTREAM`, `gh` targets), **[`@git-reset`](../../../git/reset/SKILL.md)** (aligning `main` to upstream when applicable).
+
+## Do
+
+- Classify fork vs same-repo and resolve **canonical main**, **PR targets**, and **`BASE_GIT`** for parent skills.
+
+## Do not
+
+- Run **`git fetch`**, merges, **`git reset`**, or **`gh pr create`**—parent skills own those steps.
+
+---
+
+## 1. Detect fork vs same-repo
+
+1. Run **`git remote get-url upstream`** (or equivalent).
+2. **If success** — treat as **fork**:
+   - **`UPSTREAM`** — `owner/repo` parsed from the URL (SSH or HTTPS).
+   - **`FORK_OWNER`** — owner from **`git remote get-url origin`** (the fork’s GitHub user or org).
+   - **`STREAM_MODE`** = `fork`.
+3. **If failure** — **same-repo** clone:
+   - **`UPSTREAM`** — unset / empty (no upstream remote).
+   - **`STREAM_MODE`** = `same_repo`.
+
+**If the workflow is a fork but `upstream` is missing** — **stop**; suggest `git remote add upstream <url>` and fetch. Do not guess **`UPSTREAM`**.
+
+---
+
+## 2. Canonical main ref (`CANONICAL_MAIN_REF`)
+
+Single definition used by **`@git-main`** and **`@git-pull`** for “tip of mainline in this workspace”:
+
+| Condition | `CANONICAL_MAIN_REF` |
+| --- | --- |
+| **`upstream` remote exists** | **`upstream/main`** |
+| **Else** | **`origin/main`** |
+
+Verify with **`git rev-parse "$CANONICAL_MAIN_REF"`** after remotes are fetched (callers fetch; this skill does not).
+
+**Alias:** **`ROOT_BRANCH`** in **`@git-pull`** = **`CANONICAL_MAIN_REF`**. **`CANONICAL_MAIN`** in **`@git-main`** = same ref.
+
+---
+
+## 3. PR-oriented fields (for `@gh-pr` and `gh`)
+
+Use **after** §1–§2 so **`STREAM_MODE`**, **`UPSTREAM`**, and **`FORK_OWNER`** are set.
+
+| Variable | Fork (`STREAM_MODE=fork`) | Same-repo |
+| --- | --- | --- |
+| **`BASE_GIT`** | **`upstream/main`** | **`main`** or **`origin/main`**—match how **`@git-pull`** merged canonical **`main`** into the branch (typically **`main`** if checked out, else **`origin/main`**) |
+| **`PR_TARGET_REPO`** | **`$UPSTREAM`** (`owner/repo` for `gh --repo`, `gh repo view`) | Current repo (**`gh repo view`** without `--repo` override) |
+| **`PR_BASE_BRANCH`** | **`main`** on **`$UPSTREAM`** | **`main`** |
+
+**GitHub PR base:** always **`main`** on the **destination** repo (**`$UPSTREAM`** for forks, else the current repo).
+
+**Issue list / search / URLs:** For **`@gh-pr`** and **`internal-read-gh-pr-description`** §6.6, use **`PR_TARGET_REPO`** as **`--repo owner/repo`** and as **`https://github.com/OWNER/REPO/...`** host for issues and PRs on the **destination** (upstream when forking), unless the issue genuinely lives on the fork.
+
+---
+
+## 4. PR head ref (`--head` for `gh pr create`)
+
+Let **`BRANCH`** = `git branch --show-current`.
+
+| `STREAM_MODE` | `BRANCH` | PR **head** argument |
+| --- | --- | --- |
+| **same_repo** | `main` | *(no PR from this skill’s perspective—**`@gh-pr`** stops after sync)* |
+| **same_repo** | feature | **`$BRANCH`** |
+| **fork** | `main` | **`$FORK_OWNER:main`** — open PR **from fork’s `main`** to **`$UPSTREAM`** **`main`** |
+| **fork** | feature | **`$FORK_OWNER:$BRANCH`** |
+
+This is the **“proceed toward upstream”** case when you are on **fork `main`**: the PR targets **`$UPSTREAM`**, not the fork as base.
+
+---
+
+## 5. `gh` commands (reference—run in parent skill)
+
+- **List / create / edit PR (fork):** pass **`--repo "$UPSTREAM"`** where **`@gh-pr`** already does.
+- **Templates:** **`gh repo view --json`** shapes for **`pullRequestTemplates`** / **`issueTemplates`** live **only** in **[`internal-read-gh-repo-forms-json`](../repo-forms-json/SKILL.md)**—use the **fork** / **`$UPSTREAM`** rows there when **`PR_TARGET_REPO`** is upstream (not the fork as template host).
+
+---
+
+## 6. Relation to `@git-reset` target
+
+When **`@git-reset`** resolves **`$TARGET`** and the branch is **`main`** with **`upstream/main`** available, prefer **`upstream/main`** as the canonical tip—consistent with **`CANONICAL_MAIN_REF`** above. **`@git-reset`** still uses tracking **`@{u}`** first when set; see that skill’s priority list.

--- a/.agents/skills/internal-read-gh/SKILL.md
+++ b/.agents/skills/internal-read-gh/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: internal-read-gh
+description: >-
+  Internal GitHub-oriented read-only libraries: issue and PR description helpers, list/view shapes, and repo metadata.
+---
+
+# `skills/read/gh/`
+
+Read-only GitHub libraries consumed by `@gh-*` and related planning workflows.
+
+- Issue helpers: `issue-list`, `issue-dedupe`, `issue-spec`, `issue-description`, `issue-labels`, `issue-projects-relationships`.
+- Project helpers: `project-list`, `project-item-list`.
+- PR helpers: `pr-list`, `pr-content`, `pr-description`, `pr-body-sections`.
+- Repo metadata helpers: `repo-stream`, `repo-forms-json`.
+
+These libraries define inventory and narrative guidance without direct GitHub mutations.

--- a/.agents/skills/internal-read-gh/issue-dedupe/SKILL.md
+++ b/.agents/skills/internal-read-gh/issue-dedupe/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: internal-read-gh-issue-dedupe
+description: >-
+  Read-only: list/search open issues, flag near-duplicates vs one or more candidate title+body rows; no gh writes.
+  Pasteable checklist: ./dedupe-checklist/SKILL.md. Callers: @gh-issues, @gh-issue-review.
+---
+
+# Internal: Issue dedupe (`internal-read-gh-issue-dedupe`)
+
+**Read-only library.** Compare **one or more candidate** issues (each: title + summary lines) to **open** issues using **`gh`**. **No** `gh issue create`, **no** comments, **no** closes.
+
+**Consumers:** **`@gh-issues`**, **`@gh-issue-review`** (overlap pass), optionally humans.
+
+## Do
+
+1. Follow **[`dedupe-checklist/SKILL.md`](./dedupe-checklist/SKILL.md)** (**§1** defers all **`gh issue list`** / **`gh search issues`** shapes to **`internal-read-gh-issue-list`**—**do not** duplicate flags here).
+2. Emit a short verdict **per candidate**: **`safe_to_create`** | **`likely_duplicate #n`** | **`ambiguous`** (list candidate numbers + one-line reason each). For a **single** candidate, one verdict is enough.
+
+**Reshape-review (optional caller: `@gh-issue-review`).** When the **candidate** text describes **refining existing issue `#N`**, treat a hit on **`#N` itself** as **self**, not a duplicate signal—only **other** numbers are **peer overlaps** or **likely duplicate** targets. Verdict labels stay the same; interpret **`likely_duplicate #m`** as “**`#m`** collides with the reshaped scope.”
+
+## `@gh-issues` orchestration order
+
+Use this sequence when `@gh-issues` routes create-or-update behavior.
+
+### Single candidate (default)
+
+1. **List / search** — run `@gh-issue-list` (or equivalent via [`internal-read-gh-issue-list`](../issue-list/SKILL.md) + [`dedupe-checklist/SKILL.md`](./dedupe-checklist/SKILL.md)) to inventory open issues before any write.
+2. **Dedupe verdict** — evaluate candidate title + body summary through this skill and return `safe_to_create` | `likely_duplicate #n` | `ambiguous`.
+3. **Branch**
+   - `likely_duplicate #n` (or `ambiguous` resolved to a single `#n`) -> treat as update path in `@gh-issues`.
+   - `safe_to_create` -> continue create path in `@gh-issues`.
+
+### Multi-candidate (optional `@gh-issues`)
+
+After **`@gh-issues`** has **partitioned themes** (chat and/or **[`internal-read-plan-parts`](../../plan/parts/SKILL.md)** + plan hub files):
+
+1. **List / search once** — same inventory pass as single-candidate step 1; reuse the same open-issue set for every theme. Optionally add a focused **`gh search issues`** query per theme only when the default list is too large to compare fairly.
+2. **Per-theme verdict** — for each theme, compare its working title + one-line intent to that inventory; emit `safe_to_create` | `likely_duplicate #n` | `ambiguous` **per row**. **Never** skip this for a theme that will end in **create**.
+3. **Merge similar themes before publish** — when two rows point at the same **`likely_duplicate #n`** or are clearly the same root cause, default to **one** issue (merge rows in the summary table); user confirms.
+4. **Aggregate** — hand off a table (theme → verdict → proposed **edit #n** or **create**) to **`@gh-issues`** for structured Q&A and one **Proceed — batch** per **`internal-write-plan-structured-qa`**.
+
+If clustering collapses to **one** theme, use **only** the single-candidate subsection above.
+
+Optional first pass: run `@gh-issue-review` on an existing issue when the body is weak and needs codebase + overlap analysis before deciding update vs create.
+
+## Do not
+
+- Mutate GitHub state.
+- Duplicate **`gh issue list`** / **`gh search issues`** recipes outside **`internal-read-gh-issue-list`** — the **checklist** template links there too.
+
+## See also
+
+- **[`internal-read-gh-issue-list`](../issue-list/SKILL.md)** — normative list/search **`gh`** lines.
+- [`@gh-issues`](../../../gh/issues/SKILL.md) · [`@gh-issue-review`](../../../gh/issues/review/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/internal-read-gh/issue-dedupe/dedupe-checklist/SKILL.md
+++ b/.agents/skills/internal-read-gh/issue-dedupe/dedupe-checklist/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: internal-read-gh-issue-dedupe-dedupe-checklist
+description: >-
+  Read-only: issue dedupe checklist (defers list shapes to internal-read-gh-issue-list). Parent internal-read-gh-issue-dedupe.
+---
+
+# Issue dedupe checklist
+
+Used by **`internal-read-gh-issue-dedupe`** and **`@gh-issues`** / **`@gh-issue-review`**.
+
+1. **List / search open issues** — use **only** the **List / search** and **Search** sections of [`internal-read-gh-issue-list`](../issue-list/SKILL.md) (`gh issue list`, `gh search issues`, flags, limits). **Do not** invent alternate **`gh`** shapes in this checklist.
+2. **Single candidate (default)** — Compare **titles** and first lines of **bodies** for near-duplicates against that inventory; note issue numbers. Output: **safe to create** / **likely duplicate #n** / **ambiguous — user must choose** (no **`gh`** writes in this phase).
+3. **Multi-candidate (`@gh-issues` multi-intent only)** — (a) **Theme list** — stable ids, working title, one-line intent per theme (after clustering in the router). (b) **Single inventory** — reuse the issue set from step 1 for every theme; do **not** repeat a full list pass unless a theme needs an extra targeted **`gh search issues`** (large backlog). (c) **Per-theme compare** — same title/body skim as step 2, independently per row. (d) **Aggregate user choice** — table: theme → verdict → proposed **edit #n** or **create**; flag rows that should **merge** before mutation (same **`likely_duplicate #n`** or same root cause). No **`gh`** writes in this phase.
+4. **`@gh-issue-review`** — same list/compare mechanics for **reshape** context; when reviewing **`#N`**, ignore **self** on **`#N`** when interpreting overlaps (see **`internal-read-gh-issue-dedupe`** reshape note).

--- a/.agents/skills/internal-read-gh/issue-description/SKILL.md
+++ b/.agents/skills/internal-read-gh/issue-description/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: internal-read-gh-issue-description
+description: >-
+  Read-only: discover GitHub/local issue templates vs pack body skeleton; when merge would materially reshape
+  repo template, structured AskQuestion (keep / blend / pack). Caller: gh-issues. Does not run gh.
+---
+
+# Internal: Issue description (templates vs pack)
+
+**Read-only library.** Run **after** **[`internal-read-gh-issue-dedupe`](../issue-dedupe/SKILL.md)** when the user wants a **tracked** issue, **before** drafting final **title/body** for the chosen create-or-edit path in **`@gh-issues`**. **Pack pasteable:** **[`issue-body-skeleton/SKILL.md`](./issue-body-skeleton/SKILL.md)**.
+
+**This library does not** run **`gh`** or **`AskQuestion`**. The **caller** runs **AskQuestion** when this file says **material reshape** applies, then **`gh`** after **`internal-write-plan-skill-safety`** confirm.
+
+---
+
+## 1. Discover issue templates
+
+### Step A — `gh repo view` (required when `gh` works)
+
+The **caller** executes the **`gh repo view … --json issueTemplates`** line(s) from **[`internal-read-gh-repo-forms-json`](../repo-forms-json/SKILL.md)** § **Issue templates** (default row unless the caller already chose the **upstream** row for fork parity). **Do not** duplicate those commands here.
+
+**Parse** **`issueTemplates`** (field may be **absent** on older **`gh`** builds—treat as empty and continue to **Step B**).
+
+- **One or more YAML/form** templates (`.github/ISSUE_TEMPLATE/**`) may appear as **names** only—if **no** usable **markdown body**, continue to **Step B**.
+- If **API returns usable markdown** for **exactly one** template → set **`$ISSUE_TEMPLATE_SOURCE`** = `github-api`, **`$ISSUE_TEMPLATE_BODY`** = that body.
+- **Two or more** usable markdown bodies → **template selection Q&A** per **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** (one option per template + **“Pack skeleton only”** → empty body, pack shape only).
+- **Empty / missing** → **Step B**.
+
+### Step B — Local files (when Step A yields nothing usable)
+
+Search the **current** clone:
+
+- **`.github/ISSUE_TEMPLATE.md`**, **`.github/issue_template.md`**
+- **`.github/ISSUE_TEMPLATE/*.md`** (ignore **`config.yml`** for body text)
+- **`docs/issue_template.md`** (optional convention)
+
+Use **`git ls-files`** + glob.
+
+- **Exactly one** **`.md`** → **`$ISSUE_TEMPLATE_SOURCE`** = `local`; **`$ISSUE_TEMPLATE_BODY`** = contents.
+- **Two or more** → **template selection Q&A** (same as PR **multiple templates** pattern).
+- **None** → **`$ISSUE_TEMPLATE_SOURCE`** = `canonical`; **`$ISSUE_TEMPLATE_BODY`** = **empty**.
+
+### Step C — Pack only
+
+**`$ISSUE_TEMPLATE_SOURCE`** = **`canonical`**; **`$ISSUE_TEMPLATE_BODY`** = **empty**. Draft body from **[`issue-body-skeleton/SKILL.md`](./issue-body-skeleton/SKILL.md)** and quality-check against **[`internal-read-gh-issue-spec`](../issue-spec/SKILL.md)**.
+
+---
+
+## 2. Material reshape vs pack skeleton
+
+When **`$ISSUE_TEMPLATE_BODY`** is **non-empty**, compare its **headings / required sections** to the pack **`body-skeleton`**. If applying the pack skeleton would **replace** the repo template’s top-level structure (e.g. force **Context / Proposal** where the template uses **Bug report** sections), treat as **material**.
+
+**Before** merging shapes, the **caller** runs **AskQuestion** (short labels), **separate** from the final **`gh issue create`** / **`gh issue edit`** confirm:
+
+1. **Keep repo template** — substance only inside existing sections.
+2. **Blend** — keep repo headings; add **non-duplicative** pack sections the template omits (minimal).
+3. **Pack skeleton** — draft from **`body-skeleton.md`**; ignore repo template **shape** (keep links/checklists from repo only if user asks in chat).
+
+Set **`$ISSUE_BODY_SHAPE_MODE`** to **`keep`** | **`blend`** | **`pack`** for the caller.
+
+When **`$ISSUE_TEMPLATE_SOURCE`** is **`canonical`**, set **`$ISSUE_BODY_SHAPE_MODE`** = **`pack`** with **no** extra modal.
+
+---
+
+## 3. Hand off
+
+Return to **`@gh-issues`**: draft **title** per **[`TITLE_LINE.md`](../pr-content/TITLE_LINE.md)**; draft **body** using **`$ISSUE_TEMPLATE_BODY`**, **`$ISSUE_TEMPLATE_SOURCE`**, and **`$ISSUE_BODY_SHAPE_MODE`**; then run **Goal** + **Proceed** before `gh`.
+
+## See also
+
+- **[`internal-read-gh-repo-forms-json`](../repo-forms-json/SKILL.md)** — **`gh repo view --json`** shapes for templates.
+- **[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** — PR-side discovery + merge rules (mirror concepts).
+- **[`internal-read-gh-issue-dedupe`](../issue-dedupe/SKILL.md)** — duplicate search before writes.
+- **[`internal-read-gh-issue-labels`](../issue-labels/SKILL.md)** — optional label proposals after title/body exist.

--- a/.agents/skills/internal-read-gh/issue-description/issue-body-skeleton/SKILL.md
+++ b/.agents/skills/internal-read-gh/issue-description/issue-body-skeleton/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-gh-issue-description-issue-body-skeleton
+description: >-
+  Read-only: GitHub issue body markdown skeleton. Parent internal-read-gh-issue-description.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for issue body skeleton guidance.
+

--- a/.agents/skills/internal-read-gh/issue-description/review-report/SKILL.md
+++ b/.agents/skills/internal-read-gh/issue-description/review-report/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-gh-issue-description-review-report
+description: >-
+  Read-only: issue review / reshape report scaffold. Parent internal-read-gh-issue-description.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for issue review-report guidance.
+

--- a/.agents/skills/internal-read-gh/issue-description/work-plan/SKILL.md
+++ b/.agents/skills/internal-read-gh/issue-description/work-plan/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-gh-issue-description-work-plan
+description: >-
+  Read-only: local plan scaffold embedding an issue. Parent internal-read-gh-issue-description.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for issue work-plan guidance.
+

--- a/.agents/skills/internal-read-gh/issue-labels/SKILL.md
+++ b/.agents/skills/internal-read-gh/issue-labels/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: internal-read-gh-issue-labels
+description: >-
+  Read-only: list repo labels, propose 0–3 candidates from title/body, match or suggest gh label create; command
+  shapes in label-decorate/SKILL.md. Caller: gh-issues. Does not run gh writes or AskQuestion.
+---
+
+# Internal: Issue labels (`internal-read-gh-issue-labels`)
+
+**Read-only library.** After **[`internal-read-gh-issue-description`](../issue-description/SKILL.md)** has set shape and you have a **draft title + body** (or the user supplied them), use this playbook to propose **GitHub labels**. **No** `gh label create`, **no** `gh issue create` / `edit` flags—**callers** run **AskQuestion** / structured confirm per **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)**.
+
+**Pack artifact:** **[`label-decorate/SKILL.md`](./label-decorate/SKILL.md)**.
+
+**Consumers:** **`@gh-issues`**, optionally humans.
+
+---
+
+## 1. Inventory existing labels
+
+Run the **Inventory (read-only)** command block in **[`label-decorate/SKILL.md`](./label-decorate/SKILL.md)** (same auth as other `gh` skills).
+
+Treat **exact name matches** (case-sensitive per GitHub) as **reuse**. Prefer **existing** labels over inventing new ones.
+
+---
+
+## 2. Propose 0–3 candidates
+
+From **title + first paragraph / acceptance criteria** in the body:
+
+1. **Area / domain** — e.g. paths `skills/gh/`, `docs/` → tokens like `area:skills`, `area:docs` only if the repo already uses that pattern; otherwise use **one** short area token consistent with existing names.
+2. **Type** — `bug`, `enhancement`, `documentation` only if an **existing** label matches or the repo uses GitHub defaults.
+3. **Stop at three** — do not spam labels; omit if nothing fits.
+
+**Naming hygiene** (new labels only—see **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** §2 for “short label” spirit):
+
+- Lowercase, **hyphens** not spaces; **no** emoji in label names.
+- Prefer **one** new label over three near-duplicates.
+
+---
+
+## 3. Match vs create
+
+For each **candidate**:
+
+- **Fuzzy match** an existing label (substring, plural/singular, `docs` vs `documentation`) → **map** to the existing name in the proposal table.
+- **No reasonable match** → mark **`needs_create`** with a one-line **description** and a neutral **`--color`** (e.g. `ededed` or repo palette if documented).
+
+**Caller:** If any **`needs_create`**, summarize **`gh label create NAME --color … --description "…"`** and obtain **structured confirm** before running **`gh label create`**. Then pass **`--label a,b`** on **`gh issue create`** or **`gh issue edit --add-label`** (confirm already required for those mutations).
+
+---
+
+## 4. Hand off
+
+Return to **`@gh-issues`**: attach labels in the chosen create-or-edit mutation path when the user Proceeds with a non-empty set; skip labels when the user declines.
+
+## See also
+
+- **[`internal-read-gh-issue-dedupe`](../issue-dedupe/SKILL.md)** — run **before** description for new issues.
+- **[`internal-read-gh-issue-description`](../issue-description/SKILL.md)** — templates vs pack body.

--- a/.agents/skills/internal-read-gh/issue-labels/label-decorate/SKILL.md
+++ b/.agents/skills/internal-read-gh/issue-labels/label-decorate/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: internal-read-gh-issue-labels-label-decorate
+description: >-
+  Read-only: gh label list/match/create command shapes. Parent internal-read-gh-issue-labels.
+---
+
+# Issue labels — decorate (examples)
+
+Used by **[`internal-read-gh-issue-labels`](./SKILL.md)** and **`@gh-issues`**.
+
+**Inventory (read-only):**
+
+```bash
+gh label list --json name,description,color --limit 200
+```
+
+---
+
+## Example A — Map to existing labels
+
+**Input (chat):** “Add label guidance for skills pack; touch `skills/read/gh/` and templates.”
+
+**Draft title:** `Document issue label heuristics for skill repos`
+
+**Draft body (excerpt):** “… acceptance: label list command, 0–3 labels, confirm before `gh label create` …”
+
+**Step:** Existing labels include `documentation`, `enhancement`.
+
+**Output (proposal table):**
+
+| Candidate | Action | GitHub label |
+| --- | --- | --- |
+| docs / templates | reuse | `documentation` |
+| feature work | reuse | `enhancement` |
+
+**Attach (preview, not run by agent until confirm):** use the canonical create shapes in **[`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md#create-issue-after-proceed)** and pass `--label "documentation,enhancement"` after the structured proceed gate.
+
+---
+
+## Example B — One new label, then attach
+
+**Input:** “Track flaky CI on `gh-pr` skill; file an issue.”
+
+**Draft title:** `Flaky CI when running gh-pr orchestration tests`
+
+**Existing labels:** `bug`, `ci` (no `area:gh`).
+
+**Step:** Propose **`ci`** + **`bug`**; suggest **`area:gh`** as **new** (repo has other `area:*` labels).
+
+**Output:**
+
+| Candidate | Action | Notes |
+| --- | --- | --- |
+| CI | reuse | `ci` |
+| defect | reuse | `bug` |
+| domain | **create** | `gh label create area:gh --color ededed --description "GitHub PR CLI skills"` → **structured confirm** first |
+
+**Then create issue:** use the same canonical create shapes in **[`internal-write-gh-issue-commands`](../../../../write/gh/issue-commands/SKILL.md#create-issue-after-proceed)** with `--label "ci,bug,area:gh"` after confirm.
+
+---
+
+## Do not
+
+- Attach **more than three** labels without explicit user ask.
+- Create labels that only duplicate an existing name with different spelling.

--- a/.agents/skills/internal-read-gh/issue-list/SKILL.md
+++ b/.agents/skills/internal-read-gh/issue-list/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: internal-read-gh-issue-list
+description: >-
+  Normative gh issue list and gh search issues inventory shapes. Read-only. Callers add --state, --label, --limit, --json,
+  and --repo flags per goal; mutation lives in internal-write-gh-issue-commands. Used by internal-read-gh-pr-description §6.6.
+---
+
+# Internal: GitHub issue list (`internal-read-gh-issue-list`)
+
+**Library.** **Sole** normative **`gh issue list`** and **`gh search issues`** fences for this pack. Consumed by **`@gh-issue-list`**, **`@gh-issues`** (inventory), **`@gh-issue-pick`**, **`@gh-issue-delete-closed`** (preview), **`@gh-issue-review`** (peer list), **`internal-read-gh-issue-dedupe`**, **`internal-read-gh-pr-description`** §6.6 (optional issue validation during **`@gh-pr`**), and **[`DEDUPE_CHECKLIST.md`](../issue-dedupe/DEDUPE_CHECKLIST.md)**.
+
+**Mutations** (**`gh issue create`/`edit`/`close`/`delete`**, …) live in **[`internal-write-gh-issue-commands`](../../write/gh/issue-commands/SKILL.md)**—never run those from this file.
+
+## Cadence (read-only)
+
+**Faster in inventory-only flows** — This library **only** hits GitHub for **read** list/search. **Parents** that are read-only (**`@gh-issue-list`**, **`@gh-issue-review`** peer pass, …) may use it **without** an extra **AskQuestion** from this file. **Do not** infer that **Proceed** is satisfied for a later **`gh issue`** **mutation**—that lives in **`internal-write-gh-issue-commands`** behind the right **`@gh-*`** skill.
+
+## Online changes and paths outside the repo
+
+- **This file is read-only** — listing/searching issues on GitHub does **not** replace **Goal + structured confirm** for any follow-on **`gh`** write.
+- **Inventory stays lightweight** — no mandatory **Abort / Review / Proceed** stack for routine reads; mutation parents own **Proceed** per **`internal-write-plan-skill-safety`** / **`internal-write-plan-structured-qa`** **§1e** before writes.
+- **Parent skills** that call **`internal-read-gh-issue-list`** and then **mutate** GitHub or **write outside the git workspace root** must apply **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** before those writes.
+- **Master-confirm rule** — even with **`SKIP_QA_*`** / **`SKIP_QA_WRITE`**, follow-on high-risk writes still require session-level confirm in the owning mutation skill.
+
+## Caller refinement (flags)
+
+Use the fenced shapes below as **bases**. **Callers** add flags for the task at hand, for example:
+
+- **`--state open`** | **`closed`** | **`all`**
+- **`--label "name"`** (repeat **`--label`** if **`gh`** supports it for your version)
+- **`--limit N`** (cap chat output)
+- **`--json field1,field2,…`** (machine-readable inventory)
+- **`--repo owner/repo`** when not using default **`gh`** context (**fork/upstream:** **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)**)
+
+## List / search (typical open inventory)
+
+```bash
+gh issue list --state open --limit 30
+```
+
+**Filter by label:**
+
+```bash
+gh issue list --state open --label "bug" --limit 30
+```
+
+**Search (broader)** — pass explicit **`owner/repo`** when not using default context:
+
+```bash
+gh search issues --repo owner/repo --state open --limit 30 "QUERY"
+```
+
+## List closed (inventory before bulk delete)
+
+```bash
+gh issue list --state closed --limit 200 --json number,title,state
+```
+
+## See also
+
+- **[`internal-write-gh-issue-commands`](../issue-commands/SKILL.md)** — **`gh issue view`**, create, edit, close, delete.
+- **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)** — **`--repo`** targets.
+- [`@gh-issue-list`](../../../gh/issues/list/SKILL.md) · [`@gh-issue-delete-closed`](../../../gh/issues/delete-closed/SKILL.md)
+- [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md) · [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/internal-read-gh/issue-preflight-qa/SKILL.md
+++ b/.agents/skills/internal-read-gh/issue-preflight-qa/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: internal-read-gh-issue-preflight-qa
+description: >-
+  Read-only question bank for @gh-issues pre-flight. Helps gather goal, examples, counterexamples, and
+  verification details before dedupe and mutation.
+---
+
+# Issue pre-flight Q&A
+
+Use this before any issue create/edit mutation.
+
+## Gather (deducible first)
+
+- Candidate title intent from user prompt and repository context.
+- Existing related issue numbers/titles from list/search.
+- Existing labels that might apply.
+- Whether the user is carrying **multiple independent themes** (long multi-section paste, many unrelated bullets, or a plan hub: **`.cursor/plan.md`** / linked **`.cursor/plans/<slug>.md`**) — see **[`internal-read-plan-parts`](../../plan/parts/SKILL.md)** and **`@gh-issues`** [Multi-intent clustering](../../../gh/issues/SKILL.md#multi-intent-clustering-optional).
+
+## Clarify (ask when ambiguous)
+
+- Goal: what outcome should be true after completion?
+- Examples: concrete "today vs desired" cases.
+- Counterexamples: explicitly out-of-scope or invalid behavior.
+- Constraints: compatibility, regressions to avoid, rollout risks.
+- Verification: acceptance and regression checks.
+
+## Iteration / ship gate (normative for `@gh-issues`)
+
+After each refinement pass, once requirements and draft intent are summarized, **before** list/dedupe, the caller must offer a single structured choice (AskQuestion per [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md), safe-first when ordering matters):
+
+- **Abort** — stop or park; do not run inventory/dedupe for publish.
+- **Sharpen** — another Q&A round (optionally Cursor’s built-in Plan or chat); then re-summarize and ask again.
+- **Ship** — candidate is good enough to continue the pipeline (list → dedupe → description → mutation confirm).
+
+Repeat until **Ship** or **Abort**. Readiness hints may cite [`internal-read-plan-confidence`](../../plan/confidence/SKILL.md); keep them optional, not mandatory scoring.
+
+## Multi-topic and plan hubs
+
+When a **plan hub** or **long multi-topic** paste is present, optionally use structured AskQuestion (same § as the ship gate) to confirm **one combined issue** vs **multiple themes** to ship after **Ship** (so **Sharpen** can split sections in **`.cursor/plan.md`** or chat before dedupe). Default remains one narrative until the user or router opts into the multi-intent path in **`@gh-issues`**.
+
+## AskQuestion shape
+
+- Present a concise summary in the prompt text.
+- Keep options safe-first (Abort first).
+- Use one refinement outlet only.
+
+## See also
+
+- [`internal-read-gh-issue-spec`](../issue-spec/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)
+- [`internal-read-plan-parts`](../../plan/parts/SKILL.md)
+- [`@gh-issues`](../../../gh/issues/SKILL.md)

--- a/.agents/skills/internal-read-gh/issue-projects-relationships/SKILL.md
+++ b/.agents/skills/internal-read-gh/issue-projects-relationships/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: internal-read-gh-issue-projects-relationships
+description: >-
+  Read-only: discover repo-scoped GitHub Projects for issue and PR mutation, normative gh shapes for attaching issues and
+  pull requests to projects, and issue relationship playbook (body links, duplicates, parent/sub-issues). Callers add
+  --repo and owner flags per target; mutations live in internal-write-gh-issue-commands and internal-write-gh-pr-commands.
+---
+
+# Internal: Issue projects + relationships (`internal-read-gh-issue-projects-relationships`)
+
+**Read-only.** Consumed by **`@gh-issues`** (plan + mutation summary), **`@gh-pr`** (via **`internal-read-gh-pr-description`** §6.5–6.6), **[`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)** (normative attach fences), and **[`internal-write-gh-pr-commands`](../../../write/gh/pr-commands/SKILL.md)** (PR **`item-add`**). **No `gh` mutations** in this file.
+
+**Project list shapes** — **[`internal-read-gh-project-list`](../project-list/SKILL.md)** (auth + `gh project list` bases).
+
+**Fork / PR target repo** — resolve **`owner/repo`** for issues the same way **`@gh-issues`** resolves the mutation target (see **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)** when the issue is filed on **`$PR_TARGET_REPO`** rather than the fork root). **Project discovery `--owner`** must match the **login that owns the repository** where the issue is created (first segment of **`nameWithOwner`** for that repo).
+
+**Pull requests (`@gh-pr`)** — use the same **`PR_TARGET_REPO`** for **`https://github.com/OWNER/REPO/pull/<N>`** URLs passed to **`gh project item-add --url`**. Run **`item-add` for the PR** after **`gh pr create`** (or **`gh pr edit`**) returns a PR number; then **`item-add` per confirmed issue** URL on that same **`OWNER/REPO`**. Do not substitute the fork’s **`github.com/FORK_OWNER/repo`** host in URLs when issues and PR are tracked on the **upstream** destination unless the issue genuinely lives on the fork.
+
+---
+
+## 1. Auth and capability probes
+
+**`gh issue create`**, **`gh issue edit --add-project`**, **`gh project list`**, and **`gh project item-add`** need the **`project`** scope for project features. **`gh auth status`** shows current scopes.
+
+If a command fails with missing **`project`** (or GraphQL mentions **`read:project`** / **`project`** scope), refresh:
+
+```bash
+gh auth refresh -s project
+```
+
+**GitHub Enterprise Server** may lack Projects v2 features or ship older **`gh`** flags. When **`gh issue create --help`** does not list **`--project`**, or **`gh project list`** errors with an unsupported API message, **stop** automated attach, record the error in chat, and fall back to **web UI** (Issues + Projects) or an operator-run attach.
+
+---
+
+## 2. Discover projects for the issue target repo
+
+1. Resolve **`TARGET_REPO`** — `owner/repo` passed to **`gh issue create` / `gh issue edit`** (default: current **`gh`** context; else **`--repo owner/repo`**).
+2. Load owner login:
+
+```bash
+gh repo view --json nameWithOwner --repo owner/repo
+```
+
+Use **`owner.login`** from **`gh repo view --json owner,nameWithOwner --repo owner/repo`** when you need the owner object explicitly.
+
+3. List candidate projects for that owner (open projects first; add **`--closed`** only when grooming closed boards):
+
+```bash
+gh project list --owner OWNER_LOGIN --limit 50 --format json
+```
+
+4. **Choose a project title** for **`--project` / `--add-project`**:
+   - **One unambiguous title** in the list → use it in the mutation summary and in **[`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)** fences.
+   - **Several titles match** the user’s intent (or duplicate titles) → **structured AskQuestion** in **`@gh-issues`**: pick one project, **skip** attach for this run, or **abort** until clarified.
+   - **No projects** or **`gh project list` fails** after auth → **skip** project attach; state **why** (no boards, scope, or GHE limitation)—not a silent success.
+
+The CLI does not always expose “this repo’s linked project” as a single field without GraphQL. Treat **owner-scoped listing + user disambiguation** as the supported pack workflow unless the user supplies an exact **`--project "Title"`** override.
+
+---
+
+## 3. Relationship playbook (issues)
+
+### 3.1 Cross-links in the body
+
+Use **`#123`** (same repo) or full **`https://github.com/owner/repo/issues/N`** (cross-repo) for **human-readable** context, release notes, and search. Body links **do not** replace GitHub duplicate closure or project membership—they document intent only.
+
+### 3.2 Duplicate vs “mentioned in body”
+
+To close a duplicate with correct GitHub semantics, use **`@gh-issue-close`** and **[`close-as-duplicate`](../../../write/gh/issue-commands/close-as-duplicate/SKILL.md)**: comment pointing at the canonical issue, then **`gh issue close`**. Do not rely on body text alone to mark duplicates.
+
+### 3.3 Parent / sub-issue / “blocked by”
+
+Product support (sub-issues, dependency graphs, **blocked by**) varies by **github.com** vs **GHES** and ship channel. If **`gh`** has no stable sub-issue flags for your version, use **web UI** or API where your token allows, and keep a **body fallback** (“Parent: #12”, “Blocked by: #34”) so agents stay consistent when automation is unavailable.
+
+### 3.4 Interaction with **`@gh-issue-close`**
+
+Relationship edits that **close** or **reopen** issues stay in **`@gh-issue-close`** and **`internal-write-gh-issue-commands`** close paths. **`@gh-issues`** owns **create/edit** content and **additive** project attach—not bulk close/reopen.
+
+---
+
+## 4. Pull requests and projects (`@gh-pr`)
+
+**Goal:** Put the **PR** and any **confirmed issues** on the same GitHub Project board using supported **`gh project item-add`** calls (see **[`internal-write-gh-pr-commands`](../../../write/gh/pr-commands/SKILL.md)**).
+
+1. Resolve **`PR_TARGET_REPO`** as **`owner/repo`** on the **destination** (upstream when **`STREAM_MODE=fork`**) per **`internal-read-gh-repo-stream`** §3.
+2. Resolve **`PROJECT_NUMBER`** and **`OWNER_LOGIN`** the same way as §2 of this file (**`gh project list`**, user override, or structured pick).
+3. After the PR exists, add the PR, then each issue:
+
+```text
+https://github.com/OWNER/REPO/pull/<PR_NUMBER>
+https://github.com/OWNER/REPO/issues/<ISSUE_NUMBER>
+```
+
+4. **Auth:** same **`project`** scope and GHES caveats as §1.
+
+**Do not** confuse this with the PR **Development** sidebar link—**`item-add`** is **project membership**, not a substitute for closing keywords when merge-time close semantics are required (see §6.5 of **`internal-read-gh-pr-description`**).
+
+---
+
+## See also
+
+- **[`internal-write-gh-issue-commands`](../../../write/gh/issue-commands/SKILL.md)** — create, edit, project attach, close.
+- **[`internal-write-gh-pr-commands`](../../../write/gh/pr-commands/SKILL.md)** — PR create/edit + optional **`item-add`** for PR URLs.
+- **[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** — §6.5–6.6 linking ladder + issue hint scan.
+- **[`internal-read-gh-project-list`](../project-list/SKILL.md)** — `gh project list` inventory.
+- **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)** — **`$PR_TARGET_REPO`** / fork vs same-repo.
+- **[`@gh-issues`](../../../gh/issues/SKILL.md)** · **[`@gh-issue-close`](../../../gh/issues/close/SKILL.md)** · **[`@gh-pr`](../../../gh/pr/SKILL.md)**

--- a/.agents/skills/internal-read-gh/issue-spec/SKILL.md
+++ b/.agents/skills/internal-read-gh/issue-spec/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: internal-read-gh-issue-spec
+description: >-
+  Read-only contract for high-quality implementation-ready issue bodies: required sections, quality bar,
+  anti-ambiguity examples, non-regression expectations, and verification guidance.
+---
+
+# Internal: Issue spec contract
+
+**Read-only library.** This is the canonical issue-body quality contract for this pack when a repository does not impose a stronger issue template.
+
+## Do
+
+- Draft issue bodies with these required sections:
+  1. Goal/outcome.
+  2. Current situation.
+  3. Examples today vs desired.
+  4. Scope of change.
+  5. Non-regression/compatibility.
+  6. Verification (acceptance + regression tests).
+  7. Worked examples/edge cases.
+  8. Risks/open questions.
+- Prefer concrete examples over abstract prose.
+- Preserve existing behavior requirements explicitly when extending a feature.
+- Make verification executable by a future implementer without guessing.
+- When planning surfaces **finite** implementation forks before publish, prefer **AskQuestion** (structured multiple-choice) per **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** **§1** so the user picks in the Q&A UI instead of parsing A/B/C prose alone; align pre-flight gates with **[`internal-read-gh-issue-preflight-qa`](../issue-preflight-qa/SKILL.md)**.
+
+## Do not
+
+- Publish vague issue bodies that omit examples or regression expectations.
+- Treat this as a mutation workflow; publishing remains owned by `@gh-issues`.
+
+## Quality bar (done criteria)
+
+- Goal is specific enough that success can be judged.
+- Current and desired behavior each include at least one example.
+- Change surface is bounded (in scope/out of scope clear).
+- Non-regression expectations are explicit.
+- Verification includes both acceptance and regression intent.
+- Major ambiguity points are resolved or documented as open questions.
+
+## Exemplars
+
+### Exemplar: extend calculator operations
+
+- **Goal:** add `multiply` and `divide` while preserving `sum` and `subtract` behavior.
+- **Current example:** `2 + 3 -> 5`, `8 - 3 -> 5`, `2 * 3 -> unsupported operation`.
+- **Desired example:** `2 * 3 -> 6`, `8 / 2 -> 4`, `8 / 0 -> stable validation error`.
+- **Scope:** parser/evaluator support for `*` and `/`, divide-by-zero guard, no API schema break.
+- **Verification:** acceptance tests for multiply/divide, regression tests for sum/subtract, negative tests for divide-by-zero.
+- **Open questions:** precision policy (float/decimal, rounding behavior).
+
+### Exemplar: issue router upgrade
+
+- **Goal:** when intent is vague, route through planning first, then run deterministic create-or-update.
+- **Current example:** vague prompt jumps straight into create/update logic.
+- **Desired example:** vague prompt -> Cursor Plan (or chat) -> stable issue artifact -> list -> dedupe -> edit/create.
+- **Scope:** wording and routing updates only; no new API mutations; dedupe logic unchanged.
+- **Verification:** dry-run both paths (vague intent path and ready artifact path) and validate links.
+- **Open questions:** keep router wording concise while preserving clarity.
+
+## See also
+
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md) — **§1** finite choices and prompt shape when offering alternatives in Cursor.
+
+## Consumers
+
+- [`internal-read-plan-core-github-issue-profile`](../../plan/core/github-issue-profile/SKILL.md)
+- [`@gh-issue-review`](../../../../gh/issues/review/SKILL.md)
+- [`internal-read-gh-issue-description-issue-body-skeleton`](../issue-description/issue-body-skeleton/SKILL.md)

--- a/.agents/skills/internal-read-gh/pr-body-sections/SKILL.md
+++ b/.agents/skills/internal-read-gh/pr-body-sections/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: internal-read-gh-pr-body-sections
+description: >-
+  Read-only: PR title/body markdown patterns and canonical section structure. Caller: internal-read-gh-pr-description.
+  Does not run gh or git.
+---
+
+# Internal: Pull request body sections (`internal-read-gh-pr-body-sections`)
+
+**Read-only library.** **Static** PR **substance**: section headings, canonical body rules, example skeleton, title rules. Full copy-paste reference: **[`section-patterns/SKILL.md`](./section-patterns/SKILL.md)**.
+
+**[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** owns **template discovery** (**§5** — GitHub API via **`internal-read-gh-repo-forms-json`**, local files), **`git` delta** (**§6**), **API-first linking + issue hint scan** (**§6.5–6.6**), **title/body + triple pass** (**§7**), and hand-off to **`@gh-pr`** §9. **Do not** duplicate **§5** **`gh repo view`** lines here.
+
+---
+
+## Do
+
+- When **`$PR_TEMPLATE_SOURCE`** is **`canonical`**, draft the body from **`section-patterns/SKILL.md`** only.
+- When merging a repo or GitHub template, **map** content into those headings while keeping **TL;DR** first.
+
+## Do not
+
+- Run **`gh pr create`**, **`gh pr edit`**, or **AskQuestion** for PR mutation — parent **`@gh-pr`** §9.
+
+---
+
+## See also
+
+- [`internal-read-gh-pr-content`](../pr-content/SKILL.md) — title/body shape (**`title-line`**, **`pr-body-skeleton`**)
+- [`internal-read-gh-pr-description`](../pr-description/SKILL.md) — discovery, §6 delta, §6.5–7 linking + title/body
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md) — template pick when multiple templates
+- [`@gh-pr`](../../../gh/pr/SKILL.md)

--- a/.agents/skills/internal-read-gh/pr-body-sections/section-patterns/SKILL.md
+++ b/.agents/skills/internal-read-gh/pr-body-sections/section-patterns/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: internal-read-gh-pr-body-sections-section-patterns
+description: >-
+  Read-only: canonical PR body sections and examples. Parent internal-read-gh-pr-body-sections. No default Linked issues
+  prose; optional minimal closing-keyword line only when @gh-pr §9 chose the keyword path.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for PR section patterns.
+
+## Issue and project linkage (with `@gh-pr`)
+
+- **Do not** add a standing **“Linked issues”** markdown section by default. Candidate issues and the **linking ladder** ( **`gh project item-add`**, minimal **`Refs`/`Fixes`/`Closes`** line, or **UI-only**) are confirmed in **`@gh-pr`** **§9** per **[`internal-read-gh-pr-description`](../../pr-description/SKILL.md)** §6.5–7.
+- **Minimal keyword line:** GitHub’s documented programmatic path for merge-time **closing** inference is **closing keywords in the PR body** (see **`internal-write-gh-pr-commands`**). At most **one** short trailing line when the user explicitly chose that path—**no** multi-paragraph issue prose in the PR description for traceability alone.

--- a/.agents/skills/internal-read-gh/pr-content/SKILL.md
+++ b/.agents/skills/internal-read-gh/pr-content/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: internal-read-gh-pr-content
+description: >-
+  Read-only: canonical PR title + body shape; child skills title-line/ and pr-body-skeleton/. Orchestration stays in
+  internal-read-gh-pr-description + internal-read-gh-pr-body-sections. Callers: @gh-pr. Does not write files.
+---
+
+# Internal: PR content shape (`internal-read-gh-pr-content`)
+
+**Read-only library.** **What** the **title** and **body** should look like. **Child skills:**
+
+- **[`title-line/SKILL.md`](./title-line/SKILL.md)** — PR and issue **titles**
+- **[`pr-body-skeleton/SKILL.md`](./pr-body-skeleton/SKILL.md)** — PR body markdown shape
+
+**Template discovery:** **[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** §5 (orchestration + local globs); **`gh repo view --json`** lines: **[`internal-read-gh-repo-forms-json`](../repo-forms-json/SKILL.md)**. **`git` delta commands:** **[`internal-read-git-git-diff-summary`](../../git/git-diff-summary/SKILL.md)** (§6 hand-off). **API-first linking + issue hint scan:** **`internal-read-gh-pr-description`** §6.5–6.6. **Full section prose:** **[`internal-read-gh-pr-body-sections/section-patterns/SKILL.md`](../pr-body-sections/section-patterns/SKILL.md)**.
+
+---
+
+## Ownership
+
+| Topic | Owner |
+| --- | --- |
+| Title line rules + body section order | **This skill** + **[`title-line/SKILL.md`](./title-line/SKILL.md)** + **`pr-body-sections/section-patterns`** |
+| **`gh repo view --json`** (templates API) | **`internal-read-gh-repo-forms-json`** |
+| Local template globs + merge / reshape | **`internal-read-gh-pr-description`** §5 |
+| **`git log` / `git diff`** vs **`$BASE_GIT`** | **`internal-read-git-git-diff-summary`** (§6 of **`internal-read-gh-pr-description`**) |
+| API-first linking ladder + issue hint scan (read-only) | **`internal-read-gh-pr-description`** §6.5–6.6 |
+| Title/body prose assembly + triple pass | **`internal-read-gh-pr-description`** §7 |
+| Example markdown shape only | **[`pr-body-skeleton/SKILL.md`](./pr-body-skeleton/SKILL.md)** |
+
+## See also
+
+- [`internal-read-git-git-diff-summary`](../../git/git-diff-summary/SKILL.md)
+- [`@gh-pr`](../../../gh/pr/SKILL.md)

--- a/.agents/skills/internal-read-gh/pr-content/pr-body-skeleton/SKILL.md
+++ b/.agents/skills/internal-read-gh/pr-content/pr-body-skeleton/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: internal-read-gh-pr-content-pr-body-skeleton
+description: >-
+  Read-only: PR body markdown skeleton. Parent internal-read-gh-pr-content. Optional minimal Refs/Fixes line only when
+  @gh-pr §9 confirmed keyword path; no default Linked issues block.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for PR body skeleton guidance.
+
+## Skeleton (canonical / normalized)
+
+Use **[`internal-read-gh-pr-body-sections/section-patterns`](../pr-body-sections/section-patterns/SKILL.md)** for heading names. Typical flow: **TL;DR** → **What changed** (nested bullets) → tradeoffs / risks.
+
+**Issue linkage:** omit a dedicated **Linked issues** heading. If **`@gh-pr`** **§9** confirmed the **keyword path**, append **at most one line** at the end of the body, for example `Refs #42` or `Fixes #42` (never multiple **`Fixes`** without explicit user confirmation). Otherwise rely on **Projects** (**`gh project item-add`**) and/or **UI** per **`internal-write-gh-pr-commands`**.

--- a/.agents/skills/internal-read-gh/pr-content/pr-orchestration/SKILL.md
+++ b/.agents/skills/internal-read-gh/pr-content/pr-orchestration/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: internal-read-gh-pr-content-pr-orchestration
+description: >-
+  Read-only: @gh-pr orchestration prose. Parent internal-read-gh-pr-content.
+---
+
+# PR orchestration (`@gh-pr`)
+
+**Fixed order:** **`@git-pull`** → **`@git-review`** → **`@git-push`** → list matching open PRs / resolve vars → **AskQuestion intent gate** (summary in prompt; abort/proceed/refine) → resolve `PR_NUM` → **`internal-read-gh-pr-description`** (full: §5 templates, §6 delta, **§6.5–6.6** API linking ladder + issue hint scan, **§7** title/body + triple pass) → **AskQuestion mutation gate** (summary must include **linking ladder** choice: project **`item-add`**, minimal body keywords, or UI-only, plus candidate issues) → **`gh pr create` / `gh pr edit`** → optional **`gh project item-add`** + optional **`gh pr view --json closingIssuesReferences`** per **`internal-write-gh-pr-commands`** when confirmed in that gate.
+
+**Inventory (optional):** run **`@gh-pr-list`** / **`@gh-pr-view`** using [`internal-read-gh-pr-list`](../pr-list/SKILL.md) (and [list/view hub](../pr-list/list-view-hub/SKILL.md)) when you need open PR numbers, URLs, or a quick **`gh pr diff --stat`** before drafting with **`@gh-pr`**.
+
+**Variables:** set **`BASE_GIT`**, **`PR_TARGET_REPO`**, etc. per [`internal-read-gh-repo-stream`](../repo-stream/SKILL.md) — do not re-derive fork rules inline.
+
+**After publish/recovery:** `@git-push` may complete on a different branch after failure triage (for example create/switch recovery branch). Re-apply [`internal-read-gh-repo-stream`](../repo-stream/SKILL.md) before PR lookup/drafting so head/base vars reflect the current branch.
+
+**Intent gate before drafting:** after lookup, if matches exist, ask user whether to edit one, create new, or abort. Keep the compact inventory summary inside AskQuestion prompt text and follow [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md) for safe-first options and single refinement outlet.
+
+**Do not** run `gh pr create` before pull, review, and push succeed. **Do not** inline `npm test` / full **`@git-review`** instead of the ordered **`@git-review`** hand-off in **`@gh-pr`**—**`@git-push`** does **not** own verify.
+
+**PR text:** [PR body skeleton](../pr-body-skeleton/SKILL.md), [title line](../title-line/SKILL.md). **Issue/project linkage:** **[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** §6.5–6.6 + **`internal-write-gh-pr-commands`** (optional **`gh project item-add`**, verification JSON). **Delta git commands:** **`internal-read-git-git-diff-summary`** only (invoked from **`internal-read-gh-pr-description`**). Final create/edit still requires a separate mutation AskQuestion with summary in prompt text before the write.

--- a/.agents/skills/internal-read-gh/pr-content/title-line/SKILL.md
+++ b/.agents/skills/internal-read-gh/pr-content/title-line/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-gh-pr-content-title-line
+description: >-
+  Read-only: PR and issue title line rules. Parent internal-read-gh-pr-content.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal reference for PR title-line guidance.
+

--- a/.agents/skills/internal-read-gh/pr-description/SKILL.md
+++ b/.agents/skills/internal-read-gh/pr-description/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: internal-read-gh-pr-description
+description: >-
+  Read-only: PR template discovery (§5), delta (§6), API-first issue/linking ladder + issue hint scan (§6.5–6.6), title/body + triple-pass (§7).
+  Caller @gh-pr after §5; parent §9 mutates. Does not run gh pr create/edit.
+---
+
+# Internal: PR description
+
+**Read-only.** Run after **`@gh-pr`** **§5** (**`PR_NUM`**, **`$BASE_GIT`**, branch/upstream vars per **`internal-read-gh-repo-stream`**). When open PR matches existed in §5, treat **`PR_NUM`** as user-confirmed intent from that AskQuestion gate. **Does not** mutate GitHub or own **Proceed** for PR apply—that is **`@gh-pr`** **§9** (**`internal-write-plan-skill-safety`** + **`internal-write-plan-structured-qa`** **§3a**).
+
+**Single owners (do not duplicate):** **`gh repo view --json pullRequestTemplates`** → **[`internal-read-gh-repo-forms-json`](../repo-forms-json/SKILL.md)** · local globs / **`section-patterns`** → **[`internal-read-gh-pr-body-sections`](../pr-body-sections/SKILL.md)** · **delta commands** → **[`internal-read-git-git-diff-summary`](../../git/git-diff-summary/SKILL.md)** + **[`delta-narrative/SKILL.md`](../../git/git-diff-summary/delta-narrative/SKILL.md)** · **linking ladder + issue hint scan** → **§6.5–6.6** (this file) + **[`internal-read-gh-issue-projects-relationships`](../issue-projects-relationships/SKILL.md)** + **[`internal-read-gh-issue-list`](../issue-list/SKILL.md)** · **title + section order** → **[`internal-read-gh-pr-content`](../pr-content/SKILL.md)** + **[`title-line`](../pr-content/title-line/SKILL.md)**, **[`pr-body-skeleton`](../pr-content/pr-body-skeleton/SKILL.md)** · **PR/project mutations after Proceed** → **[`internal-write-gh-pr-commands`](../../write/gh/pr-commands/SKILL.md)**.
+
+---
+
+## 5. Discover PR templates
+
+Run **after §4**, **before §6**. **Step A** always first (**`gh`** JSON); **B** if no usable template; **C** if still none.
+
+**Multiple templates:** structured pick per **`internal-write-plan-structured-qa`** (one option per template + **Canonical only** → **`$PR_TEMPLATE_SOURCE`** = **`canonical`**, empty body).
+
+### Step A — GitHub API (required)
+
+**Execute** (do not copy-paste from here): same-repo vs fork command from **`internal-read-gh-repo-forms-json`** § **Pull request templates** using **`PR_TARGET_REPO`** / **`$UPSTREAM`** from **`internal-read-gh-repo-stream`** §3.
+
+- Parse **`pullRequestTemplates`** (length probe in repo-forms-json optional; read full entries when non-empty).
+- **One** object → **`github-api`** + body markdown.
+- **≥2** → template Q&A.
+- **`[]` / missing** → Step B. **`gh`** error after retry → B + note.
+
+### Step B — Local files
+
+Globs and filenames: **`internal-read-gh-pr-body-sections`** (do not maintain a second list here). Discover with **`git ls-files`** + glob. **One** file → **`local`**; **≥2** → Q&A; **none** → Step C.
+
+### Step C — Canonical
+
+**`$PR_TEMPLATE_SOURCE`** = **`canonical`**, **`$PR_TEMPLATE_BODY`** empty — scaffold from **[Body — canonical structure](#body--canonical-structure)** via **`internal-read-gh-pr-body-sections/section-patterns/SKILL.md`**.
+
+### Merge rules (all sources)
+
+**Non-canonical body:** template owns headings/checklists; canonical rules govern **substance** (prepend **TL;DR** / **What changed** when template has no short opener—unless template forbids; strip checklist items that only duplicate **Files changed**).
+
+**Material template reshape:** **`internal-write-plan-structured-qa`** **AskQuestion** — **Keep / Blend / Pack canonical** — when applying the rules above would **reorder/remove** template-defined headings (**separate** from **`@gh-pr`** §9 PR mutation).
+
+---
+
+## 6. PR delta
+
+Run **`internal-read-git-git-diff-summary`** **in full**. **§7** “What changed” must track that output—no parallel **`git`** recipes here.
+
+---
+
+## 6.5 Linking: API ladder (read-only orientation)
+
+Use this ladder when deciding what to put in the **§9** mutation summary (and therefore what **`@gh-pr`** may run after **Proceed**). **Do not** imply undocumented GitHub APIs for the PR **Development** sidebar link.
+
+1. **Projects (board) — supported `gh` writes**  
+   After the PR exists, **`gh project item-add <PROJECT_NUMBER> --owner OWNER --url <URL>`** accepts **pull request or issue** URLs. Discovery, auth (**`project`** scope), and owner/repo rules live in **[`internal-read-gh-issue-projects-relationships`](../issue-projects-relationships/SKILL.md)** and **[`internal-read-gh-project-list`](../project-list/SKILL.md)**. Normative fences for the PR path live in **[`internal-write-gh-pr-commands`](../../write/gh/pr-commands/SKILL.md)** (same **Proceed** batch as **`gh pr create`/`edit`** when the user confirmed project attach). Issue-only attach patterns stay in **[`internal-write-gh-issue-commands`](../../write/gh/issue-commands/SKILL.md)**.
+
+2. **PR ↔ issue (closing / `closingIssuesReferences` semantics)**  
+   GitHub’s documented programmatic path for merge-time **closing** behavior is **closing keywords in the PR body** (or manual UI). There is **no** official REST/GraphQL write today for the web-only Development picker; proposed CLI flags remain **blocked** on the platform ([`cli/cli#11405`](https://github.com/cli/cli/issues/11405)). If the user refuses **any** issue text in the body, record **Projects + post-create verification + UI** only—do not invent hidden endpoints. See also [Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+3. **Read-only verification**  
+   After create/edit, parents may run **`gh pr view`** with JSON including **`closingIssuesReferences`** (see **`internal-write-gh-pr-commands`**) to confirm what GitHub already inferred—**read** only.
+
+---
+
+## 6.6 Issue hint scan (read-only)
+
+Collect **candidate issue numbers** and evidence for **`@gh-pr`** **§9** (project **`--url`** targets, optional minimal keyword line, or UI-only). **Do not** add a default **“Linked issues”** prose block to the PR body from this scan alone.
+
+**Evidence order (strongest first):**
+
+1. Explicit **`#nnn`** or **`Fixes` / `Refs` / `Closes`** in user chat or pasted intent.
+2. **Branch name** tokens (for example `issue-42`, `fix/123-short-title`, `…-#42-…`). Prefer explicit **`#`** patterns over naive long digit runs from paths.
+3. **Commit messages** on **`$BASE_GIT..HEAD`** — use full bodies, not only **`git log -1`**, so branch-wide **`Fixes #n`** / **`Refs #n`** surface; recipes in **[`internal-read-git-git-diff-summary/delta-narrative`](../../git/git-diff-summary/delta-narrative/SKILL.md)** (**Issue keywords in commit range**).
+4. **Optional `gh`** validation or disambiguation on **`PR_TARGET_REPO`** (same **`owner/repo`** as the PR destination—**forks:** use **`$UPSTREAM`**, not the fork root). Shapes: **[`internal-read-gh-issue-list`](../issue-list/SKILL.md)** (`gh issue list`, `gh search issues` with **`--repo`** as needed).
+
+**Heuristics:** If candidates disagree, defer to **`@gh-pr`** **§9** **AskQuestion**—do not auto-pick **`Fixes`** for multiple issues; default narrative is **`Refs`**-style **only when** the user explicitly chose minimal keyword lines for several refs.
+
+**Hand-off:** Pass a compact table or list (issue #, evidence source, suggested link mode: **project only** / **minimal keyword** / **UI**) to **`@gh-pr`** **§9**; **`internal-write-gh-pr-commands`** owns executable fences after **Proceed**.
+
+---
+
+## 7. Title + body + triple pass
+
+- Draft per **`internal-read-gh-pr-content`**, **`$PR_TEMPLATE_SOURCE`/`$PR_TEMPLATE_BODY`**, and **`section-patterns`** when canonical. **Full replace** vs **`$BASE_GIT`**; no compare-header noise (SHAs, commit counts).
+- **Issue linkage in the posted body:** **No** default **“Linked issues”** markdown section from §6.6. **Default:** omit **`Refs` / `Fixes` / `Closes`** lines from the draft body. Add **at most one minimal trailing line** of **`Refs #n` / `Fixes #n` / `Closes #n`** only when the user already chose the **keyword path** in chat **or** the draft is being revised **after** **`@gh-pr`** **§9** narrowed linkage (see §6.5 and **`internal-write-gh-pr-commands`**). For multiple candidates without a clear choice, keep keywords **out** of the body and carry candidates in the **§9** prompt (project **`item-add`**, keywords, or UI-only). See **[`internal-read-gh-pr-body-sections/section-patterns`](../pr-body-sections/section-patterns/SKILL.md)** and **[`pr-body-skeleton`](../pr-content/pr-body-skeleton/SKILL.md)**.
+- **Triple pass:** (1) TL;DR + outline cover §6 themes by concern? (2) form (lists, tables only when tiny)? (3) claims match §6 **and** any optional keyword line matches the **§9** mutation summary (issue numbers + **`Refs`** vs **`Fixes`/`Closes`**) before **`gh pr`** runs? Hand title/body to **`@gh-pr`** §9.
+
+### Existing PR as template
+
+When **`PR_NUM`** is set: reuse **voice** / **headings** / **emoji cadence** from the open PR body only—rebuild **facts** from §6; do not treat the old body as authority for paths or behavior.
+
+### Title
+
+**[`title-line`](../pr-content/title-line/SKILL.md)** — plain text, no emoji.
+
+### Body — canonical structure
+
+**[`internal-read-gh-pr-body-sections/section-patterns/SKILL.md`](../pr-body-sections/section-patterns/SKILL.md)** — normative when **`canonical`** or when normalizing.
+
+---
+
+## Do not
+
+- PR mutation or **Proceed** for **`gh pr create`/`edit`** (parent §9).
+- Skip **`internal-read-gh-repo-forms-json`** when Step A applies and **`gh`** is expected.
+
+## See also
+
+- [`internal-read-gh-repo-forms-json`](../repo-forms-json/SKILL.md)
+- [`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)
+- [`internal-read-gh-issue-list`](../issue-list/SKILL.md)
+- [`internal-read-gh-issue-projects-relationships`](../issue-projects-relationships/SKILL.md)
+- [`internal-write-gh-pr-commands`](../../write/gh/pr-commands/SKILL.md)
+- [`@gh-pr`](../../../gh/pr/SKILL.md)

--- a/.agents/skills/internal-read-gh/pr-list/SKILL.md
+++ b/.agents/skills/internal-read-gh/pr-list/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: internal-read-gh-pr-list
+description: >-
+  Normative gh pr list, gh pr view, and gh pr diff --stat read-only shapes. Callers add --state, --head, --base, --limit,
+  --json, and --repo per goal; PR mutations live in internal-write-gh-pr-commands.
+---
+
+# Internal: GitHub pull request list / view (`internal-read-gh-pr-list`)
+
+**Library.** **Sole** normative **`gh pr list`**, **`gh pr view`**, and read-only **`gh pr diff --stat`** fences for this pack. Consumed by **`@gh-pr-list`**, **`@gh-pr-view`**, **`@gh-pr`** (PR number lookup), and **`internal-write-gh-pr-commands`**.
+
+**Mutations** (**`gh pr create`**, **`gh pr edit`**, **`gh pr close`**) live in **[`internal-write-gh-pr-commands`](../../write/gh/pr-commands/SKILL.md)**—never run those from this file.
+
+## Cadence (read-only)
+
+**Faster in inventory-only flows** — This library **only** hits GitHub for **read** list/view/diff-stat. **Parents** that are read-only (**`@gh-pr-list`**, **`@gh-pr-view`**, **`@gh-pr`** lookup, …) may use it **without** an extra **AskQuestion** from this file. **Do not** infer **Proceed** for **`gh pr close`** or **`gh pr create`/`edit`**—those use **`internal-write-gh-pr-commands`** or **`@gh-pr`** with their own confirms.
+
+## Online changes and paths outside the repo
+
+- **This file is read-only** — listing/viewing PRs does **not** replace **Goal + structured confirm** for any follow-on **`gh`** / API write.
+- **Inventory stays lightweight** — no mandatory **Abort / Review / Proceed** stack for routine reads; mutation parents own **Proceed** per **`internal-write-plan-skill-safety`** / **`internal-write-plan-structured-qa`** **§1e** before writes.
+- **Parent skills** that call **`internal-read-gh-pr-list`** and then **mutate** GitHub or **write outside the git workspace root** must apply **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** before those writes.
+- **Master-confirm rule** — even with **`SKIP_QA_*`** / **`SKIP_QA_WRITE`**, follow-on high-risk writes still require session-level confirm in the owning mutation skill.
+
+## Caller refinement (flags)
+
+**Callers** compose the right flags for the question, for example:
+
+- **`--state open`** | **`closed`** | **`merged`** | **`all`** (see **`gh pr list --help`** for your **`gh`** version)
+- **`--head`** / **`--base`** (branch filters)
+- **`--limit N`**
+- **`--json field1,field2,…`**
+- **`--repo owner/repo`** (**fork/upstream:** **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)**)
+
+## List (current repo)
+
+Open PRs for the **current branch** (same-repo):
+
+```bash
+gh pr list --head "$(git branch --show-current)" --state open --json number,title,url --limit 20
+```
+
+All open PRs (cap output in chat):
+
+```bash
+gh pr list --state open --limit 30
+```
+
+**Closed, not merged** (optional read-only inventory):
+
+```bash
+gh pr list --state closed --limit 200 \
+  --json number,title,state,mergedAt,url \
+  --jq 'map(select(.mergedAt == null))'
+```
+
+Use **`--repo owner/repo`** when not using default **`gh`** context.
+
+**Merged only** (housekeeping/reporting where merged history is needed):
+
+```bash
+gh pr list --state merged --limit 200 --json number,title,state,mergedAt,url
+```
+
+## View (single PR)
+
+By number:
+
+```bash
+gh pr view 42 --json title,body,state,url,headRefName,baseRefName
+```
+
+Body-focused JSON (house-style hint for **`@gh-pr`**):
+
+```bash
+gh pr view 42 --json title,body
+```
+
+**GraphQL id** (for GraphQL APIs that accept pull request node ids):
+
+```bash
+gh pr view <N> --json id,number,title,state
+```
+
+Optional diff stat:
+
+```bash
+gh pr diff 42 --stat
+```
+
+## Example — PR from current branch
+
+**Input:** “Do I already have a PR from this branch?”
+
+```bash
+BRANCH=$(git branch --show-current)
+gh pr list --head "$BRANCH" --base main --state open --json number,title,url
+```
+
+**Output (sample JSON line):** `{"number":7,"title":"Add issue label playbook","url":"https://github.com/org/repo/pull/7"}`
+
+## Example — view before edit
+
+**Input:** “Show PR 7 title and base.”
+
+```bash
+gh pr view 7 --json number,title,baseRefName,headRefName,state
+```
+
+## See also
+
+- **[`internal-write-gh-pr-commands`](../../write/gh/pr-commands/SKILL.md)** — **`gh pr create`**, **`gh pr edit`**, and **`gh pr close`**.
+- **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)** — **`--repo`**, head/base for **`@gh-pr`**.
+- [`@gh-pr-list`](../../../gh/pr/list/SKILL.md) · [`@gh-pr-view`](../../../gh/pr/view/SKILL.md)
+- **[`list-view-hub/SKILL.md`](./list-view-hub/SKILL.md)** — narrative hub (no duplicate fences).
+- [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md) · [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/internal-read-gh/pr-list/list-view-hub/SKILL.md
+++ b/.agents/skills/internal-read-gh/pr-list/list-view-hub/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: internal-read-gh-pr-list-list-view-hub
+description: >-
+  Read-only: PR list/view narrative hub (no duplicate gh fences). Parent internal-read-gh-pr-list.
+---
+
+# PR list / view hub
+
+**Normative command fences** live in [`internal-read-gh-pr-list`](./SKILL.md). **PR mutations** (`gh pr create`, `gh pr edit`, `gh pr close`) live in [`internal-write-gh-pr-commands`](../../../write/gh/pr-commands/SKILL.md).
+
+**Fork / upstream:** set **`--repo`** when viewing or listing against **`$UPSTREAM`** per [`internal-read-gh-repo-stream`](../repo-stream/SKILL.md).
+
+| Task | Skill | Internal shapes |
+| --- | --- | --- |
+| Inventory / pick a PR | **`@gh-pr-list`** | **`internal-read-gh-pr-list`** — add **`--state`**, **`--head`**, **`--base`**, **`--limit`**, **`--json`**, **`--repo`** per caller |
+| Inspect one PR | **`@gh-pr-view`** | **`internal-read-gh-pr-list`** **View** / **`gh pr diff --stat`** |
+| Close a PR | **`@gh-pr-close`** | **`internal-write-gh-pr-commands`** **Close PR** (after **Proceed**) |
+
+**Do not** use this hub to **replace** **`@gh-pr`** for **`gh pr create`** / **`gh pr edit`**—those stay behind **`@git-pull`** + **`@git-review`** + **`@git-push`** + **`internal-read-gh-pr-description`**.
+
+When `@gh-pr` finds non-empty matching inventory, it may run an intent AskQuestion (edit existing vs create new vs abort) before drafting; command fences still stay in **`internal-read-gh-pr-list`**.
+
+**Safety:** Any **online mutation** or **write outside the git workspace root** requires **Goal + structured confirm** per **`internal-write-plan-skill-safety`** before execution.

--- a/.agents/skills/internal-read-gh/pr-preflight-qa/SKILL.md
+++ b/.agents/skills/internal-read-gh/pr-preflight-qa/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: internal-read-gh-pr-preflight-qa
+description: >-
+  Read-only question bank for @gh-pr pre-flight. Ensures source/target branch intent, readiness, and
+  overlap handling are clarified before create/edit mutations.
+---
+
+# PR pre-flight Q&A
+
+Use this before PR create/edit mutation.
+
+## Gather (deducible first)
+
+- Source branch (`HEAD`) and target base branch.
+- Existing matching PRs by head/base/title.
+- Repo stream context (same-repo vs fork).
+
+## Clarify (ask when ambiguous)
+
+- Should this update an existing PR or open a new PR?
+- If existing PR matches, which PR number should be edited?
+- Is branch state ready to ship (green checks expected)?
+- Any explicit reason to keep draft/WIP instead of ready-for-review?
+
+## AskQuestion shape
+
+- Summarize match evidence in the prompt text.
+- Offer safe-first choices: Abort / Edit existing / Create new.
+- Use one refinement outlet only.
+
+## See also
+
+- [`internal-read-gh-pr-list`](../pr-list/SKILL.md)
+- [`internal-read-gh-pr-description`](../pr-description/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)
+- [`@gh-pr`](../../../../gh/pr/SKILL.md)

--- a/.agents/skills/internal-read-gh/project-item-list/SKILL.md
+++ b/.agents/skills/internal-read-gh/project-item-list/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: internal-read-gh-project-item-list
+description: >-
+  Normative gh project item-list shapes, normalized item fields, v1 body-based dependency edges, Kahn-style topological
+  layers with cycle and unresolved-edge reporting. Read-only. Behavioral parity with tests/check-project-order-fixtures.py.
+---
+
+# Internal: GitHub project item list + order analysis (`internal-read-gh-project-item-list`)
+
+**Library.** **Sole** normative **`gh project item-list`** fences for this pack plus the **v1 dependency / layering contract** consumed by **`@gh-project-order-readonly`**.
+
+**Mutations** (**`gh project item-edit`**, **`item-archive`**, **`item-delete`**, reorder APIs, …) are **out of scope** for v1—never run them from this file. Inventory-only reads and in-chat analysis only.
+
+## Behavioral parity (automated)
+
+Layering, cycle detection, and unresolved-edge classification **must match** the stdlib checker **[`tests/check-project-order-fixtures.py`](../../../../tests/check-project-order-fixtures.py)** (fixtures under **`tests/fixtures/project-order/`**). If prose and code diverge, **fix the SKILL or the checker** so they agree.
+
+## Cadence (read-only)
+
+This library is read-only and needs **no** **Proceed** gate for listing or analysis. Do **not** imply permission to run any **`internal-write-gh-project-commands`** fence from this file.
+
+## Auth scope
+
+`gh project` commands require token scope **`project`**. Verify with:
+
+```bash
+gh auth status
+```
+
+If needed:
+
+```bash
+gh auth refresh -s project
+```
+
+## Resolve project number (owner scope)
+
+Use **[`internal-read-gh-project-list`](../project-list/SKILL.md)** when the user names a board by title or you need to disambiguate **`NUMBER`** + **`OWNER`**.
+
+```bash
+gh project list --owner "@me" --limit 50 --format json
+```
+
+## List items on a project (normative base)
+
+```bash
+gh project item-list <NUMBER> --owner "@me" --format json --limit 200
+```
+
+### Caller refinement (flags)
+
+- `--owner "@me"` or `--owner ORG_LOGIN`
+- `--limit N` (CLI default is low; prefer **`-L 200`** or documented cap for boards)
+- `--format json` (required for machine parsing)
+- `--query '…'` when supported (see `gh project item-list --help`); GHES may omit advanced query
+
+### Compact preview (jq)
+
+```bash
+gh project item-list 1 --owner "@me" --format json -L 50 --jq '.items[] | {title: .title, type: .content.type, number: .content.number, repo: .repository}'
+```
+
+## JSON shape (normative expectations)
+
+Hosts and CLI versions vary; treat these as **required for analysis** when present:
+
+- Top-level **`items`** — array of project items.
+- Per item (typical Projects v2 via CLI):
+  - **`id`** — project item node id (stable within the project).
+  - **`title`** — display title (may mirror content).
+  - **`repository`** — `owner/name` string when the item is linked to a repo object.
+  - **`content`** — object when the item wraps GitHub content:
+    - **`type`** — e.g. `Issue`, `PullRequest`, or draft types.
+    - **`number`** — issue/PR number when applicable.
+    - **`body`** — issue/PR body text used for **v1 edge parsing** (may be empty).
+    - **`title`** — content title when distinct from top-level title.
+
+When **`content.body`** is missing, treat **`body` as empty** for edge parsing (no inferred edges).
+
+## Normalization contract (in-chat)
+
+For each item, derive:
+
+| Field | Rule |
+| --- | --- |
+| **`id`** | Prefer CLI `id`; else stable synthetic key from `(repo,number,type)` for reporting. |
+| **`kind`** | Lowercased mapping: issue-like → **`issue`**; PR → **`pull_request`**; draft-only → **`draft`**; unknown → **`unknown`**. |
+| **`repo`** | `owner/name` from `repository` when present; else **unknown** (skip same-repo `#` edges; see unresolved). |
+| **`number`** | Integer when `content.number` exists for issues/PRs; else **null**. |
+| **`title`** | Prefer `content.title` then item `title`. |
+| **`body`** | `content.body` or empty string. |
+
+## v1 dependency edges (body lines only)
+
+**Source of truth:** explicit **line prefixes** in the issue body (same-repo **`#n`** references only). Aligns with **[`internal-read-gh-issue-projects-relationships`](../issue-projects-relationships/SKILL.md)** §3.3 body fallback guidance.
+
+### Accepted prefixes (case-insensitive)
+
+Each line is evaluated independently; leading/trailing whitespace ignored:
+
+1. **`Blocked by: …`**
+2. **`Parent: …`**
+3. **`Depends on: …`**
+
+After the colon, collect every **`#<digits>`** token as a referenced issue number **in the same repository as the item** (v1 does not parse cross-repo URLs).
+
+### Semantics (prerequisite graph)
+
+- **`Blocked by: #N`** on issue **X** means **N** is a prerequisite of **X** → directed edge **`N → X`** (complete **N** before **X**).
+- **`Depends on: #N`** → **`N → X`**.
+- **`Parent: #N`** on child **X** → **`N → X`** (parent precedes child work in v1 ordering).
+
+### Missing targets
+
+If **`#N`** is parsed but **N** is not an **issue on the same project board** (normalized issue set), record **`unresolvedEdges`** with `{ from: X, to: N, reason: "target_not_on_board" }` and **do not** add that edge to the graph.
+
+References on lines that **do not** match the three prefixes are **ignored** for edges (free text may mention `#123` without creating a dependency).
+
+## Pull requests and drafts (v1)
+
+- Include them in **inventory** and reporting groups.
+- **Do not** auto-parse PR/draft bodies for dependency edges in v1 (unclear semantics vs issues). List under **`skippedNonIssues`** (or equivalent prose) so absence of edges is explicit.
+
+## Algorithm (Kahn layers + cycles)
+
+1. **Nodes** — all **issues** on the board (`kind == issue` with a `number`).
+2. **Edges** — only for references that resolved to on-board issues (`N → X`).
+3. **In-degree** — count incoming edges inside the node set.
+4. **Layers** — repeatedly take every node with **in-degree 0**, remove them, decrement in-degrees of successors. Each removal wave is one **parallel track** (items in a layer may proceed concurrently).
+5. **Order within a layer** — stable **item-list order** (the order items appeared in **`gh project item-list`** JSON) to break ties.
+6. **Cycles** — if remaining nodes exist and **no** in-degree-0 node exists, **Kahn stalls**. Emit one cycle group as those remaining nodes **sorted by item-list order** (v1 treats the entire stall set as one reported cycle component for readability on small boards).
+
+## Output schema (report to chat)
+
+| Key | Meaning |
+| --- | --- |
+| **`layers`** | Ordered list of layers; each layer is issue **numbers** (or `id` + title if numbers absent). |
+| **`cycles`** | List of stall components (issue numbers) when cyclic; empty when DAG resolved completely. |
+| **`unresolvedEdges`** | Parsed refs that could not become edges. |
+| **`skippedNonIssues`** | PRs/drafts/other items not fed into the issue DAG (v1). |
+
+## Large boards
+
+Prefer **`-L 200`** (or document a cap). When truncated, state **truncation** in chat and avoid implying a complete graph.
+
+## Worked examples (mental / fixture-backed)
+
+Fixture JSON lives under **`tests/fixtures/project-order/`**; expected outputs are asserted in **`tests/check-project-order-fixtures.py`**.
+
+- **`no-edges.json`** — independent issues; single layer preserving list order.
+- **`dag.json`** — chain `1 → 2 → 3` via `Blocked by` / `Depends on`; three singleton layers.
+- **`cycle.json`** — mutual prerequisite lines; **no** complete layering; one **cycle** group `[1, 2]`.
+- **`missing-ref.json`** — `Blocked by: #999` when **999** not on board → **unresolvedEdges**; remaining issues stay in one layer with stable order.
+
+## See also
+
+- **[`internal-read-gh-project-list`](../project-list/SKILL.md)** — `gh project list` inventory.
+- **[`internal-read-gh-issue-projects-relationships`](../issue-projects-relationships/SKILL.md)** — project attach + relationship playbook.
+- **[`@gh-project-order-readonly`](../../../gh/projects/order-readonly/SKILL.md)** — public read-only entry.
+- **[`internal-write-gh-project-commands`](../../../write/gh/project-commands/SKILL.md)** — mutating project CLI fences (do not invoke from this read path).

--- a/.agents/skills/internal-read-gh/project-list/SKILL.md
+++ b/.agents/skills/internal-read-gh/project-list/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: internal-read-gh-project-list
+description: >-
+  Normative gh project list inventory shapes. Read-only. Callers add --owner, --closed, --limit, and --format/--jq
+  flags per goal; mutation lives in internal-write-gh-project-commands.
+---
+
+# Internal: GitHub project list (`internal-read-gh-project-list`)
+
+**Library.** **Sole** normative **`gh project list`** fences for this pack. Consumed by **`@gh-project-delete-closed`** for preview/inventory before any delete mutation.
+
+**Mutations** (**`gh project delete`**) live in **[`internal-write-gh-project-commands`](../../../write/gh/project-commands/SKILL.md)**—never run those from this file.
+
+## Cadence (read-only)
+
+This library is read-only and can run without a mutation confirm. Do **not** infer that **Proceed** is satisfied for any follow-on **`gh project delete`** command.
+
+## Auth scope
+
+`gh project` commands require token scope **`project`**. Verify with:
+
+```bash
+gh auth status
+```
+
+If needed, add scope:
+
+```bash
+gh auth refresh -s project
+```
+
+## Caller refinement (flags)
+
+Use the fenced shapes below as bases. Callers add flags for the task at hand:
+
+- `--owner "@me"` or `--owner ORG_LOGIN`
+- `--limit N`
+- `--closed` (includes closed projects in the result set)
+- `--format json` (structured preview output)
+- `--jq '…'` to filter for closed-only views and compact previews
+
+## List projects for an owner
+
+```bash
+gh project list --owner "@me" --limit 30 --format json
+```
+
+## List including closed candidates
+
+```bash
+gh project list --owner "@me" --closed --limit 100 --format json
+```
+
+## Closed-only compact preview (owner + number + title)
+
+```bash
+gh project list --owner "@me" --closed --limit 100 --format json --jq '.projects[] | select(.closed == true) | {owner: .owner.login, number: .number, title: .title}'
+```
+
+## See also
+
+- **[`internal-read-gh-issue-projects-relationships`](../issue-projects-relationships/SKILL.md)** — attach issues to projects from `@gh-issues` (read-only playbook + discovery).
+- **[`internal-write-gh-project-commands`](../../../write/gh/project-commands/SKILL.md)** — `gh project delete` command shapes.
+- **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** — required before any project deletion flow.

--- a/.agents/skills/internal-read-gh/repo-forms-json/SKILL.md
+++ b/.agents/skills/internal-read-gh/repo-forms-json/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: internal-read-gh-repo-forms-json
+description: >-
+  Read-only: sole normative gh repo view --json shapes for issueTemplates and pullRequestTemplates. Callers own
+  JSON parsing, merge rules, and AskQuestion. Does not replace internal-read-gh-repo-stream for fork/same-repo refs.
+---
+
+# Internal: `gh repo view` forms JSON (`internal-read-gh-repo-forms-json`)
+
+**Read-only library.** **Single owner** of the **`gh repo view … --json …`** invocations used to load **GitHub-hosted** issue and pull-request templates from the API. **Callers** (**[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** §5 Step A, **[`internal-read-gh-issue-description`](../issue-description/SKILL.md)** §1 Step A) **run** these lines in the shell and **parse** output in their own sections—**do not** paste duplicate **`gh`** recipes into other **`SKILL.md`** files or **`docs/**`**.
+
+**Prerequisites:** **`$UPSTREAM`**, **`PR_TARGET_REPO`**, and same-repo vs fork semantics live in **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)** §3—this file does **not** repeat that table.
+
+---
+
+## Pull request templates (`pullRequestTemplates`)
+
+Pick the **host** the same way **`internal-read-gh-pr-description`** §5 expects (same-repo → current **`gh`** context; fork → upstream **`owner/repo`** string):
+
+| Case | Command |
+| --- | --- |
+| **Same-repo** | `gh repo view --json pullRequestTemplates` |
+| **Fork** | `gh repo view "$UPSTREAM" --json pullRequestTemplates` |
+
+On GitHub Enterprise, set **`GH_HOST`** (or your **`gh`** host config) so the command hits the right server.
+
+**Optional length probe** (still read **full** template entries when length **> 0**):
+
+```bash
+gh repo view … --json pullRequestTemplates --jq '(.pullRequestTemplates | length)'
+```
+
+Use **`…`** as **`"$UPSTREAM"`** or omit for default context—**consistent** with the table row you chose.
+
+---
+
+## Issue templates (`issueTemplates`)
+
+| Case | Command |
+| --- | --- |
+| **Default** (templates for the **current** **`gh`** repository context—typical when filing on the checkout) | `gh repo view --json issueTemplates` |
+| **Upstream host** (fork workflow: load upstream’s template set—same **`$UPSTREAM`** string as the PR table) | `gh repo view "$UPSTREAM" --json issueTemplates` |
+
+**Optional length probe:**
+
+```bash
+gh repo view … --json issueTemplates --jq '(.issueTemplates | length)'
+```
+
+---
+
+## Combined fetch (same host only)
+
+When both JSON keys are needed in **one** round trip for the **same** host:
+
+```bash
+gh repo view … --json issueTemplates,pullRequestTemplates
+```
+
+**Callers** still split **PR-only** vs **issue-only** parsing and merge rules—this file supplies **commands** only.
+
+---
+
+## Do not
+
+- Copy these **`bash`** fences into **`internal-read-gh-pr-description`**, **`internal-read-gh-issue-description`**, or **`docs/**`**—link here.
+- Re-document **`$UPSTREAM`** / **`PR_TARGET_REPO`**—use **`internal-read-gh-repo-stream`**.
+
+## See also
+
+- **[`internal-read-gh-repo-stream`](../repo-stream/SKILL.md)** — variables for **`gh repo view`**
+- **[`internal-read-gh-pr-description`](../pr-description/SKILL.md)** — PR template body parsing, §6 delta, §6.5–6.6 linking ladder + issue scan, §7 title/body
+- **[`internal-read-gh-issue-description`](../issue-description/SKILL.md)** — issue template parsing and reshape rules

--- a/.agents/skills/internal-read-gh/repo-stream/SKILL.md
+++ b/.agents/skills/internal-read-gh/repo-stream/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: internal-read-gh-repo-stream
+description: >-
+  Read-only library: classify fork vs same-repo, canonical main ref, PR target repo, BASE_GIT, and PR head/base for gh
+  and git callers (no network I/O in this file). No fetch, merge, or gh pr create—callers run their own commands. Used by
+  @git-main, @git-pull, @gh-pr, @git-reset.
+---
+
+# Internal: Git repo stream (fork vs same-repo)
+
+**Read-only.** Discover **where canonical `main` lives** and **where a pull request is opened** (rules for **`git`** remotes/branches **and** **`gh --repo`** targets). Do **not** run `git fetch`, merges, `git reset`, or `gh pr create` here—parent skills own those steps.
+
+**Consumers:** **[`@git-main`](../../../git/main/SKILL.md)** (`CANONICAL_MAIN`), **[`@git-pull`](../../../git/pull/SKILL.md)** (`ROOT_BRANCH`), **[`@gh-pr`](../../../gh/pr/SKILL.md)** (`$BASE_GIT`, `$UPSTREAM`, `gh` targets), **[`@git-reset`](../../../git/reset/SKILL.md)** (aligning `main` to upstream when applicable).
+
+## Do
+
+- Classify fork vs same-repo and resolve **canonical main**, **PR targets**, and **`BASE_GIT`** for parent skills.
+
+## Do not
+
+- Run **`git fetch`**, merges, **`git reset`**, or **`gh pr create`**—parent skills own those steps.
+
+---
+
+## 1. Detect fork vs same-repo
+
+1. Run **`git remote get-url upstream`** (or equivalent).
+2. **If success** — treat as **fork**:
+   - **`UPSTREAM`** — `owner/repo` parsed from the URL (SSH or HTTPS).
+   - **`FORK_OWNER`** — owner from **`git remote get-url origin`** (the fork’s GitHub user or org).
+   - **`STREAM_MODE`** = `fork`.
+3. **If failure** — **same-repo** clone:
+   - **`UPSTREAM`** — unset / empty (no upstream remote).
+   - **`STREAM_MODE`** = `same_repo`.
+
+**If the workflow is a fork but `upstream` is missing** — **stop**; suggest `git remote add upstream <url>` and fetch. Do not guess **`UPSTREAM`**.
+
+---
+
+## 2. Canonical main ref (`CANONICAL_MAIN_REF`)
+
+Single definition used by **`@git-main`** and **`@git-pull`** for “tip of mainline in this workspace”:
+
+| Condition | `CANONICAL_MAIN_REF` |
+| --- | --- |
+| **`upstream` remote exists** | **`upstream/main`** |
+| **Else** | **`origin/main`** |
+
+Verify with **`git rev-parse "$CANONICAL_MAIN_REF"`** after remotes are fetched (callers fetch; this skill does not).
+
+**Alias:** **`ROOT_BRANCH`** in **`@git-pull`** = **`CANONICAL_MAIN_REF`**. **`CANONICAL_MAIN`** in **`@git-main`** = same ref.
+
+---
+
+## 3. PR-oriented fields (for `@gh-pr` and `gh`)
+
+Use **after** §1–§2 so **`STREAM_MODE`**, **`UPSTREAM`**, and **`FORK_OWNER`** are set.
+
+| Variable | Fork (`STREAM_MODE=fork`) | Same-repo |
+| --- | --- | --- |
+| **`BASE_GIT`** | **`upstream/main`** | **`main`** or **`origin/main`**—match how **`@git-pull`** merged canonical **`main`** into the branch (typically **`main`** if checked out, else **`origin/main`**) |
+| **`PR_TARGET_REPO`** | **`$UPSTREAM`** (`owner/repo` for `gh --repo`, `gh repo view`) | Current repo (**`gh repo view`** without `--repo` override) |
+| **`PR_BASE_BRANCH`** | **`main`** on **`$UPSTREAM`** | **`main`** |
+
+**GitHub PR base:** always **`main`** on the **destination** repo (**`$UPSTREAM`** for forks, else the current repo).
+
+**Issue list / search / URLs:** For **`@gh-pr`** and **`internal-read-gh-pr-description`** §6.6, use **`PR_TARGET_REPO`** as **`--repo owner/repo`** and as **`https://github.com/OWNER/REPO/...`** host for issues and PRs on the **destination** (upstream when forking), unless the issue genuinely lives on the fork.
+
+---
+
+## 4. PR head ref (`--head` for `gh pr create`)
+
+Let **`BRANCH`** = `git branch --show-current`.
+
+| `STREAM_MODE` | `BRANCH` | PR **head** argument |
+| --- | --- | --- |
+| **same_repo** | `main` | *(no PR from this skill’s perspective—**`@gh-pr`** stops after sync)* |
+| **same_repo** | feature | **`$BRANCH`** |
+| **fork** | `main` | **`$FORK_OWNER:main`** — open PR **from fork’s `main`** to **`$UPSTREAM`** **`main`** |
+| **fork** | feature | **`$FORK_OWNER:$BRANCH`** |
+
+This is the **“proceed toward upstream”** case when you are on **fork `main`**: the PR targets **`$UPSTREAM`**, not the fork as base.
+
+---
+
+## 5. `gh` commands (reference—run in parent skill)
+
+- **List / create / edit PR (fork):** pass **`--repo "$UPSTREAM"`** where **`@gh-pr`** already does.
+- **Templates:** **`gh repo view --json`** shapes for **`pullRequestTemplates`** / **`issueTemplates`** live **only** in **[`internal-read-gh-repo-forms-json`](../repo-forms-json/SKILL.md)**—use the **fork** / **`$UPSTREAM`** rows there when **`PR_TARGET_REPO`** is upstream (not the fork as template host).
+
+---
+
+## 6. Relation to `@git-reset` target
+
+When **`@git-reset`** resolves **`$TARGET`** and the branch is **`main`** with **`upstream/main`** available, prefer **`upstream/main`** as the canonical tip—consistent with **`CANONICAL_MAIN_REF`** above. **`@git-reset`** still uses tracking **`@{u}`** first when set; see that skill’s priority list.

--- a/.agents/skills/internal-read-git-configuration/SKILL.md
+++ b/.agents/skills/internal-read-git-configuration/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: internal-read-git-configuration
+description: >-
+  Read-only batch: from discovery output, resolve umbrella/format/lint/test/coverage commands to run.
+  No shell installs or test execution. Used by @git-review between prepare and evaluate.
+---
+
+# Internal: Check command configuration
+
+**Library.** Turns **discovery** (from **[`internal-read-git-discover-dependencies`](../discover-dependencies/SKILL.md)**) into an **ordered command plan** for **[`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md)**. Does **not** run commands—**evaluate** runs them.
+
+**Consumers:** **`@git-review`** — after Prepare, before Evaluate.
+
+---
+
+## Input
+
+- Discovery summary: stacks present, README/CI hints, coverage expectations.
+- **Post-install** state: e.g. `node_modules` exists, `cargo metadata` ok.
+
+---
+
+## Output (conceptual)
+
+Record for each applicable stack:
+
+1. **Umbrella** — Single entry if present (`make check`, `npm run check`, `pnpm validate`, `task check`, …) or **none**.
+2. **Format** — Prefer **fix** scripts when present (`npm run format`, `cargo fmt`, `ruff format`, …); otherwise check-only (`prettier --review`, …). See **[`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md)** §5. **Skip** if no formatter.
+3. **Lint** — `cargo clippy`, `ruff check`, `eslint`, `golangci-lint`, … per stack.
+4. **Test** — Primary test script or `cargo test` / `pytest` / `go test ./...`.
+5. **Coverage** — Commands + thresholds from discovery, or **omit** if §1d found no expectation.
+
+Prefer **documented** order: umbrella **first** when it clearly subsumes format+lint+test; otherwise run §5–7 of **`@git-review`** as in **[`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md)**.
+
+---
+
+## Do not
+
+- Run installs or checks.
+- Invent `npm test` / `cargo clippy` without signals from discovery + repo config.
+
+## See also
+
+- **[`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md)** — executes the matrix.

--- a/.agents/skills/internal-read-git-discover-dependencies/SKILL.md
+++ b/.agents/skills/internal-read-git-discover-dependencies/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: internal-read-git-discover-dependencies
+description: >-
+  Read-only batch: scan READMEs, CI, and repo config to infer stacks, toolchains, coverage expectations,
+  and authoritative check commands; then map gaps vs disk (lockfiles, node_modules, venv). Used by @git-review §1–2 and
+  @gh-issue-review (read-only context).
+---
+
+# Internal: Discover + map gaps (dependencies / stack)
+
+**Library.** Single **batch** of evidence gathering for **`@git-review`**: Discover (§1) and Map gaps (§2). Does not run installs, formatters, tests, or git writes—callers run **[`internal-write-gh-install-dependencies`](../../write/gh/install-dependencies/SKILL.md)** next.
+
+**Consumers:** **`@git-review`** §1–2; **`@gh-issue-review`** (issue reshape, **§1 only**—no install/evaluate); **manual / agent-led** structural planning (stack + monorepo hints, **`internal-read-git-doc-wiki`** §3 API signals).
+
+---
+
+## Batch A — Discover
+
+### Documentation (priority)
+
+Read—**do not assume only** `./README.md`:
+
+- `README.md` (root), `README.rst`, `docs/` index READMEs, `CONTRIBUTING.md`, `INSTALL.md`, `DEVELOPMENT.md`.
+- Monorepos: nested `README.md` under `packages/`*, `apps/`*, etc., when root points there.
+
+### Configuration signals (infer stacks)
+
+Scan root (and workspace layout) for:
+
+| Area      | Signals                                                                             |
+| --------- | ----------------------------------------------------------------------------------- |
+| Node / TS | `package.json`, lockfiles, `tsconfig.json`, eslint/prettier/vitest/jest configs     |
+| Python    | `pyproject.toml`, `requirements*.txt`, `ruff`, `.flake8`, `.python-version`, `mypy` |
+| Rust      | `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`                                  |
+| Go        | `go.mod`, `.golangci.*`                                                             |
+| Other     | `Gemfile`, `pom.xml`, `build.gradle*`, `Makefile`, `justfile`, `Taskfile.yml`       |
+| CI        | `.github/workflows/*.yml`, `.gitlab-ci.yml`, etc.                                   |
+
+### Internal summary (produce for downstream)
+
+- **Languages / stacks present** (or “docs-only”).
+- **Required toolchain** (README, `.nvmrc`, `rust-toolchain.toml`, …).
+- **Authoritative check commands** — README → CI → Makefile / `package.json` / `pyproject.toml` scripts → defaults in `[internal-read-git-configuration](../configuration/SKILL.md)` / `[internal-write-gh-evaluate](../../write/gh/evaluate/SKILL.md)`.
+
+If **no** code stack: report “no code checks applicable”; still allow documentation pass later.
+
+### Coverage expectations (§1d analogue)
+
+From README, CI, scripts, config: infer **whether** coverage is required and **which** command(s) / thresholds apply for `[internal-write-gh-evaluate](../../write/gh/evaluate/SKILL.md)` §7b.
+
+### API surface signals (for `docs/api/` gating)
+
+Use when **`internal-read-git-doc-wiki`** needs to decide whether **`docs/api/`** is warranted. **Presence-only** scan (read paths / globs; do not assume runtime):
+
+- OpenAPI / Swagger: `openapi.yaml`, `openapi.json`, `swagger.yaml`, `swagger.json`
+- GraphQL: `*.graphql`, `schema.graphql`, common `graphql` schema filenames
+- gRPC: `*.proto`
+- Framework hints: `routes.ts`, `router.go`, `urls.py`, `APIRouter`, `app/api/`, `pages/api/`, `src/routes/` (when clearly HTTP APIs)
+
+If **none** of the above are credible for this repo, report **no API docs scaffold** unless the user overrides in chat.
+
+### Monorepo / multi-package hints
+
+Top-level **`services/`**, **`apps/`**, **`packages/`**, or workspace config (`pnpm-workspace.yaml`, `go.work`, etc.)—surface in the internal summary for **`monorepo`** / profile selection (**`internal-read-git-doc-wiki`**).
+
+---
+
+## Batch B — Map gaps
+
+From Batch A, compare **documented / CI** expectations to **disk**:
+
+- Lockfile vs `node_modules` / vendor / `venv` / `.venv` presence when README requires install.
+- CI step order vs what has been run locally (e.g. `npm ci` vs `npm install`).
+- README vs CI mismatch — prefer README for **local dev**, **call out** divergence.
+
+**Output:** Targeted gap list for `[internal-write-gh-install-dependencies](../../write/gh/install-dependencies/SKILL.md)`.
+
+---
+
+## Do not
+
+- Install packages, run tests, or edit files.
+- Skip CI/README when inferring commands.
+
+## See also
+
+- [`internal-read-git-configuration`](../configuration/SKILL.md) — resolve command matrix.
+- [`internal-read-git-doc-wiki`](../doc-wiki/SKILL.md) — **`docs/api/`** gating and doc profiles.
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md) — **§3a** confirmations for destructive prep (via **`internal-write-gh-install-dependencies`**).

--- a/.agents/skills/internal-read-git-doc-exemplars/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-exemplars/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: internal-read-git-doc-exemplars
+description: >-
+  Read-only: markdown-first public documentation exemplars (links + patterns) and a filtering rubric before
+  adopting external ideas. Callers: internal-write-gh-documentation, @git-docs. Does not write files or copy
+  third-party bodies.
+---
+
+# Internal: Public documentation exemplars (`internal-read-git-doc-exemplars`)
+
+**Read-only library.** **Pointers and rules only** — use when **`internal-write-gh-documentation`** or **`@git-docs`** should borrow **structure** (headings, tables, troubleshooting blocks) from well-known **markdown-in-repo** documentation. **Do not** paste large chunks of external text without license checks; **do not** bypass **`internal-write-gh-documentation`** / **`@git-docs`** for substantive doc edits.
+
+**Consumers:** **[`internal-write-gh-documentation`](../../write/gh/documentation/SKILL.md)** (polish existing paths), **[`@git-docs`](../../../git/docs/SKILL.md)** (seeds, layout, polish modes).
+
+---
+
+## Skill ownership (sanctioned doc changes)
+
+External repos inform **patterns** only; changes still flow through **`@git-docs`** or **`@git-review`** §8a → **`internal-write-gh-documentation`**.
+
+```mermaid
+flowchart TB
+  classDef neuM fill:#eceff1,color:#111
+  classDef pub2 fill:#1976d2,color:#fff
+  classDef int2 fill:#00897b,color:#fff
+  classDef int3 fill:#4db6ac,color:#111
+  subgraph ext [External]
+    EX[Markdown_exemplars]
+  end
+  subgraph skills [Sanctioned_writers]
+    GD[git-docs]
+    IDOC[internal-write-gh-documentation]
+    REV[gh-review_8a]
+  end
+  EX -.->|"patterns_only"| GD
+  EX -.->|"patterns_only"| IDOC
+  REV --> IDOC
+  class EX neuM
+  class GD pub2
+  class IDOC int2
+  class REV int3
+```
+
+---
+
+## Curated shortlist (markdown in tree)
+
+Primary artifact should be **`.md` in the repository** (not a static site generator as the only source of truth).
+
+| Source | Why it is useful | Extract | Skip |
+| --- | --- | --- | --- |
+| [github/opensource.guide](https://github.com/github/opensource.guide) | Short chapters; strong **contributing / community / legal** tone | Heading depth, “when to use this page”, cross-links, checklist-style sections | Product-specific GitHub UI copy |
+| [thegooddocsproject](https://github.com/thegooddocsproject) (repos under the org) | Explicit **doc-type** templates (how-to, tutorial, reference stubs) | Skeleton ideas: prerequisites, steps, “see also”, troubleshooting | Toolchain-specific assumptions; verbatim merges without license review |
+| Large OSS **`docs/`** trees in markdown (e.g. **eslint**, **nodejs** `doc/`, **pandas** narrative docs) | Real **guide vs reference** separation | How they split narrative from catalogs; tables and version notes | Install matrices and commands that are not this repo’s truth |
+| **Small libraries** with clear READMEs (e.g. **semver**-style) | Above-the-fold clarity | First-screen structure; minimal badge/link discipline | Marketing READMEs that do not fit a skill-pack repo |
+
+**Out of scope for this skill (do not treat as copy sources here):** Diátaxis site prose; Docusaurus / VitePress / MkDocs **site source** as template (SSG coupling). You may still map ideas mentally (tutorial vs how-to vs reference) without copying those sites.
+
+---
+
+## Filtering rubric (before adopting a pattern)
+
+Apply when changing **`docs/README.md`**, **`docs/<domain>/.../README.md`**, **minimal root** **[`README.md`](../../../../README.md)**, or (legacy) monolithic **`docs/*`** files:
+
+1. **Portability** — Works as **static markdown** with relative links and optional mermaid (**[`internal-write-gh-documentation`](../../write/gh/documentation/SKILL.md)** prefers mermaid).
+2. **Hub fit** — Maps to **one** surface: **Quick guide / install** (root README), **skill catalog** (**`docs/git.md`** / **`docs/gh.md`** / **`docs/internal.md`** or a slimmer layout on other repos), **diagram** (mermaid in **`docs/README.md`** or domain wiki), or **single-file overview**—not scattered duplicates.
+3. **License** — Prefer **CC / MIT / permissive** examples; avoid long **copyleft** or **all rights reserved** pastes without explicit check.
+4. **No false precision** — Reject commands and claims that conflict with **this** repo’s **[`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md)** / CI (**[`internal-read-git-configuration`](../configuration/SKILL.md)**).
+5. **Size** — Respect **`@git-docs`** limits (~**400 lines** or ~**48 KiB** per narrative file; split when over).
+6. **Single writer path** — Land improvements via **`internal-write-gh-documentation`** or **`@git-docs`**, not ad-hoc agent edits outside those skills.
+
+---
+
+## Do
+
+- Use this file to **choose** external patterns and **justify** section/table shapes when editing under **`internal-write-gh-documentation`** or **`@git-docs`**.
+
+## Do not
+
+- **Copy** third-party documentation bodies into the repo from this skill alone — **adapt** minimally and attribute or link when required.
+- Run shell, **`git`**, or **`gh`** — read-only reference.
+
+---
+
+## See also
+
+- [`internal-write-gh-documentation`](../../write/gh/documentation/SKILL.md) — polish **existing** markdown
+- [`@git-docs`](../../../git/docs/SKILL.md) — seeds, layout, splits
+- [`internal-read-git-doc-user-guide`](../doc-user-guide/SKILL.md) · [`internal-read-git-doc-reference`](../doc-reference/SKILL.md) · [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md) — greenfield **`wiki-reference-scaffold`** / diagram child skills
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md) — doc hub placement

--- a/.agents/skills/internal-read-git-doc-explanation/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-explanation/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: internal-read-git-doc-explanation
+description: >-
+  Read-only: how to write overview/explanation sections for docs mirror pages from SKILL.md. Callers: @git-docs,
+  internal-write-gh-documentation. Does not write files.
+---
+
+# Internal: Doc explanation rules (`internal-read-git-doc-explanation`)
+
+**Read-only library.** **Normative guidance** for **Overview** / narrative blocks on **`docs/<domain>/.../README.md`** or optional **`docs/.../README.md`** mirror pages.
+
+---
+
+## Rules
+
+1. Derive **what / when / boundaries** from **`SKILL.md`** frontmatter **`description`** and **Do** / **Do not** sections.
+2. **Link** delegates (**`internal-*`**, sibling public skills) with **one line why**.
+3. Avoid speculative roadmaps—describe **current** behavior.
+
+## See also
+
+- [`internal-read-git-doc-index`](../doc-index/SKILL.md)
+- [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md) — when to add **mermaid** + palette
+- [`internal-read-git-doc-index`](../doc-index/SKILL.md) — pair narrative sections with stable page navigation.

--- a/.agents/skills/internal-read-git-doc-graphs-legacy-graphs-pack-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs-legacy-graphs-pack-scaffold/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: internal-read-git-doc-graphs-legacy-graphs-pack-scaffold
+description: >-
+  Read-only compact legacy graph scaffold. Keep this lightweight and link to in-pack skill DAG sources.
+---
+
+# Legacy graphs scaffold (compact)
+
+Use this only for repositories that still keep a legacy graphs page. Keep the content short and rely on in-pack skill links.
+
+## Rules
+
+- Keep diagrams acyclic and focused on core public skills.
+- Do not copy full command lists into this file.
+- Source operational behavior from `skills/**/SKILL.md`.
+
+## Minimal graph
+
+```mermaid
+flowchart TB
+  gitPull["@git-pull"] --> gitReview["@git-review"]
+  gitReview --> gitPush["@git-push"]
+  gitPush --> ghPr["@gh-pr"]
+  ghIssues["@gh-issues"] --> issueCmds["internal-write-gh-issue-commands"]
+  ghPr --> prCmds["internal-write-gh-pr-commands"]
+  cursorPlan[Cursor Plan] -.-> ghIssues
+```
+
+## See also
+
+- [`internal-read-git-doc-graphs`](../SKILL.md)
+- [`internal-read-git-repo-layout`](../../repo-layout/SKILL.md)
+- [`internal-read-git-workflows`](../../workflows/SKILL.md)

--- a/.agents/skills/internal-read-git-doc-graphs/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: internal-read-git-doc-graphs
+description: >-
+  Read-only: when to add mermaid, color/layout conventions; diagram scaffolds in ./diagrams/*/SKILL.md.
+  Optional legacy-graphs-pack-scaffold (legacy GRAPHS.md). Callers: @git-docs. Does not write files.
+---
+
+# Internal: Documentation graphs (`internal-read-git-doc-graphs`)
+
+**Read-only.** **When to diagram** (kind choice), **Mermaid constraints**, **color/layout narrative**, and **diagram scaffolds** all live **here**—**one** library to open for figures. **Hex tables**, **named `classDef`s**, and **copy-paste blocks** live only in **[`diagrams/palette/SKILL.md`](./diagrams/palette/SKILL.md)**, **[`diagrams/examples/SKILL.md`](./diagrams/examples/SKILL.md)**, **`diagrams/scaffold-*/SKILL.md`**. **`[legacy-graphs-pack-scaffold/SKILL.md](./legacy-graphs-pack-scaffold/SKILL.md)`** — optional legacy **`docs/GRAPHS.md`** only.
+
+**Consumers:** scaffold passes, **`@git-docs`**.
+
+## When to add a diagram
+
+- **Flows** (pipelines, hand-offs, branches) → **flowchart** or **sequence** template.
+- **Parallel tracks / subgraphs** → **DAG** template.
+- **States / modes** → **state** template.
+- **User journeys, friction, recovery** → **`diagrams/scaffold-user-journey/SKILL.md`**.
+- **Which option / when to use** → **`diagrams/scaffold-decision/SKILL.md`**.
+- **Actors or lanes** (user, product, support) → **`diagrams/scaffold-stakeholder-flow/SKILL.md`**.
+- **Static-only** folders may use a **small hierarchy** figure or skip if prose suffices.
+
+## Do (diagrams)
+
+- Pick **one** kind template, copy into a **single** fenced **`mermaid`** block with **`classDef`** / **`class`** inlined (**colored**—no monochrome-only narrative diagrams).
+
+## Published shape
+
+- **Where:** fenced **`mermaid`** inside **`docs/**`**, minimal root **`README.md`**, or legacy hubs.
+- **Scaffolds:** one block per **`diagrams/scaffold-*/SKILL.md`** child skill.
+- **Rules:** constraints below + **palette** + **examples** (do **not** duplicate long ramps or sample figures in this file).
+
+## Do not
+
+- Run shell, **`git`**, or **`gh`** from this skill.
+- Duplicate long **palette** / **examples** bodies in this file—link **`diagrams/palette`** / **`diagrams/examples`** child skills instead.
+
+## Mermaid constraints
+
+- **Node IDs:** `camelCase` / `PascalCase` / `snake_case` — **no spaces** in IDs.
+- **Labels** with spaces/special chars: **double-quoted** node text, e.g. `node["/gh-start"]`.
+- **GitHub renderer safety:** quote any label containing `@` (for example `node["@gh-pr"]`) or other special punctuation to avoid parse failures like `LINK_ID` in README/PR/issue rendering. Reference: [GitHub Mermaid docs](https://docs.github.com/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams).
+- **Edge labels** with parens/commas: **quotes**, e.g. `A -->|"O(n)"| B`.
+- **Reserved words:** avoid bare `end`, `subgraph`, `graph`, `flowchart` as IDs; use `endNode`, `subgraph id [Label]`.
+- **Subgraphs:** explicit ids: `subgraph id [Human label]`.
+
+## Color — spine first
+
+**Unique to this file:** narrative for **A→…→B** emphasis (entry-strong vs leaf-strong). **Implementation:** always **`classDef`** + **`class`** at block end; contrast per **`diagrams/palette/SKILL.md`**.
+
+1. **Spine** — pick the main directed path; **A** = entry / trigger, **B** = outcome (or **leaf-strong**: strongest on terminal outcome—**one story per figure**).
+2. **Ramp** — 2–5 `classDef` steps along the spine (mix toward white / lower saturation between anchors); **side branches** muted (`pubM`, `intM`, `neuM`, legacy `hueGhM`, `uxOff`, … per **`diagrams/palette/SKILL.md`**).
+3. **Do not** — rainbow unrelated nodes; identical strong fills everywhere; low-contrast labels.
+
+For skill-pack or agent-architecture figures, prefer domain ramps from **`diagrams/palette/SKILL.md`**: **`pub*`** (public skills), **`hum*`** (human instructions), **`int*`** (internal narrowed skills), with **`neu*`** only for non-skill context.
+
+**Worked colored DAGs** — copy from **`diagrams/examples/SKILL.md`** only.
+
+## Layout
+
+- **TB** — portrait-friendly single column; **LR** — wide pipelines.
+- **Avoid** dense N×M grids; split into two figures or use **`sequenceDiagram`** when time-order dominates vertical space.
+
+## File layout
+
+| File | Role |
+| --- | --- |
+| **`SKILL.md`** (this) | Constraints + layout narrative |
+| **`legacy-graphs-pack-scaffold/SKILL.md`** | Legacy **`docs/GRAPHS.md`** only |
+| [`diagrams/palette/SKILL.md`](./diagrams/palette/SKILL.md) | Named ramps |
+| [`diagrams/scaffold-*/SKILL.md`](./diagrams/) | Per-kind scaffolds |
+| [`diagrams/examples/SKILL.md`](./diagrams/examples/SKILL.md) | Sample figures |
+
+## See also
+
+- [`internal-read-git-doc-exemplars`](../doc-exemplars/SKILL.md) — markdown rubric
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md) — hub contract
+- [`@git-docs`](../../../git/docs/SKILL.md)

--- a/.agents/skills/internal-read-git-doc-graphs/diagrams/diagrams-index/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/diagrams/diagrams-index/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-diagrams-index
+description: >-
+  Read-only: index of mermaid diagram scaffolds. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold index for diagram helpers.
+

--- a/.agents/skills/internal-read-git-doc-graphs/diagrams/examples/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/diagrams/examples/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-examples
+description: >-
+  Read-only: mermaid example figures. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for diagram examples.
+

--- a/.agents/skills/internal-read-git-doc-graphs/diagrams/palette/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/diagrams/palette/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-palette
+description: >-
+  Read-only: mermaid palette (classDef ramps). Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for diagram palette guidance.
+

--- a/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-dag/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-dag/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-dag
+description: >-
+  Read-only: mermaid DAG template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-decision/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-decision/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-decision
+description: >-
+  Read-only: mermaid decision-tree template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-domain-taxonomy/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-domain-taxonomy/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-domain-taxonomy
+description: >-
+  Read-only: mermaid skill-layer flow template (public/human/internal). Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-flowchart/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-flowchart/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-flowchart
+description: >-
+  Read-only: mermaid flowchart template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-sequence/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-sequence/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-sequence
+description: >-
+  Read-only: mermaid sequence diagram template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-stakeholder-flow/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-stakeholder-flow/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-stakeholder-flow
+description: >-
+  Read-only: mermaid stakeholder-flow template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-state/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-state/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-state
+description: >-
+  Read-only: mermaid state diagram template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-user-journey/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/diagrams/scaffold-user-journey/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-user-journey
+description: >-
+  Read-only: mermaid user-journey template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git-doc-graphs/legacy-graphs-pack-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-graphs/legacy-graphs-pack-scaffold/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: internal-read-git-doc-graphs-legacy-graphs-pack-scaffold
+description: >-
+  Read-only compact legacy graph scaffold. Keep this lightweight and link to in-pack skill DAG sources.
+---
+
+# Legacy graphs scaffold (compact)
+
+Use this only for repositories that still keep a legacy graphs page. Keep the content short and rely on in-pack skill links.
+
+## Rules
+
+- Keep diagrams acyclic and focused on core public skills.
+- Do not copy full command lists into this file.
+- Source operational behavior from `skills/**/SKILL.md`.
+
+## Minimal graph
+
+```mermaid
+flowchart TB
+  gitPull["@git-pull"] --> gitReview["@git-review"]
+  gitReview --> gitPush["@git-push"]
+  gitPush --> ghPr["@gh-pr"]
+  ghIssues["@gh-issues"] --> issueCmds["internal-write-gh-issue-commands"]
+  ghPr --> prCmds["internal-write-gh-pr-commands"]
+  cursorPlan[Cursor Plan] -.-> ghIssues
+```
+
+## See also
+
+- [`internal-read-git-doc-graphs`](../SKILL.md)
+- [`internal-read-git-repo-layout`](../../repo-layout/SKILL.md)
+- [`internal-read-git-workflows`](../../workflows/SKILL.md)

--- a/.agents/skills/internal-read-git-doc-index/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-index/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: internal-read-git-doc-index
+description: >-
+  Read-only: rules for doc page indexes (numbered lists, lexicographic order, no tables in Contents). Callers:
+  @git-docs, internal-write-gh-documentation. Does not write files.
+---
+
+# Internal: Doc index rules (`internal-read-git-doc-index`)
+
+**Read-only library.** **Normative rules** for **navigation** sections on **`docs/**`** pages.
+
+**Consumers:** **`@git-docs`**, **`internal-write-gh-documentation`**, **`internal-read-git-readme-tree`** (bootstrap text).
+
+**Default for agents** — When you add or fix **`## Contents`** (or similar nav blocks) in **`README.md`** / **`docs/**`** in **any** project, apply **these rules silently** as part of **`@git-docs`** or **`internal-write-gh-documentation`**—the user does **not** need to name **`internal-read-git-doc-index`** in chat.
+
+---
+
+## Rules
+
+1. **`## Contents`** (and **See also** when it is pure navigation): **numbered nested lists** only.
+2. **Lexicographic** ordering of children (stable convention per repo).
+3. **No markdown tables** for directory listings—GitHub file view is already tabular.
+4. Link to **source** **`SKILL.md`** where the doc mirrors a skill folder.
+
+## Do not
+
+- Duplicate full skeleton bodies here—reuse this file's rules and sibling doc libraries instead.
+
+## See also
+
+- [`internal-read-git-doc-explanation`](../doc-explanation/SKILL.md)
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md)
+- [`docs/README.md`](../../../../docs/README.md)

--- a/.agents/skills/internal-read-git-doc-reference-docs-hub-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-reference-docs-hub-scaffold/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: internal-read-git-doc-reference-docs-hub-scaffold
+description: >-
+  Read-only: docs hub README scaffold. Parent internal-read-git-doc-reference.
+---
+
+# Documentation index
+
+**Repository:** <name> — <one-line purpose>.
+
+Use this as a **wiki hub** starter when `docs/` is the human-facing surface and `skills/**/SKILL.md` remains normative.
+
+---
+
+## 📑 Contents
+
+1. [Location map](#location-map)
+2. [Browse](#browse)
+3. [Common commands](#common-commands)
+4. [Diagram policy](#diagram-policy)
+5. [See also](#see-also)
+
+---
+
+## 🧩 Location map
+
+| Location | Purpose |
+| --- | --- |
+| [`docs/README.md`](README.md) | Hub index and routing for human readers. |
+| [`docs/git.md`](git.md) | Public/local git workflow wiki. |
+| [`docs/gh.md`](gh.md) | GitHub issue/PR workflow wiki. |
+| [`docs/internal.md`](internal.md) | Internal read/write library map. |
+| [`skills/**/SKILL.md`](../skills/) | Source of truth for contracts and behavior. |
+
+---
+
+## 🧩 Browse
+
+| Topic | Description |
+| --- | --- |
+| [reference/README.md](reference/README.md) | Start here — map of reference pages |
+| <add more rows> | <link each `docs/reference/*.md`> |
+
+---
+
+## 🧩 Common commands
+
+1. `@git-review` for verification.
+2. `@git-docs` for in-place doc corrections.
+3. `@git-push` for commit + publish.
+4. `@gh-pr` after pull + push for PR metadata.
+
+---
+
+## 🧩 Diagram policy
+
+- Diagrams are welcome in the hub and key flow pages, but avoid adding Mermaid blocks everywhere.
+- Keep 0-2 diagrams per page unless the workflow is genuinely complex.
+- For GitHub rendering safety, quote labels containing special characters (for example `node["@gh-pr"]`).
+- For palette and scaffold examples, use [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md).
+
+---
+
+## 🔗 See also
+
+- **[docs/git.md](../../../../../docs/git.md)**, **[docs/gh.md](../../../../../docs/gh.md)**, **[docs/internal.md](../../../../../docs/internal.md)** — agent skills by domain (**this** pack)
+- **Pasteables** under **`docs/`**: see *Folder and file index* in [reference/README.md](reference/README.md) or your legacy [REFERENCE.md](REFERENCE.md)

--- a/.agents/skills/internal-read-git-doc-reference-reference-readme-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-reference-reference-readme-scaffold/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: internal-read-git-doc-reference-reference-readme-scaffold
+description: >-
+  Read-only: root README long-form scaffold. Parent internal-read-git-doc-reference.
+---
+
+# Reference wiki
+
+Deep dives and catalogs. **Diagrams:** use self-contained **`mermaid`** in each page; **color and spine** rules live only in **`internal-read-git-doc-graphs`** (**`SKILL.md`** + **`diagrams/*/SKILL.md`**)—do not paste authoring appendix tables into published docs.
+
+---
+
+## Contents
+
+| Page | Description |
+| --- | --- |
+| <e.g. [skills.md](skills.md)> | <Public + internal skill summaries — link to `SKILL.md`> |
+| <e.g. [pipelines.md](pipelines.md)> | <Verify / PR / context flows> |
+
+---
+
+## Folder and file index
+
+Link every domain **`README.md`** under **`skills/`** (and other top-level folders) so readers can jump from wiki to subtree owners.
+
+- **[docs/git.md](../../../../../docs/git.md)**, **[docs/gh.md](../../../../../docs/gh.md)**, **[docs/internal.md](../../../../../docs/internal.md)** (domain docs for `skills/`, **this** pack)
+- <add per-domain READMEs>
+
+---
+
+## Template sources (internal)
+
+| Role | Skill |
+| --- | --- |
+| Wiki hub | `internal-read-git-doc-reference` — child **`SKILL.md`** bodies (e.g. **`wiki-reference-scaffold`**) + repo **`docs/`** |
+| User guide | `internal-read-git-doc-user-guide` |
+| Diagram authoring | `internal-read-git-doc-graphs` |
+| Root / folder README | `internal-read-git-readme-root`, `internal-read-git-readme-tree` |
+
+---
+
+## Related
+
+- [Documentation index](../SKILL.md)
+- [USER_GUIDE.md](../USER_GUIDE.md)

--- a/.agents/skills/internal-read-git-doc-reference-wiki-reference-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-reference-wiki-reference-scaffold/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: internal-read-git-doc-reference-wiki-reference-scaffold
+description: >-
+  Read-only: legacy REFERENCE/wiki page scaffold. Parent internal-read-git-doc-reference.
+---
+
+# Skills reference
+
+Complete catalog of **every** skill in this repository: **public** skills first (user-invoked under `skills/git/` and `skills/gh/`), then **internal** libraries (`skills/<domain>/`). Invocation: `/flattened-name` or `@flattened-name` (path under `skills/` with `/` → `-`, e.g. `skills/gh/pr/SKILL.md` → **`gh-pr`**).
+
+**Install:** [README.md](../README.md) · **Doc index:** [README.md](README.md) (wiki) or this file (legacy) · **Workflows:** [USER_GUIDE.md](USER_GUIDE.md)
+
+---
+
+## Documentation set (`docs/`)
+
+**Preferred (wiki):** [README.md](README.md), [USER_GUIDE.md](USER_GUIDE.md), **`reference/**`** — scaffold **manual / agent-led** from **`internal-read-git-doc-reference`** child skills (**`reference-readme-scaffold`**, **`docs-hub-scaffold`**, …) **confirm-first**. **Legacy:** this monolithic **[REFERENCE.md](REFERENCE.md)**; optional **[GRAPHS.md](GRAPHS.md)**. Templates stay in **`skills/read/git/doc-*`**.
+
+| Path | Role |
+| --- | --- |
+| [README.md](README.md) | Doc hub index (wiki layout) |
+| [reference/README.md](reference/README.md) | Reference wiki start page |
+| [REFERENCE.md](REFERENCE.md) | This file — legacy full catalog |
+| [USER_GUIDE.md](USER_GUIDE.md) | Install, prerequisites, workflows |
+| [GRAPHS.md](GRAPHS.md) | Optional legacy diagram file |
+
+---
+
+## Folder and file index
+
+Hub **READMEs** (subtree scope and **Related** links)—use with **`docs/reference/**`** or small **mermaid** in each **README** when a diagram helps:
+
+- **[`docs/git.md`](../../../../../docs/git.md)**, **[`docs/gh.md`](../../../../../docs/gh.md)**, **[`docs/internal.md`](../../../../../docs/internal.md)** — domain wikis (**this** pack)
+- **`skills/git/**`**, **`skills/gh/**`**, **`skills/read/**`**, **`skills/write/**`** — normative **`SKILL.md`** per folder
+- **[`skills/write/plan/`](../../../../write/plan/)** — structured Q&A + safety (**`internal-write-plan-structured-qa`**, **`internal-write-plan-skill-safety`**)
+- **[`skills/read/git/SKILL.md`](../../../../read/git/SKILL.md)**, **[`skills/read/gh/SKILL.md`](../../../../read/gh/SKILL.md)**, **[`skills/read/plan/SKILL.md`](../../../../read/plan/SKILL.md)** — library root indexes
+
+**Scaffold sources** — **`skills/read/git/doc-index/`** skeleton child skills + diagram scaffolds under **`internal-read-git-doc-graphs`**, plus other **`internal-read-git-doc-*`** child **`SKILL.md`** bodies. **`@git-docs`** only aligns **existing** pages **in place**—it does **not** add new **`docs/`** files from scaffolds alone.
+
+| Scaffold role | Skill | Location |
+| --- | --- | --- |
+| **`docs/README.md`** + **`docs/reference/**`** | [`internal-read-git-doc-reference`](../SKILL.md) | [`reference-readme-scaffold/SKILL.md`](../reference-readme-scaffold/SKILL.md), [`docs-hub-scaffold/SKILL.md`](../docs-hub-scaffold/SKILL.md) |
+| **`docs/REFERENCE.md`** (legacy) | same | [`wiki-reference-scaffold/SKILL.md`](./SKILL.md) |
+| **Optional `docs/GRAPHS.md`** | [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md) | [`../doc-graphs/legacy-graphs-pack-scaffold/SKILL.md`](../doc-graphs/legacy-graphs-pack-scaffold/SKILL.md) |
+| **`docs/USER_GUIDE.md`** | [`internal-read-git-doc-user-guide`](../doc-user-guide/SKILL.md) | [`../doc-user-guide/user-guide-scaffold/SKILL.md`](../doc-user-guide/user-guide-scaffold/SKILL.md) |
+| **Root `README.md`** | [`internal-read-git-readme-root`](../readme-root/SKILL.md) | skill body + exemplar § |
+| **`docs/...` mirror `README.md`** | [`internal-read-git-readme-tree`](../readme-tree/SKILL.md) | Rules in **`SKILL.md`**; optional examples under [`doc-index/`](../doc-index/) |
+
+---
+
+## Public skills
+
+### Local git (`skills/git/`)
+
+| Invoke | Source | Description |
+| --- | --- | --- |
+| **`@git-review`** | [`skills/git/review/SKILL.md`](../../../../git/review/SKILL.md) | *Discover → install → evaluate → §8a docs.* |
+| **`@git-docs`** | [`skills/git/docs/SKILL.md`](../../../../git/docs/SKILL.md) | *Post-green doc accuracy: existing `.md` in place only; may no-op; Q&A for scope.* |
+| **`@git-main`** | [`skills/git/main/SKILL.md`](../../../../git/main/SKILL.md) | *Align to canonical main.* |
+| **`@git-pull`** | [`skills/git/pull/SKILL.md`](../../../../git/pull/SKILL.md) | *Fetch + merge main + conflicts playbook.* |
+| **`@git-push`** | [`skills/git/push/SKILL.md`](../../../../git/push/SKILL.md) | *Inventory → `@git-commit` if needed → branch gate → push.* |
+| **`@git-reset`** | [`skills/git/reset/SKILL.md`](../../../../git/reset/SKILL.md) | *Reset to target ref.* |
+| **`@git-start`** | [`skills/git/start/SKILL.md`](../../../../git/start/SKILL.md) | *Dirty-tree gate → @git-main → new branch → optional @git-push.* |
+| **`@git-zip`** | [`skills/git/zip/SKILL.md`](../../../../git/zip/SKILL.md) | *Orchestrates `@git-tag` when needed, then `git archive` export (GitHub-style); runnable blocks in `internal-write-git-zip`.* |
+
+### GitHub (`skills/gh/`)
+
+| Invoke | Source | Description |
+| --- | --- | --- |
+| **`@gh-pr`** | [`skills/gh/pr/SKILL.md`](../../../../gh/pr/SKILL.md) | *@git-pull → @git-review → @git-push → PR description → `gh pr`.* |
+| **`@gh-pr-*`** (list, view, close, skills) | [`skills/gh/pr/`](../../../../gh/pr/) | *PR helpers; create/edit only via **`@gh-pr`**; list **`internal-read-gh-pr-list`**; mutations **`internal-write-gh-pr-commands`**; hub **[`list-view-hub/SKILL.md`](../../../../read/gh/pr-list/list-view-hub/SKILL.md)**.* |
+| **`@gh-issue-*`** (create, list, view, pick, edit, close, delete-closed) | [`skills/gh/issues/`](../../../../gh/issues/) | *Issues CRUD + dedupe + label helpers; list **`internal-read-gh-issue-list`**; view/mutations **`internal-write-gh-issue-commands`**; template **`gh repo view`** in **`internal-read-gh-repo-forms-json`**.* |
+
+---
+
+## Internal skills
+
+Libraries under `skills/<domain>/`. Flattened names: path with `/` → `-` (e.g. `write/gh/evaluate` → **`internal-write-gh-evaluate`**).
+
+### Agent (`skills/write/plan/`)
+
+| Invoke | Source | Description |
+| --- | --- | --- |
+| **`internal-write-plan-structured-qa`** | [`skills/write/plan/structured-qa/SKILL.md`](../../../../write/plan/structured-qa/SKILL.md) | *AskQuestion / confirm UX.* |
+| **`internal-write-plan-skill-safety`** | [`skills/write/plan/skill-safety/SKILL.md`](../../../../write/plan/skill-safety/SKILL.md) | *What needs confirm.* |
+
+### Internal libraries (verify + docs + `gh`)
+
+| Invoke | Source | Description |
+| --- | --- | --- |
+| **`internal-read-git-configuration`** | [`../../../../read/git/configuration/SKILL.md`](../../../../read/git/configuration/SKILL.md) | *Resolve format/lint/test commands.* |
+| **`internal-read-git-discover-dependencies`** | [`../../../../read/git/discover-dependencies/SKILL.md`](../../../../read/git/discover-dependencies/SKILL.md) | *Scan repo for stacks and gaps.* |
+| **`internal-write-gh-documentation`** | [`../../../../write/gh/documentation/SKILL.md`](../../../../write/gh/documentation/SKILL.md) | *Sharpen existing markdown — §8a.* |
+| **`internal-read-git-readme-tree`** | [`../readme-tree/SKILL.md`](../readme-tree/SKILL.md) | *Read-only mirror bootstrap + checklist.* |
+| **`internal-write-gh-evaluate`** | [`../../../../write/gh/evaluate/SKILL.md`](../../../../write/gh/evaluate/SKILL.md) | *Run verify matrix.* |
+| **`internal-write-gh-install-dependencies`** | [`../../../../write/gh/install-dependencies/SKILL.md`](../../../../write/gh/install-dependencies/SKILL.md) | *Install / build — §3.* |
+| **`internal-read-git-repo-layout`** | [`../repo-layout/SKILL.md`](../repo-layout/SKILL.md) | *Layout rules — read-only.* |
+| **`internal-read-gh-repo-forms-json`** | [`../../../../read/gh/repo-forms-json/SKILL.md`](../../../../read/gh/repo-forms-json/SKILL.md) | *Sole `gh repo view --json` shapes for issue/PR templates.* |
+| **`internal-read-gh-pr-description`** | [`../../../../read/gh/pr-description/SKILL.md`](../../../../read/gh/pr-description/SKILL.md) | *PR templates + delta + title/body.* |
+| **`internal-read-gh-pr-body-sections`** | [`../../../../read/gh/pr-body-sections/SKILL.md`](../../../../read/gh/pr-body-sections/SKILL.md) | *Static PR body patterns.* |
+| **`internal-read-gh-issue-list`** | [`../../../../read/gh/issue-list/SKILL.md`](../../../../read/gh/issue-list/SKILL.md) | *`gh issue list` / `gh search issues` (read-only).* |
+| **`internal-write-gh-issue-commands`** | [`../../../../write/gh/issue-commands/SKILL.md`](../../../../write/gh/issue-commands/SKILL.md) | *`gh issue` view/create/edit/close/delete.* |
+| **`internal-read-gh-pr-list`** | [`../../../../read/gh/pr-list/SKILL.md`](../../../../read/gh/pr-list/SKILL.md) | *`gh pr list` / `view` / `diff --stat` (read-only).* |
+| **`internal-write-gh-pr-commands`** | [`../../../../write/gh/pr-commands/SKILL.md`](../../../../write/gh/pr-commands/SKILL.md) | *`gh pr create`, `gh pr edit`, `gh pr close`.* |
+| **`internal-read-git-doc-graphs`** | [`../doc-graphs/SKILL.md`](../doc-graphs/SKILL.md) | *README mermaid rules + `diagrams/`.* |
+| **`internal-read-git-doc-reference`** | [`../SKILL.md`](../SKILL.md) | *REFERENCE.md template.* |
+| **`internal-read-git-doc-user-guide`** | [`../doc-user-guide/SKILL.md`](../doc-user-guide/SKILL.md) | *USER_GUIDE.md template.* |
+| **`internal-read-git-doc-exemplars`** | [`../doc-exemplars/SKILL.md`](../doc-exemplars/SKILL.md) | *Public markdown patterns + adoption rubric.* |
+| **`internal-read-git-readme-root`** | [`../readme-root/SKILL.md`](../readme-root/SKILL.md) | *Root README template.* |
+| *…* | *…* | *`repo-stream`, `merge-conflicts`, `git-diff-summary`, …* |
+
+---
+
+## Pipeline order (verify)
+
+**`@git-review`:** discover-dependencies → install-dependencies → configuration → evaluate → internal-write-gh-documentation (§8a). Diagram: [GRAPHS.md](GRAPHS.md).
+
+---
+
+## See also
+
+- [Skills graphs](GRAPHS.md)
+- [User guide](USER_GUIDE.md)
+- [install.sh](../install.sh) — if your pack uses a copy script

--- a/.agents/skills/internal-read-git-doc-reference/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-reference/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: internal-read-git-doc-reference
+description: >-
+  Read-only: legacy monolithic docs/REFERENCE.md + docs/reference/wiki templates (migration). Primary narrative
+  is docs/README.md + optional docs/ mirror per internal-read-git-repo-layout. Callers: @git-docs. Does not write files.
+---
+
+# Internal: Reference documentation template (`internal-read-git-doc-reference`)
+
+**Read-only library.** **Current** default narrative: **`docs/README.md`** + optional **`docs/`** mirror (**[`internal-read-git-repo-layout`](../repo-layout/SKILL.md)**). **Other** repos may add a **profile** wiki per **`internal-read-git-doc-wiki`**—**cursor-skills** does not ship **`docs/wiki/`**. This skill supplies **extra** **migration / legacy** tracks when a repo still wants **`docs/reference/**`** or **`docs/REFERENCE.md`**:
+
+1. **Legacy single file** — **[`wiki-reference-scaffold/SKILL.md`](./wiki-reference-scaffold/SKILL.md)** → **`docs/REFERENCE.md`** (monolithic catalog).
+2. **Legacy split wiki** — skill-local **[`reference-readme-scaffold/SKILL.md`](./reference-readme-scaffold/SKILL.md)**, **[`docs-hub-scaffold/SKILL.md`](./docs-hub-scaffold/SKILL.md)** → hub pages under **`docs/reference/**`** (older style; prefer **`docs/README.md`** + domain indexes for greenfield).
+
+**Consumers:** **Manual** scaffold (when user keeps or migrates **`docs/**`**), **`@git-docs`**.
+
+---
+
+## Do
+
+- For **wiki layout**, copy from **`docs/`** (this pack) or your repo’s existing **`docs/`** first, then split catalogs into **`docs/reference/*.md`** when **`wiki-reference-scaffold/SKILL.md`** would exceed **`@git-docs`** size limits.
+- For **legacy** repos, copy **`wiki-reference-scaffold/SKILL.md`** into **`docs/REFERENCE.md`**; replace placeholder rows with real skills.
+- Keep **public** skills **before** **internal** in any catalog tables.
+- Use consistent table columns (**Invoke** | **Source** | **Description**) or document your variant once per repo.
+
+## Do not
+
+- Run commands or edit the filesystem from this skill.
+
+---
+
+## Rendered paths
+
+| Layout | Paths |
+| --- | --- |
+| **Profile wiki** (preferred) | Often **`docs/README.md`** alone (**minimal**); or expanded sections per **`internal-read-git-doc-wiki`** when you need deeper hubs |
+| **Optional skills mirror** | **`docs/.../README.md`** (full tree when opted in) |
+| Minimal root | **`README.md`** at repo root |
+| Legacy wiki | **`docs/README.md`**, **`docs/reference/**`** |
+| Legacy monolith | **`docs/REFERENCE.md`** |
+| Flat variant | **`REFERENCE.md`** at repo root |
+
+---
+
+## See also
+
+- [`internal-read-git-doc-wiki`](../doc-wiki/SKILL.md) — doc depth orientation
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md) — hub contract
+- [`internal-read-git-doc-exemplars`](../doc-exemplars/SKILL.md) — markdown patterns + rubric
+- [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md) — diagram authoring (not required **`GRAPHS.md`**)
+- [`internal-read-git-doc-user-guide`](../doc-user-guide/SKILL.md) — **`USER_GUIDE.md`**
+- [`internal-read-git-readme-root`](../readme-root/SKILL.md) — root **`README.md`**

--- a/.agents/skills/internal-read-git-doc-reference/docs-hub-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-reference/docs-hub-scaffold/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: internal-read-git-doc-reference-docs-hub-scaffold
+description: >-
+  Read-only: docs hub README scaffold. Parent internal-read-git-doc-reference.
+---
+
+# Documentation index
+
+**Repository:** <name> — <one-line purpose>.
+
+Use this as a **wiki hub** starter when `docs/` is the human-facing surface and `skills/**/SKILL.md` remains normative.
+
+---
+
+## 📑 Contents
+
+1. [Location map](#location-map)
+2. [Browse](#browse)
+3. [Common commands](#common-commands)
+4. [Diagram policy](#diagram-policy)
+5. [See also](#see-also)
+
+---
+
+## 🧩 Location map
+
+| Location | Purpose |
+| --- | --- |
+| [`docs/README.md`](README.md) | Hub index and routing for human readers. |
+| [`docs/git.md`](git.md) | Public/local git workflow wiki. |
+| [`docs/gh.md`](gh.md) | GitHub issue/PR workflow wiki. |
+| [`docs/internal.md`](internal.md) | Internal read/write library map. |
+| [`skills/**/SKILL.md`](../skills/) | Source of truth for contracts and behavior. |
+
+---
+
+## 🧩 Browse
+
+| Topic | Description |
+| --- | --- |
+| [reference/README.md](reference/README.md) | Start here — map of reference pages |
+| <add more rows> | <link each `docs/reference/*.md`> |
+
+---
+
+## 🧩 Common commands
+
+1. `@git-review` for verification.
+2. `@git-docs` for in-place doc corrections.
+3. `@git-push` for commit + publish.
+4. `@gh-pr` after pull + push for PR metadata.
+
+---
+
+## 🧩 Diagram policy
+
+- Diagrams are welcome in the hub and key flow pages, but avoid adding Mermaid blocks everywhere.
+- Keep 0-2 diagrams per page unless the workflow is genuinely complex.
+- For GitHub rendering safety, quote labels containing special characters (for example `node["@gh-pr"]`).
+- For palette and scaffold examples, use [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md).
+
+---
+
+## 🔗 See also
+
+- **[docs/git.md](../../../../../docs/git.md)**, **[docs/gh.md](../../../../../docs/gh.md)**, **[docs/internal.md](../../../../../docs/internal.md)** — agent skills by domain (**this** pack)
+- **Pasteables** under **`docs/`**: see *Folder and file index* in [reference/README.md](reference/README.md) or your legacy [REFERENCE.md](REFERENCE.md)

--- a/.agents/skills/internal-read-git-doc-reference/reference-readme-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-reference/reference-readme-scaffold/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: internal-read-git-doc-reference-reference-readme-scaffold
+description: >-
+  Read-only: root README long-form scaffold. Parent internal-read-git-doc-reference.
+---
+
+# Reference wiki
+
+Deep dives and catalogs. **Diagrams:** use self-contained **`mermaid`** in each page; **color and spine** rules live only in **`internal-read-git-doc-graphs`** (**`SKILL.md`** + **`diagrams/*/SKILL.md`**)—do not paste authoring appendix tables into published docs.
+
+---
+
+## Contents
+
+| Page | Description |
+| --- | --- |
+| <e.g. [skills.md](skills.md)> | <Public + internal skill summaries — link to `SKILL.md`> |
+| <e.g. [pipelines.md](pipelines.md)> | <Verify / PR / context flows> |
+
+---
+
+## Folder and file index
+
+Link every domain **`README.md`** under **`skills/`** (and other top-level folders) so readers can jump from wiki to subtree owners.
+
+- **[docs/git.md](../../../../../docs/git.md)**, **[docs/gh.md](../../../../../docs/gh.md)**, **[docs/internal.md](../../../../../docs/internal.md)** (domain docs for `skills/`, **this** pack)
+- <add per-domain READMEs>
+
+---
+
+## Template sources (internal)
+
+| Role | Skill |
+| --- | --- |
+| Wiki hub | `internal-read-git-doc-reference` — child **`SKILL.md`** bodies (e.g. **`wiki-reference-scaffold`**) + repo **`docs/`** |
+| User guide | `internal-read-git-doc-user-guide` |
+| Diagram authoring | `internal-read-git-doc-graphs` |
+| Root / folder README | `internal-read-git-readme-root`, `internal-read-git-readme-tree` |
+
+---
+
+## Related
+
+- [Documentation index](../SKILL.md)
+- [USER_GUIDE.md](../USER_GUIDE.md)

--- a/.agents/skills/internal-read-git-doc-reference/wiki-reference-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-reference/wiki-reference-scaffold/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: internal-read-git-doc-reference-wiki-reference-scaffold
+description: >-
+  Read-only: legacy REFERENCE/wiki page scaffold. Parent internal-read-git-doc-reference.
+---
+
+# Skills reference
+
+Complete catalog of **every** skill in this repository: **public** skills first (user-invoked under `skills/git/` and `skills/gh/`), then **internal** libraries (`skills/<domain>/`). Invocation: `/flattened-name` or `@flattened-name` (path under `skills/` with `/` → `-`, e.g. `skills/gh/pr/SKILL.md` → **`gh-pr`**).
+
+**Install:** [README.md](../README.md) · **Doc index:** [README.md](README.md) (wiki) or this file (legacy) · **Workflows:** [USER_GUIDE.md](USER_GUIDE.md)
+
+---
+
+## Documentation set (`docs/`)
+
+**Preferred (wiki):** [README.md](README.md), [USER_GUIDE.md](USER_GUIDE.md), **`reference/**`** — scaffold **manual / agent-led** from **`internal-read-git-doc-reference`** child skills (**`reference-readme-scaffold`**, **`docs-hub-scaffold`**, …) **confirm-first**. **Legacy:** this monolithic **[REFERENCE.md](REFERENCE.md)**; optional **[GRAPHS.md](GRAPHS.md)**. Templates stay in **`skills/read/git/doc-*`**.
+
+| Path | Role |
+| --- | --- |
+| [README.md](README.md) | Doc hub index (wiki layout) |
+| [reference/README.md](reference/README.md) | Reference wiki start page |
+| [REFERENCE.md](REFERENCE.md) | This file — legacy full catalog |
+| [USER_GUIDE.md](USER_GUIDE.md) | Install, prerequisites, workflows |
+| [GRAPHS.md](GRAPHS.md) | Optional legacy diagram file |
+
+---
+
+## Folder and file index
+
+Hub **READMEs** (subtree scope and **Related** links)—use with **`docs/reference/**`** or small **mermaid** in each **README** when a diagram helps:
+
+- **[`docs/git.md`](../../../../../docs/git.md)**, **[`docs/gh.md`](../../../../../docs/gh.md)**, **[`docs/internal.md`](../../../../../docs/internal.md)** — domain wikis (**this** pack)
+- **`skills/git/**`**, **`skills/gh/**`**, **`skills/read/**`**, **`skills/write/**`** — normative **`SKILL.md`** per folder
+- **[`skills/write/plan/`](../../../../write/plan/)** — structured Q&A + safety (**`internal-write-plan-structured-qa`**, **`internal-write-plan-skill-safety`**)
+- **[`skills/read/git/SKILL.md`](../../../../read/git/SKILL.md)**, **[`skills/read/gh/SKILL.md`](../../../../read/gh/SKILL.md)**, **[`skills/read/plan/SKILL.md`](../../../../read/plan/SKILL.md)** — library root indexes
+
+**Scaffold sources** — **`skills/read/git/doc-index/`** skeleton child skills + diagram scaffolds under **`internal-read-git-doc-graphs`**, plus other **`internal-read-git-doc-*`** child **`SKILL.md`** bodies. **`@git-docs`** only aligns **existing** pages **in place**—it does **not** add new **`docs/`** files from scaffolds alone.
+
+| Scaffold role | Skill | Location |
+| --- | --- | --- |
+| **`docs/README.md`** + **`docs/reference/**`** | [`internal-read-git-doc-reference`](../SKILL.md) | [`reference-readme-scaffold/SKILL.md`](../reference-readme-scaffold/SKILL.md), [`docs-hub-scaffold/SKILL.md`](../docs-hub-scaffold/SKILL.md) |
+| **`docs/REFERENCE.md`** (legacy) | same | [`wiki-reference-scaffold/SKILL.md`](./SKILL.md) |
+| **Optional `docs/GRAPHS.md`** | [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md) | [`../doc-graphs/legacy-graphs-pack-scaffold/SKILL.md`](../doc-graphs/legacy-graphs-pack-scaffold/SKILL.md) |
+| **`docs/USER_GUIDE.md`** | [`internal-read-git-doc-user-guide`](../doc-user-guide/SKILL.md) | [`../doc-user-guide/user-guide-scaffold/SKILL.md`](../doc-user-guide/user-guide-scaffold/SKILL.md) |
+| **Root `README.md`** | [`internal-read-git-readme-root`](../readme-root/SKILL.md) | skill body + exemplar § |
+| **`docs/...` mirror `README.md`** | [`internal-read-git-readme-tree`](../readme-tree/SKILL.md) | Rules in **`SKILL.md`**; optional examples under [`doc-index/`](../doc-index/) |
+
+---
+
+## Public skills
+
+### Local git (`skills/git/`)
+
+| Invoke | Source | Description |
+| --- | --- | --- |
+| **`@git-review`** | [`skills/git/review/SKILL.md`](../../../../git/review/SKILL.md) | *Discover → install → evaluate → §8a docs.* |
+| **`@git-docs`** | [`skills/git/docs/SKILL.md`](../../../../git/docs/SKILL.md) | *Post-green doc accuracy: existing `.md` in place only; may no-op; Q&A for scope.* |
+| **`@git-main`** | [`skills/git/main/SKILL.md`](../../../../git/main/SKILL.md) | *Align to canonical main.* |
+| **`@git-pull`** | [`skills/git/pull/SKILL.md`](../../../../git/pull/SKILL.md) | *Fetch + merge main + conflicts playbook.* |
+| **`@git-push`** | [`skills/git/push/SKILL.md`](../../../../git/push/SKILL.md) | *Inventory → `@git-commit` if needed → branch gate → push.* |
+| **`@git-reset`** | [`skills/git/reset/SKILL.md`](../../../../git/reset/SKILL.md) | *Reset to target ref.* |
+| **`@git-start`** | [`skills/git/start/SKILL.md`](../../../../git/start/SKILL.md) | *Dirty-tree gate → @git-main → new branch → optional @git-push.* |
+| **`@git-zip`** | [`skills/git/zip/SKILL.md`](../../../../git/zip/SKILL.md) | *Orchestrates `@git-tag` when needed, then `git archive` export (GitHub-style); runnable blocks in `internal-write-git-zip`.* |
+
+### GitHub (`skills/gh/`)
+
+| Invoke | Source | Description |
+| --- | --- | --- |
+| **`@gh-pr`** | [`skills/gh/pr/SKILL.md`](../../../../gh/pr/SKILL.md) | *@git-pull → @git-review → @git-push → PR description → `gh pr`.* |
+| **`@gh-pr-*`** (list, view, close, skills) | [`skills/gh/pr/`](../../../../gh/pr/) | *PR helpers; create/edit only via **`@gh-pr`**; list **`internal-read-gh-pr-list`**; mutations **`internal-write-gh-pr-commands`**; hub **[`list-view-hub/SKILL.md`](../../../../read/gh/pr-list/list-view-hub/SKILL.md)**.* |
+| **`@gh-issue-*`** (create, list, view, pick, edit, close, delete-closed) | [`skills/gh/issues/`](../../../../gh/issues/) | *Issues CRUD + dedupe + label helpers; list **`internal-read-gh-issue-list`**; view/mutations **`internal-write-gh-issue-commands`**; template **`gh repo view`** in **`internal-read-gh-repo-forms-json`**.* |
+
+---
+
+## Internal skills
+
+Libraries under `skills/<domain>/`. Flattened names: path with `/` → `-` (e.g. `write/gh/evaluate` → **`internal-write-gh-evaluate`**).
+
+### Agent (`skills/write/plan/`)
+
+| Invoke | Source | Description |
+| --- | --- | --- |
+| **`internal-write-plan-structured-qa`** | [`skills/write/plan/structured-qa/SKILL.md`](../../../../write/plan/structured-qa/SKILL.md) | *AskQuestion / confirm UX.* |
+| **`internal-write-plan-skill-safety`** | [`skills/write/plan/skill-safety/SKILL.md`](../../../../write/plan/skill-safety/SKILL.md) | *What needs confirm.* |
+
+### Internal libraries (verify + docs + `gh`)
+
+| Invoke | Source | Description |
+| --- | --- | --- |
+| **`internal-read-git-configuration`** | [`../../../../read/git/configuration/SKILL.md`](../../../../read/git/configuration/SKILL.md) | *Resolve format/lint/test commands.* |
+| **`internal-read-git-discover-dependencies`** | [`../../../../read/git/discover-dependencies/SKILL.md`](../../../../read/git/discover-dependencies/SKILL.md) | *Scan repo for stacks and gaps.* |
+| **`internal-write-gh-documentation`** | [`../../../../write/gh/documentation/SKILL.md`](../../../../write/gh/documentation/SKILL.md) | *Sharpen existing markdown — §8a.* |
+| **`internal-read-git-readme-tree`** | [`../readme-tree/SKILL.md`](../readme-tree/SKILL.md) | *Read-only mirror bootstrap + checklist.* |
+| **`internal-write-gh-evaluate`** | [`../../../../write/gh/evaluate/SKILL.md`](../../../../write/gh/evaluate/SKILL.md) | *Run verify matrix.* |
+| **`internal-write-gh-install-dependencies`** | [`../../../../write/gh/install-dependencies/SKILL.md`](../../../../write/gh/install-dependencies/SKILL.md) | *Install / build — §3.* |
+| **`internal-read-git-repo-layout`** | [`../repo-layout/SKILL.md`](../repo-layout/SKILL.md) | *Layout rules — read-only.* |
+| **`internal-read-gh-repo-forms-json`** | [`../../../../read/gh/repo-forms-json/SKILL.md`](../../../../read/gh/repo-forms-json/SKILL.md) | *Sole `gh repo view --json` shapes for issue/PR templates.* |
+| **`internal-read-gh-pr-description`** | [`../../../../read/gh/pr-description/SKILL.md`](../../../../read/gh/pr-description/SKILL.md) | *PR templates + delta + title/body.* |
+| **`internal-read-gh-pr-body-sections`** | [`../../../../read/gh/pr-body-sections/SKILL.md`](../../../../read/gh/pr-body-sections/SKILL.md) | *Static PR body patterns.* |
+| **`internal-read-gh-issue-list`** | [`../../../../read/gh/issue-list/SKILL.md`](../../../../read/gh/issue-list/SKILL.md) | *`gh issue list` / `gh search issues` (read-only).* |
+| **`internal-write-gh-issue-commands`** | [`../../../../write/gh/issue-commands/SKILL.md`](../../../../write/gh/issue-commands/SKILL.md) | *`gh issue` view/create/edit/close/delete.* |
+| **`internal-read-gh-pr-list`** | [`../../../../read/gh/pr-list/SKILL.md`](../../../../read/gh/pr-list/SKILL.md) | *`gh pr list` / `view` / `diff --stat` (read-only).* |
+| **`internal-write-gh-pr-commands`** | [`../../../../write/gh/pr-commands/SKILL.md`](../../../../write/gh/pr-commands/SKILL.md) | *`gh pr create`, `gh pr edit`, `gh pr close`.* |
+| **`internal-read-git-doc-graphs`** | [`../doc-graphs/SKILL.md`](../doc-graphs/SKILL.md) | *README mermaid rules + `diagrams/`.* |
+| **`internal-read-git-doc-reference`** | [`../SKILL.md`](../SKILL.md) | *REFERENCE.md template.* |
+| **`internal-read-git-doc-user-guide`** | [`../doc-user-guide/SKILL.md`](../doc-user-guide/SKILL.md) | *USER_GUIDE.md template.* |
+| **`internal-read-git-doc-exemplars`** | [`../doc-exemplars/SKILL.md`](../doc-exemplars/SKILL.md) | *Public markdown patterns + adoption rubric.* |
+| **`internal-read-git-readme-root`** | [`../readme-root/SKILL.md`](../readme-root/SKILL.md) | *Root README template.* |
+| *…* | *…* | *`repo-stream`, `merge-conflicts`, `git-diff-summary`, …* |
+
+---
+
+## Pipeline order (verify)
+
+**`@git-review`:** discover-dependencies → install-dependencies → configuration → evaluate → internal-write-gh-documentation (§8a). Diagram: [GRAPHS.md](GRAPHS.md).
+
+---
+
+## See also
+
+- [Skills graphs](GRAPHS.md)
+- [User guide](USER_GUIDE.md)
+- [install.sh](../install.sh) — if your pack uses a copy script

--- a/.agents/skills/internal-read-git-doc-table/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-table/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: internal-read-git-doc-table
+description: >-
+  Read-only: markdown table conventions for doc reference sections (not indexes). Callers: @git-docs,
+  internal-write-gh-documentation. Does not write files.
+---
+
+# Internal: Doc table rules (`internal-read-git-doc-table`)
+
+**Read-only library.** **When** to use **markdown tables** on **`docs/`** pages: **reference** and **comparison** sections only—not **`## Contents`**.
+
+**Default for agents** — Whenever you touch a **markdown table** in **reference** material (including root **`README.md`** and **`docs/**`** in **any** Cursor project), apply **these rules silently** as part of **`@git-docs`**, **`internal-write-gh-documentation`**, or ad-hoc doc polish—the user does **not** need to name **`internal-read-git-doc-table`** in chat.
+
+---
+
+## Rules
+
+1. **Sort** rows by **first column** lexicographically.
+2. After the table, **call out** the **largest** row by the chosen metric and **why** it matters.
+3. Optional **summary** prose for aggregates—avoid double-counting with child pages.
+
+## See also
+
+- [`internal-read-git-doc-index`](../doc-index/SKILL.md)
+- [`internal-read-git-doc-explanation`](../doc-explanation/SKILL.md)

--- a/.agents/skills/internal-read-git-doc-user-guide-user-guide-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-user-guide-user-guide-scaffold/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: internal-read-git-doc-user-guide-user-guide-scaffold
+description: >-
+  Read-only: legacy USER_GUIDE scaffold. Parent internal-read-git-doc-user-guide.
+---
+
+---
+template_for: docs/USER_GUIDE.md
+source_skill: internal-read-git-doc-user-guide
+instructions: >-
+  Copy into docs/USER_GUIDE.md. Replace skill names and paths with your pack. Link install to root README.
+---
+
+# User guide
+
+**Purpose:** **install from scratch**, **prerequisites**, **workflows**, **per-repo storage**, **troubleshooting**. Use **raw Terminal commands** (especially on **macOS**). **README-only repos:** fold this into **root `README.md`**; catalogs live in **`docs/README.md`** plus **`docs/git.md`**, **`docs/gh.md`**, **`docs/internal.md`**, … (**this** pack) or optional **`docs/`** mirror. **Legacy:** deep catalogs in **`docs/reference/**`** or **[REFERENCE.md](REFERENCE.md)**; hub index **`docs/README.md`** if present.
+
+**Root** **`README.md`** stays short; **`docs/<domain>/`** documents domains (**this** pack), or optional **`docs/.../README.md`** mirrors the **`skills/`** tree on other repos (no per-folder README under **`skills/`** when using that mirror policy).
+
+---
+
+## Prerequisites (macOS)
+
+Run in **Terminal** (replace versions with what your project needs).
+
+```bash
+# Xcode CLI tools (if prompted)
+xcode-select --install
+
+# Homebrew (if missing) — see https://brew.sh
+# /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Example toolchains (adapt)
+brew install git
+brew install gh && gh auth login
+# brew install node@22   # if your pack needs Node
+```
+
+**Cursor:** install the editor from vendor instructions; restart after adding skills. **Skills install:** from repo root, `./install.sh` (or your pack’s script)—see root **README**.
+
+---
+
+## Diagrams
+
+Prefer **small `mermaid` blocks** in **folder `README.md`** / **root `README.md`** (README-only), or in **`docs/reference/**`** (legacy). **Color / spine rules:** **`internal-read-git-doc-graphs`** **`SKILL.md`** + **`diagrams/`** child skills—optional legacy **`docs/GRAPHS.md`**, not default. Optional PNG export: **`diagrams/diagrams-index/SKILL.md`** in that library.
+
+---
+
+## Workflows
+
+Open a **target git repo** in Cursor. Invoke with `/skill-name` or `@skill-name`.
+
+| Goal | Skills |
+| --- | --- |
+| Issue → implement → PR | `@gh-issue-pick` / `@gh-issue-view` → `@git-start` → `@gh-pr` (runs pull, review, push, then PR) |
+| Verify (no push) | `@git-review` |
+| Commit + push | `@git-push` |
+| Pull request | `@gh-pr` (full chain: `@git-pull` → `@git-review` → `@git-push` → PR text) |
+| New branch from clean `main` | `@git-start` |
+| Doc accuracy (existing files, after green verify) | `@git-docs` — **not** part of **`@git-review`** evaluate; run after **`@git-review`** when you need a broader in-place pass |
+
+**Typical task:** **`@git-start`** creates a branch and runs **`@git-push`** (commit-if-needed + publish). Run **`@git-review`** before PR work if you want green locally first, or rely on **`@gh-pr`** which runs **`@git-review`** then **`@git-push`**, then PR text and **`gh pr create` / `edit`**.
+
+---
+
+## Documentation workflow
+
+| Situation | Skill | Notes |
+| --- | --- | --- |
+| Greenfield or missing mirror / large `docs/` reshuffle | Normal change set | Add or move **`docs/`** paths in git like any other source; use **`internal-read-git-readme-tree`** + **`internal-read-git-repo-layout`** as guides; **`internal-write-plan-skill-safety`** when the diff is huge. |
+| After code changes, before commit | `@git-commit` or `@git-push` §1–2 | **`@git-commit`** for a local savepoint; **`@git-push`** runs inventory then **`@git-commit`** only when needed. For doc-only tweaks before commit, **`@git-docs`** (existing **`.md`** in place). **New** paths → add them in a normal edit first. |
+| After tests pass (verify pipeline) | `@git-review` §8a | §8a light polish on **existing** paths (**`internal-write-gh-documentation`**). |
+
+Do **not** use **`@git-review`** alone to **reshape** the whole doc tree for big moves — do that as explicit file edits with the usual review and safety confirms.
+
+---
+
+## Per-repo storage (`<project>/.cursor/`)
+
+Optional **`.cursor/`** snippets — copy subtrees from this pack’s **`docs/`** (and diagram scaffolds under **`skills/read/git/doc-graphs/diagrams/`**) (see root **`README.md`** and **`docs/README.md`**). **`@git-zip`** writes the **`.zip`** **outside** the repo root by default—confirm paths per **`internal-write-plan-skill-safety`**.
+
+---
+
+## Troubleshooting
+
+| Issue | What to try |
+| --- | --- |
+| Skill not listed | Re-run your install script; restart Cursor |
+| Stack not detected | README + CI config at repo root |
+| Checks fail | Install toolchains; re-run `@git-review` |
+| `gh` CLI missing | Install GitHub CLI and `gh auth login` |
+
+---
+
+## See also
+
+- **[Skills reference](REFERENCE.md)**
+- **[Skills graphs](GRAPHS.md)**
+- **[Root README](../README.md)**

--- a/.agents/skills/internal-read-git-doc-user-guide/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-user-guide/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: internal-read-git-doc-user-guide
+description: >-
+  Read-only: TEMPLATE.md for legacy docs/USER_GUIDE.md (migration). README-only repos fold narrative into
+  internal-read-git-readme-root / root README. Callers: @git-docs. Does
+  not write files.
+---
+
+# Internal: User guide template (`internal-read-git-doc-user-guide`)
+
+**Read-only library.** Canonical **body** for **legacy** **`docs/USER_GUIDE.md`** when a repo still uses a **`docs/`** hub. **Default** for this pack: fold the same material into **root `README.md`** (**[`internal-read-git-readme-root`](../readme-root/SKILL.md)**). Full source: **`[TEMPLATE.md](./TEMPLATE.md)`**.
+
+**Consumers:** **`@git-docs`** when maintaining **`docs/USER_GUIDE.md`** in a legacy tree; otherwise prefer **`internal-read-git-readme-root`**.
+
+---
+
+## Do
+
+- **Install from scratch** (especially **macOS** **Terminal**, **raw** `brew` / `git` / `gh` commands).
+- Describe **happy path** workflows (e.g. **`gh-start` → work → `gh-pr`**).
+- Point **short** install blurbs at root **`README.md`**; keep **catalogs** under **`docs/*.md`** hubs (**this** pack: **`docs/git.md`**, **`docs/gh.md`**, **`docs/internal.md`**) or optional wiki-only layouts on other repos, or, in legacy repos, **`docs/reference/**`** / **`REFERENCE.md`**.
+- Document **`.cursor/`** or project-local artifact dirs with a **who writes what** table.
+
+## Do not
+
+- Duplicate long wiki tables — link **`docs/README.md`** (**this** pack), optional **`docs/README.md`**, or **`docs/reference/**`** (legacy).
+
+---
+
+## Rendered path
+
+| Layout | Path |
+| --- | --- |
+| **Domain docs** (**this** pack) | **`docs/README.md`** + **`docs/git.md`** / **`docs/gh.md`** / **`docs/internal.md`** — **[`internal-read-git-repo-layout`](../repo-layout/SKILL.md)** |
+| Legacy hub | **`docs/USER_GUIDE.md`** |
+| Variant | **`USER_GUIDE.md`** at repo root |
+
+---
+
+## See also
+
+- [`internal-read-git-doc-exemplars`](../doc-exemplars/SKILL.md) — public markdown patterns + rubric
+- [`internal-read-git-doc-reference`](../doc-reference/SKILL.md)
+- [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md)
+- [`internal-read-git-doc-wiki`](../doc-wiki/SKILL.md) — doc depth orientation
+- [`@git-docs`](../../../git/docs/SKILL.md)

--- a/.agents/skills/internal-read-git-doc-user-guide/user-guide-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-user-guide/user-guide-scaffold/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: internal-read-git-doc-user-guide-user-guide-scaffold
+description: >-
+  Read-only: legacy USER_GUIDE scaffold. Parent internal-read-git-doc-user-guide.
+---
+
+---
+template_for: docs/USER_GUIDE.md
+source_skill: internal-read-git-doc-user-guide
+instructions: >-
+  Copy into docs/USER_GUIDE.md. Replace skill names and paths with your pack. Link install to root README.
+---
+
+# User guide
+
+**Purpose:** **install from scratch**, **prerequisites**, **workflows**, **per-repo storage**, **troubleshooting**. Use **raw Terminal commands** (especially on **macOS**). **README-only repos:** fold this into **root `README.md`**; catalogs live in **`docs/README.md`** plus **`docs/git.md`**, **`docs/gh.md`**, **`docs/internal.md`**, … (**this** pack) or optional **`docs/`** mirror. **Legacy:** deep catalogs in **`docs/reference/**`** or **[REFERENCE.md](REFERENCE.md)**; hub index **`docs/README.md`** if present.
+
+**Root** **`README.md`** stays short; **`docs/<domain>/`** documents domains (**this** pack), or optional **`docs/.../README.md`** mirrors the **`skills/`** tree on other repos (no per-folder README under **`skills/`** when using that mirror policy).
+
+---
+
+## Prerequisites (macOS)
+
+Run in **Terminal** (replace versions with what your project needs).
+
+```bash
+# Xcode CLI tools (if prompted)
+xcode-select --install
+
+# Homebrew (if missing) — see https://brew.sh
+# /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Example toolchains (adapt)
+brew install git
+brew install gh && gh auth login
+# brew install node@22   # if your pack needs Node
+```
+
+**Cursor:** install the editor from vendor instructions; restart after adding skills. **Skills install:** from repo root, `./install.sh` (or your pack’s script)—see root **README**.
+
+---
+
+## Diagrams
+
+Prefer **small `mermaid` blocks** in **folder `README.md`** / **root `README.md`** (README-only), or in **`docs/reference/**`** (legacy). **Color / spine rules:** **`internal-read-git-doc-graphs`** **`SKILL.md`** + **`diagrams/`** child skills—optional legacy **`docs/GRAPHS.md`**, not default. Optional PNG export: **`diagrams/diagrams-index/SKILL.md`** in that library.
+
+---
+
+## Workflows
+
+Open a **target git repo** in Cursor. Invoke with `/skill-name` or `@skill-name`.
+
+| Goal | Skills |
+| --- | --- |
+| Issue → implement → PR | `@gh-issue-pick` / `@gh-issue-view` → `@git-start` → `@gh-pr` (runs pull, review, push, then PR) |
+| Verify (no push) | `@git-review` |
+| Commit + push | `@git-push` |
+| Pull request | `@gh-pr` (full chain: `@git-pull` → `@git-review` → `@git-push` → PR text) |
+| New branch from clean `main` | `@git-start` |
+| Doc accuracy (existing files, after green verify) | `@git-docs` — **not** part of **`@git-review`** evaluate; run after **`@git-review`** when you need a broader in-place pass |
+
+**Typical task:** **`@git-start`** creates a branch and runs **`@git-push`** (commit-if-needed + publish). Run **`@git-review`** before PR work if you want green locally first, or rely on **`@gh-pr`** which runs **`@git-review`** then **`@git-push`**, then PR text and **`gh pr create` / `edit`**.
+
+---
+
+## Documentation workflow
+
+| Situation | Skill | Notes |
+| --- | --- | --- |
+| Greenfield or missing mirror / large `docs/` reshuffle | Normal change set | Add or move **`docs/`** paths in git like any other source; use **`internal-read-git-readme-tree`** + **`internal-read-git-repo-layout`** as guides; **`internal-write-plan-skill-safety`** when the diff is huge. |
+| After code changes, before commit | `@git-commit` or `@git-push` §1–2 | **`@git-commit`** for a local savepoint; **`@git-push`** runs inventory then **`@git-commit`** only when needed. For doc-only tweaks before commit, **`@git-docs`** (existing **`.md`** in place). **New** paths → add them in a normal edit first. |
+| After tests pass (verify pipeline) | `@git-review` §8a | §8a light polish on **existing** paths (**`internal-write-gh-documentation`**). |
+
+Do **not** use **`@git-review`** alone to **reshape** the whole doc tree for big moves — do that as explicit file edits with the usual review and safety confirms.
+
+---
+
+## Per-repo storage (`<project>/.cursor/`)
+
+Optional **`.cursor/`** snippets — copy subtrees from this pack’s **`docs/`** (and diagram scaffolds under **`skills/read/git/doc-graphs/diagrams/`**) (see root **`README.md`** and **`docs/README.md`**). **`@git-zip`** writes the **`.zip`** **outside** the repo root by default—confirm paths per **`internal-write-plan-skill-safety`**.
+
+---
+
+## Troubleshooting
+
+| Issue | What to try |
+| --- | --- |
+| Skill not listed | Re-run your install script; restart Cursor |
+| Stack not detected | README + CI config at repo root |
+| Checks fail | Install toolchains; re-run `@git-review` |
+| `gh` CLI missing | Install GitHub CLI and `gh auth login` |
+
+---
+
+## See also
+
+- **[Skills reference](REFERENCE.md)**
+- **[Skills graphs](GRAPHS.md)**
+- **[Root README](../README.md)**

--- a/.agents/skills/internal-read-git-doc-wiki/SKILL.md
+++ b/.agents/skills/internal-read-git-doc-wiki/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: internal-read-git-doc-wiki
+description: >-
+  Read-only: light orientation for how deep docs/ can go on other repositories; this pack uses docs/README.md + docs/
+  mirror only. No structural scaffold workflow in pack skills. Does not write files.
+---
+
+# Internal: Doc depth orientation (`internal-read-git-doc-wiki`)
+
+**Read-only.** **This repository** (**cursor-skills**): documentation is **`docs/README.md`** (hub) + **`docs/`** mirroring **`skills/`**. There is **no** separate **`docs/wiki/`** profile tree checked in here.
+
+**Other repositories** may grow richer **`docs/`** trees (architecture notes, runbooks, per-service hubs). This skill **does not** prescribe manifests, bulk scaffolds, or agent-driven “wiki regen”—those are **normal repo edits** outside this pack’s **`@git-*`** shortcuts.
+
+**Consumers:** **`internal-read-git-repo-layout`**, **`internal-write-gh-documentation`**, **`internal-read-git-doc-reference`**, **`internal-read-git-repo-classification`** (optional hints only).
+
+## Bootstrap hints (when starting from scratch)
+
+1. **Pick hub depth** — Smallest useful surface is **`docs/README.md`** + links; add domain wikis (**`docs/git.md`**, **`docs/gh.md`**, …) when **`@`** skills multiply.
+2. **Keep domains aligned** — Mirror **`skills/`** folder names under **`docs/`** when you want a wiki beside the pack (**`internal-read-git-repo-layout`**).
+3. **API / schema docs** — Add **`docs/api/`** (or similar) only when the repo actually ships HTTP/GraphQL/proto contracts worth documenting (**`internal-read-git-discover-dependencies`** can hint at signals).
+4. **Shape** — Indexes, tables, diagrams: **`internal-read-git-doc-index`**, **`internal-read-git-doc-table`**, **`internal-read-git-doc-graphs`**, **`internal-read-git-doc-explanation`**.
+5. **Hub starter** — For a cursor-skills-style docs hub scaffold, start from **`internal-read-git-doc-reference/docs-hub-scaffold/SKILL.md`**.
+
+## Do not
+
+- Run commands or write files from this skill.
+- Treat this file as a mandatory multi-folder **`docs/wiki/`** scaffold for every consumer of the pack.
+
+## See also
+
+- [`internal-read-git-repo-classification`](../repo-classification/SKILL.md)
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md)
+- [`internal-read-git-readme-tree`](../readme-tree/SKILL.md)
+- [`docs/README.md`](../../../../docs/README.md)

--- a/.agents/skills/internal-read-git-docs-mirror-bootstrap/SKILL.md
+++ b/.agents/skills/internal-read-git-docs-mirror-bootstrap/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: internal-read-git-docs-mirror-bootstrap
+description: >-
+  Read-only: bootstrap docs/ mirror pages from README inventory using canonical internal doc libraries.
+---
+
+# Internal: docs mirror bootstrap
+
+**Read-only.** Use this when creating a docs mirror for the first time or after a large layout change. This is not part of `@git-review` and does not replace in-place updates from `@git-docs`.
+
+## Inputs
+
+- Repository root.
+- Scope (`skills/` subtree only, or full repository).
+
+## Steps
+
+1. Enumerate candidate `README.md` files in the chosen scope.
+2. Decide which paths should have a docs mirror page.
+3. Map each source path to a `docs/<parallel-path>/README.md` target.
+4. Draft each target page using canonical doc libraries:
+   - [`internal-read-git-doc-index`](../doc-index/SKILL.md)
+   - [`internal-read-git-doc-explanation`](../doc-explanation/SKILL.md)
+   - [`internal-read-git-doc-table`](../doc-table/SKILL.md) when reference tables are needed
+5. Apply wiki/layout constraints from:
+   - [`internal-read-git-repo-layout`](../repo-layout/SKILL.md)
+   - [`internal-read-git-doc-index`](../doc-index/SKILL.md)
+6. For diagram-heavy pages, use [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md) and child templates.
+
+## Do not
+
+- Treat this as continuous mirror regeneration.
+- Replace `@git-docs` or `internal-write-gh-documentation` for routine in-place doc alignment.

--- a/.agents/skills/internal-read-git-git-diff-summary-delta-narrative/SKILL.md
+++ b/.agents/skills/internal-read-git-git-diff-summary-delta-narrative/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: internal-read-git-git-diff-summary-delta-narrative
+description: >-
+  Read-only: git log/diff recipes and PR/commit narrative shape; optional full commit-body log for issue keywords.
+  Parent internal-read-git-git-diff-summary.
+---
+
+# Git diff summary (commit message or PR prep)
+
+Reusable shape for summarizing **`git diff`** or **`$BASE_GIT..HEAD`** before writing a **commit message** or **PR body**. **Normative PR delta commands** live here; **`internal-read-git-git-diff-summary`** owns when and how agents use the evidence.
+
+---
+
+## Steps (human or agent)
+
+1. **Inventory** — List changed **areas** (top-level dirs or subsystems), not every file, unless the branch is tiny. Run **`git diff --name-status "$BASE_GIT...HEAD"`** and group by concern.
+2. **Themes** — From **`git log --oneline "$BASE_GIT..HEAD"`**, group into **2–5 bullets** (what readers must know).
+3. **Risk** — One line: **merge risk**, **behavior change**, or **none**.
+4. **Omit** — Noise renames, generated lockfile-only churn unless that *is* the story.
+
+---
+
+## Shell recipes (PR delta)
+
+Use **`$BASE_GIT`** and **`HEAD`**. **Two-dot** for commits, **three-dot** for file list.
+
+```bash
+git log --oneline "$BASE_GIT..HEAD"
+```
+
+```bash
+git diff --name-status "$BASE_GIT...HEAD"
+```
+
+Optional:
+
+```bash
+git merge-base --is-ancestor "$BASE_GIT" HEAD
+git log --reverse --oneline "$BASE_GIT..HEAD"
+```
+
+### Issue keywords in commit range (PR / `@gh-pr`)
+
+For **`internal-read-gh-pr-description`** §6.6, scan **full** commit messages on the branch (not only **`git log -1`**) for **`Fixes #n`**, **`Refs #n`**, **`Closes #n`**, **`Resolves #n`**, and bare **`#nnn`** mentions. Use a **two-dot** range so merges behave as expected for your branch topology.
+
+```bash
+git log --pretty=format:'---%n%s%n%n%b' "$BASE_GIT..HEAD"
+```
+
+When the log is long, you may **cap** output for chat (for example **`--max-count=30`**) but **state the cap** if older commits were omitted.
+
+---
+
+## Commit message skeleton (short)
+
+```
+<area>: <imperative outcome>
+
+- <bullet tied to diff>
+- <bullet>
+
+Refs: #n
+```
+
+Use **50–72** char first line when possible; body wraps at ~72.
+
+---
+
+## Hand-off
+
+- **PR / issue title:** [`title-line`](../../gh/pr-content/title-line/SKILL.md).
+- **PR body:** [`pr-body-skeleton`](../../gh/pr-content/pr-body-skeleton/SKILL.md).
+- **Orchestration:** [`internal-read-git-git-diff-summary`](../SKILL.md), [`internal-read-gh-pr-description`](../../gh/pr-description/SKILL.md).

--- a/.agents/skills/internal-read-git-git-diff-summary/SKILL.md
+++ b/.agents/skills/internal-read-git-git-diff-summary/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: internal-read-git-git-diff-summary
+description: >-
+  Read-only: local git diff/log narrative for PR evidence (no GitHub API). PR delta evidence contract and narrative
+  clustering for What changed. Command shapes live in delta-narrative/SKILL.md.
+  Caller: internal-read-gh-pr-description §6.
+---
+
+# Internal: Git diff summary (`internal-read-git-git-diff-summary`)
+
+**Read-only library.** **Local `git` only** (no **`gh`** / GitHub REST). **Sole owner** of the **evidence contract** and **inventory discipline** for computing the merge-aware delta from destination to **`HEAD`** for PR drafting. **Command and narrative shape:** **[`delta-narrative/SKILL.md`](./delta-narrative/SKILL.md)**.
+
+**Consumers:** **`internal-read-gh-pr-description`** §6 (run this skill **in full** before §7); humans writing commits; **`@gh-pr`** orchestration.
+
+---
+
+## Do
+
+1. **Inventory** by **theme** / subsystem, not raw file list (unless tiny branch).
+2. Use **[`delta-narrative/SKILL.md`](./delta-narrative/SKILL.md)** for the delta commands after **`@git-pull`** / **`@git-push`** in the PR flow.
+3. **Reuse** the same summary discipline for **commit** and **PR** to avoid drift.
+4. Point agents to **`delta-narrative/SKILL.md`** for copy-paste structure and short commit messages.
+
+## Do not
+
+- Run PR mutations.
+- Duplicate delta evidence steps inside **`internal-read-gh-pr-description`** — that skill **delegates** §6 here.
+
+## Evidence Contract
+
+Use the destination and **`HEAD`** values from **`@gh-pr`** / **`internal-read-gh-repo-stream`**. Output is for **drafting accuracy** and **triple pass** in **`internal-read-gh-pr-description`** §7—**do not** paste base/head identifiers, commit counts, or compare metadata into the PR body.
+
+**Full-branch coverage (required):** The PR description must reflect the **entire** meaningful delta from destination to **`HEAD`**.
+
+1. **Area checklist** — Build from the merge-aware file list and group paths by top-level directory / concern (e.g. **`skills/`**, **`docs/`**, **`.github/`**, **`README.md`**).
+2. **Commit themes** — Cluster the branch history across the whole branch.
+3. **Optional sanity checks** — Use the template when the graph is messy or the range looks surprising.
+4. **Destination and head pins** — Keep these internal for accuracy; do not post them in the PR body.
+
+**Short history** (roughly **≤ ~12** commits, one clear theme): you may **weave** commit themes into narrative bullets without pasting the log.
+
+**Long or multi-era history:** **do not** dump the raw log. **Summarize** older phases in **1–3 tight bullets** each.
+
+## Template
+
+- **[`delta-narrative/SKILL.md`](./delta-narrative/SKILL.md)** — delta commands, command range notes, and commit/PR narrative shape.
+
+## See also
+
+- [`internal-read-gh-pr-content`](../gh/pr-content/SKILL.md)
+- [`internal-read-gh-pr-description`](../gh/pr-description/SKILL.md)
+- [`delta-narrative/SKILL.md`](./delta-narrative/SKILL.md)
+- [`title-line`](../gh/pr-content/title-line/SKILL.md)

--- a/.agents/skills/internal-read-git-git-diff-summary/delta-narrative/SKILL.md
+++ b/.agents/skills/internal-read-git-git-diff-summary/delta-narrative/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: internal-read-git-git-diff-summary-delta-narrative
+description: >-
+  Read-only: git log/diff recipes and PR/commit narrative shape; optional full commit-body log for issue keywords.
+  Parent internal-read-git-git-diff-summary.
+---
+
+# Git diff summary (commit message or PR prep)
+
+Reusable shape for summarizing **`git diff`** or **`$BASE_GIT..HEAD`** before writing a **commit message** or **PR body**. **Normative PR delta commands** live here; **`internal-read-git-git-diff-summary`** owns when and how agents use the evidence.
+
+---
+
+## Steps (human or agent)
+
+1. **Inventory** — List changed **areas** (top-level dirs or subsystems), not every file, unless the branch is tiny. Run **`git diff --name-status "$BASE_GIT...HEAD"`** and group by concern.
+2. **Themes** — From **`git log --oneline "$BASE_GIT..HEAD"`**, group into **2–5 bullets** (what readers must know).
+3. **Risk** — One line: **merge risk**, **behavior change**, or **none**.
+4. **Omit** — Noise renames, generated lockfile-only churn unless that *is* the story.
+
+---
+
+## Shell recipes (PR delta)
+
+Use **`$BASE_GIT`** and **`HEAD`**. **Two-dot** for commits, **three-dot** for file list.
+
+```bash
+git log --oneline "$BASE_GIT..HEAD"
+```
+
+```bash
+git diff --name-status "$BASE_GIT...HEAD"
+```
+
+Optional:
+
+```bash
+git merge-base --is-ancestor "$BASE_GIT" HEAD
+git log --reverse --oneline "$BASE_GIT..HEAD"
+```
+
+### Issue keywords in commit range (PR / `@gh-pr`)
+
+For **`internal-read-gh-pr-description`** §6.6, scan **full** commit messages on the branch (not only **`git log -1`**) for **`Fixes #n`**, **`Refs #n`**, **`Closes #n`**, **`Resolves #n`**, and bare **`#nnn`** mentions. Use a **two-dot** range so merges behave as expected for your branch topology.
+
+```bash
+git log --pretty=format:'---%n%s%n%n%b' "$BASE_GIT..HEAD"
+```
+
+When the log is long, you may **cap** output for chat (for example **`--max-count=30`**) but **state the cap** if older commits were omitted.
+
+---
+
+## Commit message skeleton (short)
+
+```
+<area>: <imperative outcome>
+
+- <bullet tied to diff>
+- <bullet>
+
+Refs: #n
+```
+
+Use **50–72** char first line when possible; body wraps at ~72.
+
+---
+
+## Hand-off
+
+- **PR / issue title:** [`title-line`](../../gh/pr-content/title-line/SKILL.md).
+- **PR body:** [`pr-body-skeleton`](../../gh/pr-content/pr-body-skeleton/SKILL.md).
+- **Orchestration:** [`internal-read-git-git-diff-summary`](../SKILL.md), [`internal-read-gh-pr-description`](../../gh/pr-description/SKILL.md).

--- a/.agents/skills/internal-read-git-merge-conflicts/SKILL.md
+++ b/.agents/skills/internal-read-git-merge-conflicts/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: internal-read-git-merge-conflicts
+description: >-
+  Read-only playbook: principles and steps to resolve git merge conflicts when merging into the current branch (local
+  git only; no gh). Caller: @git-pull. Does not fetch, merge, or push.
+visibility: internal
+---
+
+# Internal: Merge conflict resolution
+
+**Read-only library.** **Local `git` only** (no **`gh`**). Use when **`@git-pull`** (or any parent) merges **`@{u}`** or **`ROOT_BRANCH`** and **`git`** leaves **unmerged paths**. **Ours** = current branch; **theirs** = the ref being merged (for example **`origin/main`** or a tracking branch).
+
+**Consumers:** **[`@git-pull`](../../../git/pull/SKILL.md)** — run this file **in full** whenever conflicts occur; conflict resolution is part of **`@git-pull`**, not **`@git-push`**.
+
+**Canonical merge phase:** `@git-pull` can merge in two phases (tracking branch first, canonical root second). In phase 2, prefer incoming (**theirs**) from `ROOT_BRANCH` in shared regions and adapt branch-only code around it.
+
+---
+
+## Principles
+
+- **Never blindly checkout sides** — Read conflict markers manually (`<<<<<<<`, `=======`, `>>>>>>>`), especially in manifests (`package.json`, `Cargo.toml`, `.gitignore`), where both sides' additions often need to be preserved together. Avoid `git checkout --theirs` / `--ours` across all files, which can silently wipe branch additions.
+- **Accept what main/root brought** — For shared files and root-owned regions, default to **incoming (theirs)** unless a small local tweak is required for the branch to compile or meet its goal.
+- **Avoid large rewrites of root code** — Do not replace big root blocks with older branch versions to “win” the merge. Keep root structure; adjust **branch additions** (new code, modules, tests) to fit.
+- **Branch goal** — After merging, the feature or fix the branch exists for should still be achievable; adapt call sites, imports, and branch-only logic—not revert upstream refactors wholesale.
+
+---
+
+## Procedure (execute in order)
+
+When any merge leaves unmerged paths:
+
+1. **Confirm merge in progress** — `git status` shows unmerged paths.
+
+2. **List conflicted files** — `git diff --name-only --diff-filter=U` (or `git status`).
+
+3. **Resolve each conflict**
+   - **Read the files first** to see the markers. **Never** blindly run `git checkout --theirs` or `git checkout --ours` across all files, especially for manifests (`package.json`, `.gitignore`, `Cargo.toml`).
+   - **Default to incoming (theirs)** for overlapping regions in files **main/root** owns (shared modules, config patterns, APIs updated on root). Prefer their version, then fix **branch-only** breakages (imports, types, tests) in the smallest follow-up edits.
+   - **Adapt branch code** — For files that are mostly **branch work**, keep branch intent but align with new root APIs and layout (move code, update signatures) rather than restoring pre-merge branch snapshots of root files.
+   - **Remove conflict markers** and leave one coherent result. **Do not** mass-reformat or restyle root code to match the branch; keep root formatting when you kept their side.
+
+4. **Stage** — `git add <file>` for each resolved file.
+
+5. **Complete merge** — `git status` has no unmerged paths; `git commit` (default merge message unless the user specifies otherwise).
+
+Then continue from the **parent** step that triggered the conflict (e.g. **`@git-pull`** §3 or §5).
+
+---
+
+## Do not (library)
+
+- **Fetch**, **merge** (except completing the in-progress merge via **`git commit`** after resolution), or **`git push`** — parent skill owns merge invocations; **`@git-push`** owns publish.
+
+---
+
+## See also
+
+- **[`@git-pull`](../../../git/pull/SKILL.md)** — source of truth for how `ROOT_BRANCH` is chosen before conflicts are resolved.
+- **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** — **`@git-pull`** merge-commit carve-out.
+- **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** **§4** — ambiguous tree before merge.

--- a/.agents/skills/internal-read-git-project-structure-eval/SKILL.md
+++ b/.agents/skills/internal-read-git-project-structure-eval/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: internal-read-git-project-structure-eval
+description: >-
+  Read-only: one-pass repository structure/readiness evaluation that combines repo classification and optional dependency discovery into
+  pillar status, posture, prioritized themes, and tracking recommendation. No installs, tests, or GitHub mutations.
+---
+
+# Internal: Project structure evaluation (`internal-read-git-project-structure-eval`)
+
+**Read-only library.** Produces a concise repository posture snapshot for planning and issue shaping:
+
+1. **Repo kind** + evidence
+2. **Pillar table** with `Have` / `Missing` / `Unknown` / `N/A`
+3. **Posture**: `good-shape` | `needs-foundation` | `mixed`
+4. **0-5 prioritized themes**
+5. **Tracking recommendation**: continue in plan vs open GitHub issues
+
+This skill combines signals from **[`internal-read-git-repo-classification`](../repo-classification/SKILL.md)** and optional **[`internal-read-git-discover-dependencies`](../discover-dependencies/SKILL.md)** output.
+
+## Consumers
+
+- **`@git-start`**, **`@gh-issues`**, Cursor Plan
+- `@gh-issues`, `@gh-issue-review`
+- Public router: `@git-project-structure-eval`
+
+## Non-goals
+
+- No dependency installs
+- No format/lint/test execution
+- No git mutation
+- No `gh` mutation
+- No file writes
+
+## Procedure
+
+1. **Collect context**
+   - Skim root and first-level structure (`skills/`, `docs/`, `src/`, `apps/`, `packages/`, `services/`, lockfiles, CI files).
+   - Reuse existing summary from `internal-read-git-repo-classification`.
+   - Optionally layer in dependency/CI/check-command clues from `internal-read-git-discover-dependencies`.
+2. **Select primary kind**
+   - Use one primary kind from `repo-classification` and mention relevant modifiers.
+3. **Evaluate pillars**
+   - Score each pillar as `Have`, `Missing`, `Unknown`, or `N/A`.
+   - Include one short rationale per pillar.
+4. **Determine posture**
+   - `good-shape`: mostly `Have`, few/no critical `Missing`.
+   - `needs-foundation`: several critical `Missing`.
+   - `mixed`: meaningful strengths with material gaps.
+5. **Return impact-ordered themes**
+   - 0-5 themes, highest impact first.
+6. **Return tracking recommendation**
+   - Keep in planning flow when scope is uncertain.
+   - Open GitHub issue(s) when implementation-ready actions are clear.
+
+## Pillars and status rules
+
+| Pillar | What to look for | Status guidance |
+| --- | --- | --- |
+| Repository shape clarity | Clear top-level structure and ownership hints (`README`, domain docs, folder conventions) | `Have` when navigation is clear; `Missing` when structure is opaque |
+| Workflow contracts | Public/internal skill boundaries and orchestration docs are coherent | `Have` when contracts are consistent; `Missing` for contradictory guidance |
+| Verification surface | Meaningful evaluation path exists for repo kind (`N/A` for checks that do not apply) | For markdown-first repos, code-only CI gates can be `N/A` |
+| Documentation integrity | Core docs/indexes and links align with current tree/contracts | `Missing` when docs drift; `Unknown` if evidence is incomplete |
+| Safety and mutation controls | Confirm-first policies for risky operations are explicit | `Missing` if high-risk actions can occur without explicit confirmation |
+
+## N/A vs Missing guidance
+
+- Use **`N/A`** when a pillar genuinely does not apply to the repository kind.
+  - Example: markdown-first pack without runtime services => service-deploy readiness is `N/A`.
+- Use **`Missing`** when the pillar should apply but required evidence is absent.
+  - Example: repo has executable code and CI references tests, but no clear local verification path.
+- Use **`Unknown`** when evidence is insufficient and additional inspection is required.
+
+## Output contract (chat shape)
+
+1. **Repo kind**: `<primary-kind>` (+ modifiers)
+2. **Evidence**: 2-5 bullets
+3. **Pillar table**: `Pillar | Status | Rationale`
+4. **Posture**: `good-shape` | `needs-foundation` | `mixed`
+5. **Themes**: 0-5 impact-ordered bullets
+6. **Tracking recommendation**: `stay-in-plan` or `open-issue`
+
+## See also
+
+- [`internal-read-git-repo-classification`](../repo-classification/SKILL.md)
+- [`internal-read-git-discover-dependencies`](../discover-dependencies/SKILL.md)
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md)
+- [`@gh-issues`](../../../gh/issues/SKILL.md)
+- [`@gh-issue-review`](../../../gh/issues/review/SKILL.md)

--- a/.agents/skills/internal-read-git-readme-root-root-readme-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git-readme-root-root-readme-scaffold/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: internal-read-git-readme-root-root-readme-scaffold
+description: >-
+  Read-only: monolithic root README scaffold. Parent internal-read-git-readme-root.
+---
+
+# TEMPLATE: repository root `README.md`
+
+**Prefix** blocks below come **first**; then use **`internal-read-git-readme-root`** + **`internal-read-git-doc-index`** for **Overview**, **See also**, **Contents** (**lists only**, no tables in Contents).
+
+---
+
+## 🧩 Brief pack variant (cursor-skills style)
+
+Use this when the repository keeps rich narrative in **`docs/`** and wants a short root landing page.
+
+Suggested structure:
+
+1. `# <Repo title>` + one-line value proposition.
+2. `## 🚀 Quick guide` with 2-4 first-run bullets.
+3. `## 📦 Install` with the minimal command block:
+
+```bash
+./install.sh
+```
+
+4. `## 🧭 Lane overview` with one small comparison table.
+5. Optional `## 🗺️ Example flow` (single Mermaid block) using GitHub-safe quoted labels:
+
+```mermaid
+flowchart LR
+  idea[Idea] --> exploreStep[Cursor Plan]
+  exploreStep --> ghIssuesStep["@gh-issues"]
+  ghIssuesStep --> prStep["@gh-pr"]
+```
+
+6. `## 📚 Learn more` with links to `docs/README.md`, `docs/git.md`, and `docs/gh.md`.
+
+Guidelines for this brief variant:
+
+- Keep **emoji** on major `##` titles.
+- Use **tables** only for compact comparisons; keep **`## Contents`** as numbered lists when present.
+- Keep Mermaid sparse (0-2 diagrams in root), and quote labels with special characters for GitHub compatibility.
+
+---
+
+# &lt;Repo title&gt;
+
+&lt;What this repository is for today.&gt;
+
+---
+
+## 🚀 Quick guide
+
+&lt;User-guide–style: first 2–3 things to do, where `skills/` or main code lives, how to invoke `@` skills.&gt;
+
+---
+
+## 🎯 Example usage
+
+```mermaid
+flowchart LR
+  classDef pub2 fill:#1976d2,color:#fff
+  classDef pub3 fill:#42a5f5,color:#111
+  classDef neu3 fill:#cfd8dc,color:#111
+  u[User] --> r["@git-review"]
+  r --> ok[Green tree]
+  class u neu3
+  class r pub2
+  class ok pub3
+```
+
+&lt;Replace nodes with **this repo’s** real skill names and paths.&gt;
+
+---
+
+## 🔭 Overview
+
+&lt;High-level architecture; colored mermaid if helpful.&gt;
+
+---
+
+## 💰 Estimates / economics (optional)
+
+*&lt;Explicitly labeled estimates&gt;* — e.g. marginal **cost per API call**, payload roll-ups aggregated from subtree READMEs. **Leaf-first** authoring: children hold granular tables; root **summarizes**.
+
+---
+
+## 📦 Install
+
+&lt;Minimal commands.&gt; **Prefer** prompting the user to run **Terminal batches by hand**; do not assume the agent runs installs.
+
+---
+
+## 🔗 See also
+
+1. [docs/README.md](docs/README.md) — documentation hub; domain indexes: [docs/git.md](docs/git.md), [docs/gh.md](docs/gh.md), [docs/internal.md](docs/internal.md) (**this** pack)
+2. …
+
+---
+
+## 📋 Contents
+
+1. … &lt;numbered nested lists, lexicographic; **no markdown table**&gt;
+
+---
+
+## 🏥 Health (optional)
+
+- **CI:** …
+
+---
+
+## Related
+
+&lt;Legacy cross-links if not covered above.&gt;

--- a/.agents/skills/internal-read-git-readme-root/SKILL.md
+++ b/.agents/skills/internal-read-git-readme-root/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: internal-read-git-readme-root
+description: >-
+  Read-only: minimal repository root README.md (link docs hub); optional Appendix D CI. Full narrative lives in
+  docs/ for this pack. Callers: @git-docs, internal-write-gh-documentation. Does not write files.
+---
+
+# Internal: Root README template (`internal-read-git-readme-root`)
+
+**Read-only library.** **This pack (cursor-skills):** root **`README.md`** stays **short**—opening **Quick guide** (what/why + a few usage examples), **`./install.sh`** (flags + env), link **[`docs/README.md`](../../../../docs/README.md)**, short **Documentation** pointer, optional **Usage flow** Mermaid—no full skill catalog in root. **Legacy / other repos:** full **superset** scaffold lives in **[`./root-readme-scaffold/SKILL.md`](./root-readme-scaffold/SKILL.md)** and **Appendix A** below.
+
+**Consumers:** **`@git-docs`**, **`internal-write-gh-documentation`** (alignment target), **`internal-read-git-readme-tree`** (bootstrap cross-links).
+
+---
+
+## Do
+
+- **Default (this pack):** Root = **short** entry: optional opening **Quick guide** (what/why + brief examples), **`./install.sh`** (install + verify flags), **link [`docs/README.md`](../../../../docs/README.md)**; optional link **[`docs/README.md`](../../../../docs/README.md)**; optional **Usage flow** diagram (**`internal-read-git-doc-graphs`**).
+- Prefer the **brief pack variant** in **[`./root-readme-scaffold/SKILL.md`](./root-readme-scaffold/SKILL.md)**: emoji on top-level `##` headings, one compact comparison table when useful, and at most 0-2 Mermaid blocks in root.
+- **Legacy / monolithic root:** Use **Appendix A** + **[`./root-readme-scaffold/SKILL.md`](./root-readme-scaffold/SKILL.md)** (Quick guide, mermaid, Contents, …).
+- Keep install **minimal**; **prompt** the user to run **Terminal batches** for heavy setup (**public `gh-*`** execution contract).
+- Optional **Appendix D** (CI/coverage) when real signals exist.
+
+## Do not
+
+- Put full per-skill catalogs in root—use **`docs/git.md`**, **`docs/gh.md`**, **`docs/internal.md`**, … (**this** pack) or optional **`docs/`** mirror elsewhere.
+- **Stuff** long reference into root when **`docs/README.md`** can own it.
+
+---
+
+## Appendix A — Template: main (root) README
+
+**Full scaffold:** **[`./root-readme-scaffold/SKILL.md`](./root-readme-scaffold/SKILL.md)**.
+
+Use for **repository root** `README.md`. Replace placeholders.
+
+**Principles** (full root README — legacy or non-mirror repos)
+
+- **Docs mirror pack:** prefer **minimal** root + **`docs/`** hub per **`internal-read-git-repo-layout`** §2.
+- **Subtree scope:** Summarize at high level; **do not** paste full inventories—**[`docs/README.md`](../../../../docs/README.md)** and **`docs/<domain>/README.md`** files own domain indexes (**this** pack).
+- **`## Contents` (root):** **numbered nested lists** only—**no markdown table** for the index.
+- **Tables:** OK in **reference** sections—not for directory listings.
+- **Section titles:** keep emoji on major `##` headings for scanability in pack-facing docs.
+- **Mermaid:** at least one **colored** diagram when the root is long-form (**`internal-read-git-doc-graphs`** + **`skills/read/git/doc-graphs/diagrams/*/SKILL.md`** scaffolds; human index **`docs/README.md`**).
+- **Estimates:** optional **`## Estimates` / `## Economics`** for service-level roll-ups (**explicitly labeled estimates**).
+- **No forecasted features**—describe **current** behavior only.
+
+**Conventions:** **Timelines**: **newest → oldest**. **Data tables**: sort rows **lexicographically** on the first column; **call out largest** rows (**`internal-read-git-doc-table`**).
+
+---
+
+## Appendix D — Optional: coverage and CI quick block (root only)
+
+Use when the repo has **real** signals (not placeholder). Omit the whole section if unknown.
+
+```markdown
+## Health
+
+- **CI:** [![CI](<badge-url>)](<actions-or-ci-url>) — <what it runs>
+- **Coverage:** <e.g. `npm run test -- --coverage` or link to report> — <threshold or “see CI”>
+```
+
+---
+
+## Exemplar (this repository)
+
+Live root **[`README.md`](../../../../README.md)** is **source of truth**: it stays brief, uses emoji on major `##` headings, includes a compact lane-comparison table, and keeps Mermaid focused on lane/flow visuals. Merge Appendix A only when the repo truly needs long-form root documentation.
+
+---
+
+## See also
+
+- [`internal-read-git-readme-tree`](../readme-tree/SKILL.md) — optional **`docs/`** mirror checklist + bootstrap
+- [`internal-read-git-doc-user-guide`](../doc-user-guide/SKILL.md)
+- [`internal-read-git-doc-reference`](../doc-reference/SKILL.md)

--- a/.agents/skills/internal-read-git-readme-root/root-readme-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git-readme-root/root-readme-scaffold/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: internal-read-git-readme-root-root-readme-scaffold
+description: >-
+  Read-only: monolithic root README scaffold. Parent internal-read-git-readme-root.
+---
+
+# TEMPLATE: repository root `README.md`
+
+**Prefix** blocks below come **first**; then use **`internal-read-git-readme-root`** + **`internal-read-git-doc-index`** for **Overview**, **See also**, **Contents** (**lists only**, no tables in Contents).
+
+---
+
+## 🧩 Brief pack variant (cursor-skills style)
+
+Use this when the repository keeps rich narrative in **`docs/`** and wants a short root landing page.
+
+Suggested structure:
+
+1. `# <Repo title>` + one-line value proposition.
+2. `## 🚀 Quick guide` with 2-4 first-run bullets.
+3. `## 📦 Install` with the minimal command block:
+
+```bash
+./install.sh
+```
+
+4. `## 🧭 Lane overview` with one small comparison table.
+5. Optional `## 🗺️ Example flow` (single Mermaid block) using GitHub-safe quoted labels:
+
+```mermaid
+flowchart LR
+  idea[Idea] --> exploreStep[Cursor Plan]
+  exploreStep --> ghIssuesStep["@gh-issues"]
+  ghIssuesStep --> prStep["@gh-pr"]
+```
+
+6. `## 📚 Learn more` with links to `docs/README.md`, `docs/git.md`, and `docs/gh.md`.
+
+Guidelines for this brief variant:
+
+- Keep **emoji** on major `##` titles.
+- Use **tables** only for compact comparisons; keep **`## Contents`** as numbered lists when present.
+- Keep Mermaid sparse (0-2 diagrams in root), and quote labels with special characters for GitHub compatibility.
+
+---
+
+# &lt;Repo title&gt;
+
+&lt;What this repository is for today.&gt;
+
+---
+
+## 🚀 Quick guide
+
+&lt;User-guide–style: first 2–3 things to do, where `skills/` or main code lives, how to invoke `@` skills.&gt;
+
+---
+
+## 🎯 Example usage
+
+```mermaid
+flowchart LR
+  classDef pub2 fill:#1976d2,color:#fff
+  classDef pub3 fill:#42a5f5,color:#111
+  classDef neu3 fill:#cfd8dc,color:#111
+  u[User] --> r["@git-review"]
+  r --> ok[Green tree]
+  class u neu3
+  class r pub2
+  class ok pub3
+```
+
+&lt;Replace nodes with **this repo’s** real skill names and paths.&gt;
+
+---
+
+## 🔭 Overview
+
+&lt;High-level architecture; colored mermaid if helpful.&gt;
+
+---
+
+## 💰 Estimates / economics (optional)
+
+*&lt;Explicitly labeled estimates&gt;* — e.g. marginal **cost per API call**, payload roll-ups aggregated from subtree READMEs. **Leaf-first** authoring: children hold granular tables; root **summarizes**.
+
+---
+
+## 📦 Install
+
+&lt;Minimal commands.&gt; **Prefer** prompting the user to run **Terminal batches by hand**; do not assume the agent runs installs.
+
+---
+
+## 🔗 See also
+
+1. [docs/README.md](docs/README.md) — documentation hub; domain indexes: [docs/git.md](docs/git.md), [docs/gh.md](docs/gh.md), [docs/internal.md](docs/internal.md) (**this** pack)
+2. …
+
+---
+
+## 📋 Contents
+
+1. … &lt;numbered nested lists, lexicographic; **no markdown table**&gt;
+
+---
+
+## 🏥 Health (optional)
+
+- **CI:** …
+
+---
+
+## Related
+
+&lt;Legacy cross-links if not covered above.&gt;

--- a/.agents/skills/internal-read-git-readme-tree/SKILL.md
+++ b/.agents/skills/internal-read-git-readme-tree/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: internal-read-git-readme-tree
+description: >-
+  Read-only: optional docs/ mirror parity checklist and greenfield hints vs skills/. No tree regen or bulk README apply
+  from pack skills—use @git-docs + internal-write-gh-documentation for in-place edits. Does not write files.
+---
+
+# Internal: Docs mirror notes (`internal-read-git-readme-tree`)
+
+**Read-only.** This pack keeps **`docs/**`** as a **human-facing mirror** of **`skills/`** when you choose that layout. **Agents** do **not** run a separate “mirror regen” step after **`@git-review`**. **`@git-docs`** and **`internal-write-gh-documentation`** edit **existing** markdown **in place**; if a **`docs/.../README.md`** is missing, add it in a normal edit (same PR) using the bootstrap bullets below.
+
+## Bootstrap (greenfield or new folders)
+
+1. **Domain layout** — **[`internal-read-git-repo-layout`](../repo-layout/SKILL.md)** — public skills under **`skills/<domain>/<verb>/`**; shared libraries under top-level **`skills/read/<domain>/**`** vs **`skills/write/<domain>/**`** depending on whether they mutate the machine or GitHub.
+2. **Mirror hub pages** — **`docs/<same-relpath>/README.md`**: short overview, **`## Contents`** as **numbered lists** only (**[`internal-read-git-doc-index`](../doc-index/SKILL.md)**), overview prose per **[`internal-read-git-doc-explanation`](../doc-explanation/SKILL.md)**.
+3. **Diagrams** — Add fenced **`mermaid`** only when a diagram clarifies flow; palette and hierarchy per **[`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md)**. Example scaffolds live in **`skills/read/git/doc-graphs/diagrams/*/SKILL.md`** (optional references, not required files in consuming repos).
+4. **Tables** — Data tables in reference sections: sort rows, call out large rows (**[`internal-read-git-doc-table`](../doc-table/SKILL.md)**). Never use a markdown **table** for a pure index (**[`internal-read-git-doc-index`](../doc-index/SKILL.md)**).
+
+## Optional parity checklist (human)
+
+If this repo uses a **`docs/`** mirror: skip **`.gitignore`**d paths; spot-check that important **`skills/.../`** dirs have a sibling **`docs/.../README.md`** when that is your convention; **`## Contents`** ordered lexicographically; relative links into **`skills/`** still resolve.
+
+## Do not
+
+- Treat this skill as part of **`@git-review`** after green evaluate—the verify pipeline ends at **`internal-write-gh-documentation`** (**§8a**).
+
+## See also
+
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md)
+- [`internal-read-git-docs-mirror-bootstrap`](../docs-mirror-bootstrap/SKILL.md)
+- [`internal-write-gh-documentation`](../../../write/gh/documentation/SKILL.md)
+- [`@git-docs`](../../../git/docs/SKILL.md)
+- [`internal-read-git-readme-root`](../readme-root/SKILL.md)

--- a/.agents/skills/internal-read-git-repo-classification/SKILL.md
+++ b/.agents/skills/internal-read-git-repo-classification/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: internal-read-git-repo-classification
+description: >-
+  Read-only: classify repository kind (markdown-first vs code vs multi-service/monorepo vs tooling-heavy) from tree
+  skim plus optional internal-read-git-discover-dependencies summary. Recommendations for doc stance only—no writes. Callers
+  may use output to scope @git-docs inventory or planning chat.
+---
+
+# Internal: Repository classification (`internal-read-git-repo-classification`)
+
+**Read-only library.** Produces a **short label**, **evidence bullets**, and **suggested documentation stance** for the open workspace. **Does not** replace **[`internal-read-git-discover-dependencies`](../discover-dependencies/SKILL.md)** (toolchains, CI, check commands)—combine a **quick tree skim** with that skill’s summary when available.
+
+**Consumers:** Any skill or session that benefits from **scope** (e.g. which **`docs/**`** paths exist, how heavy wiki scaffolding might be). **Optional**—no required wiring across the pack.
+
+## Do
+
+1. **Skim** repo root and one level down: **`skills/`**, **`docs/`**, **`src/`**, **`apps/`**, **`packages/`**, **`services/`**, `package.json`, lockfiles, CI config, dominant extensions (`.md` vs `.ts`/`.go`/`.py`).
+2. **Optionally** ingest **`internal-read-git-discover-dependencies`** output: languages/stacks, “docs-only” vs real code checks, monorepo/workspace signals.
+3. **Emit for chat** (recommendations only):
+   - **Primary label** — one of: **`markdown-docs-first`**, **`code-app-or-library`**, **`multi-service-monorepo`**, **`scripts-tooling-heavy`**, or **`mixed`** (state why).
+   - **Evidence** — **2–5** bullets (paths, artifacts, CI).
+   - **Suggested doc stance** — e.g. minimal **`docs/README.md`** only vs full **[`internal-read-git-doc-wiki`](../doc-wiki/SKILL.md)** **`coding`** profile vs **`skill-pack`** / **`knowledge`**; whether **`docs/api/`** is plausible (see **`internal-read-git-doc-wiki`** §3).
+
+## Kind reference (signals)
+
+| Kind | Typical signals |
+| --- | --- |
+| **Markdown / docs-first** | Mostly **`.md`**; **`skills/**/SKILL.md`** trees; little or no app **`src/`**; no or trivial build/test stack. |
+| **Code present** | Lockfiles, **`src/`** / language-specific roots, CI running tests/build; single product or library. |
+| **Multi-service / monorepo** | **`services/`**, **`apps/*`**, **`packages/*`**, **`pnpm-workspace.yaml`**, **`go.work`**, multiple deployables. |
+| **Tooling-heavy** | **`tools/`**, Make/Task **`justfile`**, small CLIs, automation entrypoints; docs may still matter but the codebase is automation-centric. |
+
+**Modifiers:** A repo can be **`markdown-docs-first` + `scripts-tooling-heavy`** (e.g. skill pack with **`install.sh`**). Prefer the label that best answers “what is the main artifact?”
+
+## Do not
+
+- Run commands, write files, or mutate git from this skill.
+- Treat classification as **authoritative** without user confirmation when it drives large doc or structural changes.
+- Duplicate **`internal-read-git-doc-wiki`** profile tables—**link** there for path-level detail.
+
+## See also
+
+- [`internal-read-git-discover-dependencies`](../discover-dependencies/SKILL.md)
+- [`internal-read-git-doc-wiki`](../doc-wiki/SKILL.md)
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md)
+- [`@git-docs`](../../../git/docs/SKILL.md) — in-place updates on **existing** **`.md`** only

--- a/.agents/skills/internal-read-git-repo-layout/SKILL.md
+++ b/.agents/skills/internal-read-git-repo-layout/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: internal-read-git-repo-layout
+description: >-
+  Read-only: domain-driven skills/, docs/README.md + optional docs/ mirror (this pack), diagram examples under
+  skills/read/git/doc-graphs/diagrams/*/SKILL.md, minimal root README. Consumed by @git-docs (read-only alignment); not @git-review.
+---
+
+# Internal: Repo layout (domain-driven)
+
+**Read-only.** Canonical **shape** for repositories that use this skill pack: **`skills/`** (workflows), **`docs/README.md`** + optional **`docs/...`** beside **`skills/`** (per-folder **`README.md`** and workflow markdown), **`skills/read/git/doc-graphs/diagrams/*/SKILL.md`** (optional mermaid examples), and a **minimal** root **`README.md`**. **Does not** run commands or verify—**[`@git-docs`](../../../git/docs/SKILL.md)** aligns **existing** markdown to this contract (**in place** only).
+
+**Consumers:** **`@git-docs`** (post-green **content** sync on **existing** **`.md`** only—**no** structural file ops from that skill). **Single source** for layout rules—do not duplicate these tables in other skills.
+
+## Do
+
+- Serve as the **single** read-only contract for **`skills/`** + documentation hub shape; callers **read** it and **link** here instead of copying prose.
+
+## Do not
+
+- Run commands, create files, or verify—**[`@git-docs`](../../../git/docs/SKILL.md)** applies **in-place** doc alignment only.
+
+---
+
+## 1. Skills (`skills/`)
+
+Treat **`skills/`** as a **single aggregate** of agent workflows, partitioned by **domain** (bounded context):
+
+| Domain | Typical path | Group together |
+| --- | --- | --- |
+| **GitHub (`gh`)** | `skills/gh/...` | **`pr`**, **`issues/*`** — **`@gh-*`** only; local git lives under **`skills/git/`** |
+| **Cross-cutting internal** | `skills/read/<domain>/**`, `skills/write/<domain>/**` | **`read/gh`**: **`gh`** inventory and PR/issue form helpers (issues, PRs, **`repo-stream`**, **`repo-forms-json`**). **`read/git`**: verify prep (**`discover-dependencies`**, **`configuration`**), doc/markdown rules (**`doc-*`**, **`readme-*`**, **`repo-layout`**, **`repo-classification`**, **`doc-wiki`**), **`git-diff-summary`**, **`merge-conflicts`**. **`write/gh`**: install, evaluate, documentation, issue/pr **command** fences. **`write/git`**: zip, tag, working-tree align. **`write/plan`**: safety + structured Q&A. |
+| **Public wikis + scaffolds** | **`docs/git.md`**, **`docs/gh.md`**, **`internal-read-git-doc-graphs`** `diagrams/` … | **Not** invocable skills—**`.md`** only (diagrams use **fenced `mermaid`** inside those files). |
+
+**Rules**
+
+1. **One skill per folder** — each leaf is `.../<name>/SKILL.md` with YAML **`name`** + **`description`** matching the pack’s conventions.
+2. **Similar verbs, same parent** — e.g. all `gh-*` public skills live under **`skills/gh/`**, not scattered at `skills/` root.
+3. **Public vs library** — user-invoked flows stay shallow (`skills/<domain>/<verb>`); shared libraries and policies live under `skills/read/<domain>` and `skills/write/<domain>`.
+4. **Names mirror behavior** — folder names stay short and match the skill `name` prefix (`git-docs` → `skills/git/docs/`).
+
+When **moving** skill folders, update **relative links** in the same change set; **`internal-read-git-repo-layout`** stays the single source for layout rules.
+
+---
+
+## 2. Narrative wiki + optional mirror under `docs/`
+
+**Mirror:** when you use one, **`docs/<relpath>/README.md`** may sit beside each **`skills/`** directory; parity expectations are a **repo convention**, not an automated pack step—see **`internal-read-git-readme-tree`** for a short checklist.
+
+**Root `README.md`:** minimal—title, purpose, install pointer, link **`docs/README.md`** (**`internal-read-git-readme-root`**).
+
+**`skills/`:** one **`SKILL.md`** per leaf; with a mirror, avoid duplicate prose in **`skills/**/README.md`**—use **`docs/...`** or **`SKILL.md`** only.
+
+**Policy vs bodies:** “when/how” in **`internal-read-git-doc-*`**, **`internal-read-gh-pr-content`**, **`internal-read-git-git-diff-summary`**, **`internal-read-git-doc-graphs`**; long checklist/skeleton/scaffold bodies as **sibling `.md`** files next to the owning **`internal-*`** library; **`docs/`** wikis stay **short** indexes over **`skills/`**.
+
+**Hub scaffold:** use **`internal-read-git-doc-reference/docs-hub-scaffold/SKILL.md`** as the baseline for emoji headings, numbered `Contents`, and structural comparison tables in new/reshaped docs hubs.
+
+**Exemplars:** **`internal-read-git-doc-exemplars`**.
+
+---
+
+## 3. What this is not
+
+- **Not** **`@git-review`** — verify + **light** polish of **existing** paths only.
+- **Not** **`internal-write-gh-documentation`** in place of this file — that skill **edits** after green tests; **layout policy** stays here only.
+
+---
+
+## See also
+
+- [`internal-read-git-doc-wiki`](../doc-wiki/SKILL.md) — how deep **`docs/`** might go elsewhere
+- [`internal-read-git-readme-tree`](../readme-tree/SKILL.md) — mirror bootstrap + optional parity checklist
+- [`@git-docs`](../../../git/docs/SKILL.md) — post-green doc accuracy (**existing** files **in place**)
+- [`internal-write-gh-documentation`](../../write/gh/documentation/SKILL.md) — §8a polish existing docs after green evaluate
+- [`docs/README.md`](../../../../docs/README.md) — documentation hub (**this** pack)
+
+## 4. Naming hygiene
+
+- Avoid nested segments repeating the parent (`foo/foo/`). For this pack, keep planning internals under `skills/read/plan/core/` (not `skills/read/plan/plan/`).
+- When moving folders, keep `name:` path-faithful with `internal-<full-path-with-dashes>` for read/write internals.
+
+## 5. Workspace staging conventions (`.cursor/`)
+
+- `.cursor/plan.md` is the canonical planning hub.
+- `.cursor/plans/<slug>.md` is an overflow split linked from the hub.
+- `.cursor/gh/issues/` stores issue draft bodies/manifests.
+- `.cursor/gh/pr/` stores PR draft fragments.

--- a/.agents/skills/internal-read-git-workflows/SKILL.md
+++ b/.agents/skills/internal-read-git-workflows/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: internal-read-git-workflows
+description: >-
+  Read-only in-pack git workflow references for public git skills, covering
+  branch/main/pull/push/reset/stash/revert/rebase/zip guidance.
+---
+
+# In-pack git workflows
+
+Use these sections as the in-repo workflow source for public `@git-*` skills.
+
+High-risk steps referenced here (for example `git fetch`, `git push`, `git reset --hard`, `git clean`, or any out-of-repo write in delegated libraries) must still run behind [`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md) and [`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md). `SKIP_QA_*` / `SKIP_QA_WRITE` does not bypass session-level master confirm for those actions.
+
+## Git start workflow
+
+1. Derive `BRANCH` from Jira / issue / activity context.
+2. Run full `@git-main` once. If `@git-main` aborts, stop `@git-start`.
+3. After `@git-main` succeeds, create the feature branch from clean `main`:
+   - `git checkout -b "$BRANCH"`
+4. Hand off to full `@git-push` unless the user explicitly skips publish.
+
+## Git main align workflow
+
+1. Validate repository context:
+   - `git rev-parse --is-inside-work-tree`
+2. Check out `main` before fetch/reset:
+   - `git checkout main`
+   - If local `main` is missing, create from `origin/main`.
+3. Fetch canonical refs:
+   - `git fetch origin`
+4. Resolve canonical main for standalone workflow:
+   - `CANONICAL_MAIN_REF=origin/main`
+   - `git rev-parse "$CANONICAL_MAIN_REF"` must succeed
+5. If tree is clean and `HEAD == $CANONICAL_MAIN_REF`, stop.
+6. Else align via `internal-write-git-working-tree-align` with:
+   - `ALIGN_REF="$CANONICAL_MAIN_REF"`
+   - `BRANCH=main`
+   - `MODE=combined`
+7. Do not `git pull` after reset/clean in this workflow.
+8. Do not push in this workflow.
+
+## Git pull workflow
+
+1. Capture current branch; fail if detached:
+   - `BRANCH=$(git branch --show-current)`
+2. Fetch refs:
+   - `git fetch origin`
+   - If `upstream` exists, `git fetch upstream`
+3. If branch has upstream tracking, merge `@{u}`; on conflict use `internal-read-git-merge-conflicts`.
+4. Resolve canonical root branch via `internal-read-gh-repo-stream`:
+   - `ROOT_BRANCH="$CANONICAL_MAIN_REF"` (`upstream/main` on fork, else `origin/main`)
+5. Merge `"$ROOT_BRANCH"`; on conflict use `internal-read-git-merge-conflicts`.
+6. Stop after merges complete; do not push in this workflow.
+
+## Git push workflow
+
+- **Read-only inventory** first (`git status --short`; optional **`HEAD...@{u}`** counts when upstream exists).
+- Run **full `@git-commit`** **only when** that inventory shows **something to commit**; if the tree is clean, **skip** commit (still run publish when there are **unpushed commits**).
+- **Publish** — **One** structured **Proceed** for branch intent + **`git push`** when the first attempt succeeds; **`origin`-aware** branch gate (**`main`** + **`origin`** → recommend new branch + later **`@gh-pr`**; no **`origin`** → single proceed on current branch). Use failure triage only when **`git push`** fails.
+- **Full verify** before opening/updating a PR is **`@git-review`** inside **`@gh-pr`** (see **`@gh-pr`** fixed order), not a prerequisite of standalone **`@git-push`**.
+
+## Git commit workflow
+
+- Run **`@git-commit`** for local savepoints only (no review gate, no push).
+- **Inventory first** — if **nothing to commit**, **no-op** with **no Q&A**.
+- **Single gate** when work exists — default **`git add -A`**, confirm **`COMMIT_SUBJECT`**, **Cancel / Proceed**, then stage + **one** commit (optional **one** follow-up for ambiguous paths only).
+- Use **`@git-push`** when publishing; use **`@git-review`** (or **`@gh-pr`**, which runs it) when you need a verify-backed gate before sharing work broadly.
+
+## Git tag workflow
+
+- **Optional publish-first** — When **`origin`** exists and the repo is **dirty**, **ahead** of **`@{u}`**, or the user asked to publish first, run **full `@git-push`** **before** **`@git-main`** + tag gates; otherwise skip with a short reason.
+- Then **`@git-main`**, optional **`@git-commit`** when **`@git-push`** did not run and the tree is still dirty, **read-only tag inventory**, then **fewer Q&A gates** (publish intent → local collision → remote collision → **Proceed**) per **`@git-tag`**.
+- **`@git-zip`** still hands off tag mutations only to **`@git-tag`**; export uses **`internal-write-git-zip`**.
+
+## Git reset align workflow
+
+- Resolve target ref, show impact, then align via reset/clean after confirm.
+
+## Git stash workflow
+
+- Save/list/show/apply/pop/drop with explicit confirmation for destructive steps.
+
+## Git branch workflow
+
+- Prune stale refs and optionally rename current branch.
+
+## Git rebase workflow
+
+- Rebase current branch onto target with conflict resolution.
+
+## Git revert workflow
+
+- Create inverse commits for selected commits (including merges when needed).
+
+## Git zip workflow
+
+- Export a **GitHub-style** **`.zip`** of **tracked files** at **`refs/tags/${TAG}`** via **`internal-write-git-zip`**.
+- **`@git-zip`** orchestrates only: **`@git-tag`** when a tag must be created or repointed, then export; or read-only tag verification plus export when the tag already exists.
+- **`@git-tag`** owns optional **publish-first `@git-push`**, sync **`main`**, label, and tag-push Q&A; **`@git-zip`** does not run tag-mutating fences from **`internal-write-git-tag`**.
+
+## See also
+
+- [`@git-zip`](../../../git/zip/SKILL.md)
+- [`@git-tag`](../../../git/tag/SKILL.md)
+- [`internal-write-git-tag`](../../../write/git/tag/SKILL.md)
+- [`internal-write-git-zip`](../../../write/git/zip/SKILL.md)
+- [`internal-write-git-commit`](../../../write/git/commit/SKILL.md)
+- [`internal-write-git-working-tree-align`](../../../write/git/working-tree-align/SKILL.md)

--- a/.agents/skills/internal-read-git/SKILL.md
+++ b/.agents/skills/internal-read-git/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: internal-read-git
+description: >-
+  Internal git-oriented read-only libraries for discovery, docs conventions, repo layout, and merge/diff playbooks.
+---
+
+# `skills/read/git/`
+
+Read-only library layer consumed by public `@git-*` and `@gh-*` workflows.
+
+Docs map: [`docs/read.md`](../../../docs/read.md) for read-library navigation and [`docs/internal.md`](../../../docs/internal.md) for read/write internal boundaries and safety pairing.
+
+- `discover-dependencies`, `configuration` for check command discovery.
+- `doc-*`, `readme-*`, `repo-layout`, `repo-classification` for docs structure.
+- `project-structure-eval` for one-pass posture scoring (kind + pillars + themes).
+- `git-diff-summary` and `merge-conflicts` for git narratives and conflict handling.
+
+These files define policies and command-shape guidance; they do not mutate git or GitHub state directly.

--- a/.agents/skills/internal-read-git/configuration/SKILL.md
+++ b/.agents/skills/internal-read-git/configuration/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: internal-read-git-configuration
+description: >-
+  Read-only batch: from discovery output, resolve umbrella/format/lint/test/coverage commands to run.
+  No shell installs or test execution. Used by @git-review between prepare and evaluate.
+---
+
+# Internal: Check command configuration
+
+**Library.** Turns **discovery** (from **[`internal-read-git-discover-dependencies`](../discover-dependencies/SKILL.md)**) into an **ordered command plan** for **[`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md)**. Does **not** run commands—**evaluate** runs them.
+
+**Consumers:** **`@git-review`** — after Prepare, before Evaluate.
+
+---
+
+## Input
+
+- Discovery summary: stacks present, README/CI hints, coverage expectations.
+- **Post-install** state: e.g. `node_modules` exists, `cargo metadata` ok.
+
+---
+
+## Output (conceptual)
+
+Record for each applicable stack:
+
+1. **Umbrella** — Single entry if present (`make check`, `npm run check`, `pnpm validate`, `task check`, …) or **none**.
+2. **Format** — Prefer **fix** scripts when present (`npm run format`, `cargo fmt`, `ruff format`, …); otherwise check-only (`prettier --review`, …). See **[`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md)** §5. **Skip** if no formatter.
+3. **Lint** — `cargo clippy`, `ruff check`, `eslint`, `golangci-lint`, … per stack.
+4. **Test** — Primary test script or `cargo test` / `pytest` / `go test ./...`.
+5. **Coverage** — Commands + thresholds from discovery, or **omit** if §1d found no expectation.
+
+Prefer **documented** order: umbrella **first** when it clearly subsumes format+lint+test; otherwise run §5–7 of **`@git-review`** as in **[`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md)**.
+
+---
+
+## Do not
+
+- Run installs or checks.
+- Invent `npm test` / `cargo clippy` without signals from discovery + repo config.
+
+## See also
+
+- **[`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md)** — executes the matrix.

--- a/.agents/skills/internal-read-git/discover-dependencies/SKILL.md
+++ b/.agents/skills/internal-read-git/discover-dependencies/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: internal-read-git-discover-dependencies
+description: >-
+  Read-only batch: scan READMEs, CI, and repo config to infer stacks, toolchains, coverage expectations,
+  and authoritative check commands; then map gaps vs disk (lockfiles, node_modules, venv). Used by @git-review §1–2 and
+  @gh-issue-review (read-only context).
+---
+
+# Internal: Discover + map gaps (dependencies / stack)
+
+**Library.** Single **batch** of evidence gathering for **`@git-review`**: Discover (§1) and Map gaps (§2). Does not run installs, formatters, tests, or git writes—callers run **[`internal-write-gh-install-dependencies`](../../write/gh/install-dependencies/SKILL.md)** next.
+
+**Consumers:** **`@git-review`** §1–2; **`@gh-issue-review`** (issue reshape, **§1 only**—no install/evaluate); **manual / agent-led** structural planning (stack + monorepo hints, **`internal-read-git-doc-wiki`** §3 API signals).
+
+---
+
+## Batch A — Discover
+
+### Documentation (priority)
+
+Read—**do not assume only** `./README.md`:
+
+- `README.md` (root), `README.rst`, `docs/` index READMEs, `CONTRIBUTING.md`, `INSTALL.md`, `DEVELOPMENT.md`.
+- Monorepos: nested `README.md` under `packages/`*, `apps/`*, etc., when root points there.
+
+### Configuration signals (infer stacks)
+
+Scan root (and workspace layout) for:
+
+| Area      | Signals                                                                             |
+| --------- | ----------------------------------------------------------------------------------- |
+| Node / TS | `package.json`, lockfiles, `tsconfig.json`, eslint/prettier/vitest/jest configs     |
+| Python    | `pyproject.toml`, `requirements*.txt`, `ruff`, `.flake8`, `.python-version`, `mypy` |
+| Rust      | `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`                                  |
+| Go        | `go.mod`, `.golangci.*`                                                             |
+| Other     | `Gemfile`, `pom.xml`, `build.gradle*`, `Makefile`, `justfile`, `Taskfile.yml`       |
+| CI        | `.github/workflows/*.yml`, `.gitlab-ci.yml`, etc.                                   |
+
+### Internal summary (produce for downstream)
+
+- **Languages / stacks present** (or “docs-only”).
+- **Required toolchain** (README, `.nvmrc`, `rust-toolchain.toml`, …).
+- **Authoritative check commands** — README → CI → Makefile / `package.json` / `pyproject.toml` scripts → defaults in `[internal-read-git-configuration](../configuration/SKILL.md)` / `[internal-write-gh-evaluate](../../write/gh/evaluate/SKILL.md)`.
+
+If **no** code stack: report “no code checks applicable”; still allow documentation pass later.
+
+### Coverage expectations (§1d analogue)
+
+From README, CI, scripts, config: infer **whether** coverage is required and **which** command(s) / thresholds apply for `[internal-write-gh-evaluate](../../write/gh/evaluate/SKILL.md)` §7b.
+
+### API surface signals (for `docs/api/` gating)
+
+Use when **`internal-read-git-doc-wiki`** needs to decide whether **`docs/api/`** is warranted. **Presence-only** scan (read paths / globs; do not assume runtime):
+
+- OpenAPI / Swagger: `openapi.yaml`, `openapi.json`, `swagger.yaml`, `swagger.json`
+- GraphQL: `*.graphql`, `schema.graphql`, common `graphql` schema filenames
+- gRPC: `*.proto`
+- Framework hints: `routes.ts`, `router.go`, `urls.py`, `APIRouter`, `app/api/`, `pages/api/`, `src/routes/` (when clearly HTTP APIs)
+
+If **none** of the above are credible for this repo, report **no API docs scaffold** unless the user overrides in chat.
+
+### Monorepo / multi-package hints
+
+Top-level **`services/`**, **`apps/`**, **`packages/`**, or workspace config (`pnpm-workspace.yaml`, `go.work`, etc.)—surface in the internal summary for **`monorepo`** / profile selection (**`internal-read-git-doc-wiki`**).
+
+---
+
+## Batch B — Map gaps
+
+From Batch A, compare **documented / CI** expectations to **disk**:
+
+- Lockfile vs `node_modules` / vendor / `venv` / `.venv` presence when README requires install.
+- CI step order vs what has been run locally (e.g. `npm ci` vs `npm install`).
+- README vs CI mismatch — prefer README for **local dev**, **call out** divergence.
+
+**Output:** Targeted gap list for `[internal-write-gh-install-dependencies](../../write/gh/install-dependencies/SKILL.md)`.
+
+---
+
+## Do not
+
+- Install packages, run tests, or edit files.
+- Skip CI/README when inferring commands.
+
+## See also
+
+- [`internal-read-git-configuration`](../configuration/SKILL.md) — resolve command matrix.
+- [`internal-read-git-doc-wiki`](../doc-wiki/SKILL.md) — **`docs/api/`** gating and doc profiles.
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md) — **§3a** confirmations for destructive prep (via **`internal-write-gh-install-dependencies`**).

--- a/.agents/skills/internal-read-git/doc-exemplars/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-exemplars/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: internal-read-git-doc-exemplars
+description: >-
+  Read-only: markdown-first public documentation exemplars (links + patterns) and a filtering rubric before
+  adopting external ideas. Callers: internal-write-gh-documentation, @git-docs. Does not write files or copy
+  third-party bodies.
+---
+
+# Internal: Public documentation exemplars (`internal-read-git-doc-exemplars`)
+
+**Read-only library.** **Pointers and rules only** — use when **`internal-write-gh-documentation`** or **`@git-docs`** should borrow **structure** (headings, tables, troubleshooting blocks) from well-known **markdown-in-repo** documentation. **Do not** paste large chunks of external text without license checks; **do not** bypass **`internal-write-gh-documentation`** / **`@git-docs`** for substantive doc edits.
+
+**Consumers:** **[`internal-write-gh-documentation`](../../write/gh/documentation/SKILL.md)** (polish existing paths), **[`@git-docs`](../../../git/docs/SKILL.md)** (seeds, layout, polish modes).
+
+---
+
+## Skill ownership (sanctioned doc changes)
+
+External repos inform **patterns** only; changes still flow through **`@git-docs`** or **`@git-review`** §8a → **`internal-write-gh-documentation`**.
+
+```mermaid
+flowchart TB
+  classDef neuM fill:#eceff1,color:#111
+  classDef pub2 fill:#1976d2,color:#fff
+  classDef int2 fill:#00897b,color:#fff
+  classDef int3 fill:#4db6ac,color:#111
+  subgraph ext [External]
+    EX[Markdown_exemplars]
+  end
+  subgraph skills [Sanctioned_writers]
+    GD[git-docs]
+    IDOC[internal-write-gh-documentation]
+    REV[gh-review_8a]
+  end
+  EX -.->|"patterns_only"| GD
+  EX -.->|"patterns_only"| IDOC
+  REV --> IDOC
+  class EX neuM
+  class GD pub2
+  class IDOC int2
+  class REV int3
+```
+
+---
+
+## Curated shortlist (markdown in tree)
+
+Primary artifact should be **`.md` in the repository** (not a static site generator as the only source of truth).
+
+| Source | Why it is useful | Extract | Skip |
+| --- | --- | --- | --- |
+| [github/opensource.guide](https://github.com/github/opensource.guide) | Short chapters; strong **contributing / community / legal** tone | Heading depth, “when to use this page”, cross-links, checklist-style sections | Product-specific GitHub UI copy |
+| [thegooddocsproject](https://github.com/thegooddocsproject) (repos under the org) | Explicit **doc-type** templates (how-to, tutorial, reference stubs) | Skeleton ideas: prerequisites, steps, “see also”, troubleshooting | Toolchain-specific assumptions; verbatim merges without license review |
+| Large OSS **`docs/`** trees in markdown (e.g. **eslint**, **nodejs** `doc/`, **pandas** narrative docs) | Real **guide vs reference** separation | How they split narrative from catalogs; tables and version notes | Install matrices and commands that are not this repo’s truth |
+| **Small libraries** with clear READMEs (e.g. **semver**-style) | Above-the-fold clarity | First-screen structure; minimal badge/link discipline | Marketing READMEs that do not fit a skill-pack repo |
+
+**Out of scope for this skill (do not treat as copy sources here):** Diátaxis site prose; Docusaurus / VitePress / MkDocs **site source** as template (SSG coupling). You may still map ideas mentally (tutorial vs how-to vs reference) without copying those sites.
+
+---
+
+## Filtering rubric (before adopting a pattern)
+
+Apply when changing **`docs/README.md`**, **`docs/<domain>/.../README.md`**, **minimal root** **[`README.md`](../../../../README.md)**, or (legacy) monolithic **`docs/*`** files:
+
+1. **Portability** — Works as **static markdown** with relative links and optional mermaid (**[`internal-write-gh-documentation`](../../write/gh/documentation/SKILL.md)** prefers mermaid).
+2. **Hub fit** — Maps to **one** surface: **Quick guide / install** (root README), **skill catalog** (**`docs/git.md`** / **`docs/gh.md`** / **`docs/internal.md`** or a slimmer layout on other repos), **diagram** (mermaid in **`docs/README.md`** or domain wiki), or **single-file overview**—not scattered duplicates.
+3. **License** — Prefer **CC / MIT / permissive** examples; avoid long **copyleft** or **all rights reserved** pastes without explicit check.
+4. **No false precision** — Reject commands and claims that conflict with **this** repo’s **[`internal-write-gh-evaluate`](../../write/gh/evaluate/SKILL.md)** / CI (**[`internal-read-git-configuration`](../configuration/SKILL.md)**).
+5. **Size** — Respect **`@git-docs`** limits (~**400 lines** or ~**48 KiB** per narrative file; split when over).
+6. **Single writer path** — Land improvements via **`internal-write-gh-documentation`** or **`@git-docs`**, not ad-hoc agent edits outside those skills.
+
+---
+
+## Do
+
+- Use this file to **choose** external patterns and **justify** section/table shapes when editing under **`internal-write-gh-documentation`** or **`@git-docs`**.
+
+## Do not
+
+- **Copy** third-party documentation bodies into the repo from this skill alone — **adapt** minimally and attribute or link when required.
+- Run shell, **`git`**, or **`gh`** — read-only reference.
+
+---
+
+## See also
+
+- [`internal-write-gh-documentation`](../../write/gh/documentation/SKILL.md) — polish **existing** markdown
+- [`@git-docs`](../../../git/docs/SKILL.md) — seeds, layout, splits
+- [`internal-read-git-doc-user-guide`](../doc-user-guide/SKILL.md) · [`internal-read-git-doc-reference`](../doc-reference/SKILL.md) · [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md) — greenfield **`wiki-reference-scaffold`** / diagram child skills
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md) — doc hub placement

--- a/.agents/skills/internal-read-git/doc-explanation/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-explanation/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: internal-read-git-doc-explanation
+description: >-
+  Read-only: how to write overview/explanation sections for docs mirror pages from SKILL.md. Callers: @git-docs,
+  internal-write-gh-documentation. Does not write files.
+---
+
+# Internal: Doc explanation rules (`internal-read-git-doc-explanation`)
+
+**Read-only library.** **Normative guidance** for **Overview** / narrative blocks on **`docs/<domain>/.../README.md`** or optional **`docs/.../README.md`** mirror pages.
+
+---
+
+## Rules
+
+1. Derive **what / when / boundaries** from **`SKILL.md`** frontmatter **`description`** and **Do** / **Do not** sections.
+2. **Link** delegates (**`internal-*`**, sibling public skills) with **one line why**.
+3. Avoid speculative roadmaps—describe **current** behavior.
+
+## See also
+
+- [`internal-read-git-doc-index`](../doc-index/SKILL.md)
+- [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md) — when to add **mermaid** + palette
+- [`internal-read-git-doc-index`](../doc-index/SKILL.md) — pair narrative sections with stable page navigation.

--- a/.agents/skills/internal-read-git/doc-graphs/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: internal-read-git-doc-graphs
+description: >-
+  Read-only: when to add mermaid, color/layout conventions; diagram scaffolds in ./diagrams/*/SKILL.md.
+  Optional legacy-graphs-pack-scaffold (legacy GRAPHS.md). Callers: @git-docs. Does not write files.
+---
+
+# Internal: Documentation graphs (`internal-read-git-doc-graphs`)
+
+**Read-only.** **When to diagram** (kind choice), **Mermaid constraints**, **color/layout narrative**, and **diagram scaffolds** all live **here**—**one** library to open for figures. **Hex tables**, **named `classDef`s**, and **copy-paste blocks** live only in **[`diagrams/palette/SKILL.md`](./diagrams/palette/SKILL.md)**, **[`diagrams/examples/SKILL.md`](./diagrams/examples/SKILL.md)**, **`diagrams/scaffold-*/SKILL.md`**. **`[legacy-graphs-pack-scaffold/SKILL.md](./legacy-graphs-pack-scaffold/SKILL.md)`** — optional legacy **`docs/GRAPHS.md`** only.
+
+**Consumers:** scaffold passes, **`@git-docs`**.
+
+## When to add a diagram
+
+- **Flows** (pipelines, hand-offs, branches) → **flowchart** or **sequence** template.
+- **Parallel tracks / subgraphs** → **DAG** template.
+- **States / modes** → **state** template.
+- **User journeys, friction, recovery** → **`diagrams/scaffold-user-journey/SKILL.md`**.
+- **Which option / when to use** → **`diagrams/scaffold-decision/SKILL.md`**.
+- **Actors or lanes** (user, product, support) → **`diagrams/scaffold-stakeholder-flow/SKILL.md`**.
+- **Static-only** folders may use a **small hierarchy** figure or skip if prose suffices.
+
+## Do (diagrams)
+
+- Pick **one** kind template, copy into a **single** fenced **`mermaid`** block with **`classDef`** / **`class`** inlined (**colored**—no monochrome-only narrative diagrams).
+
+## Published shape
+
+- **Where:** fenced **`mermaid`** inside **`docs/**`**, minimal root **`README.md`**, or legacy hubs.
+- **Scaffolds:** one block per **`diagrams/scaffold-*/SKILL.md`** child skill.
+- **Rules:** constraints below + **palette** + **examples** (do **not** duplicate long ramps or sample figures in this file).
+
+## Do not
+
+- Run shell, **`git`**, or **`gh`** from this skill.
+- Duplicate long **palette** / **examples** bodies in this file—link **`diagrams/palette`** / **`diagrams/examples`** child skills instead.
+
+## Mermaid constraints
+
+- **Node IDs:** `camelCase` / `PascalCase` / `snake_case` — **no spaces** in IDs.
+- **Labels** with spaces/special chars: **double-quoted** node text, e.g. `node["/gh-start"]`.
+- **GitHub renderer safety:** quote any label containing `@` (for example `node["@gh-pr"]`) or other special punctuation to avoid parse failures like `LINK_ID` in README/PR/issue rendering. Reference: [GitHub Mermaid docs](https://docs.github.com/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams).
+- **Edge labels** with parens/commas: **quotes**, e.g. `A -->|"O(n)"| B`.
+- **Reserved words:** avoid bare `end`, `subgraph`, `graph`, `flowchart` as IDs; use `endNode`, `subgraph id [Label]`.
+- **Subgraphs:** explicit ids: `subgraph id [Human label]`.
+
+## Color — spine first
+
+**Unique to this file:** narrative for **A→…→B** emphasis (entry-strong vs leaf-strong). **Implementation:** always **`classDef`** + **`class`** at block end; contrast per **`diagrams/palette/SKILL.md`**.
+
+1. **Spine** — pick the main directed path; **A** = entry / trigger, **B** = outcome (or **leaf-strong**: strongest on terminal outcome—**one story per figure**).
+2. **Ramp** — 2–5 `classDef` steps along the spine (mix toward white / lower saturation between anchors); **side branches** muted (`pubM`, `intM`, `neuM`, legacy `hueGhM`, `uxOff`, … per **`diagrams/palette/SKILL.md`**).
+3. **Do not** — rainbow unrelated nodes; identical strong fills everywhere; low-contrast labels.
+
+For skill-pack or agent-architecture figures, prefer domain ramps from **`diagrams/palette/SKILL.md`**: **`pub*`** (public skills), **`hum*`** (human instructions), **`int*`** (internal narrowed skills), with **`neu*`** only for non-skill context.
+
+**Worked colored DAGs** — copy from **`diagrams/examples/SKILL.md`** only.
+
+## Layout
+
+- **TB** — portrait-friendly single column; **LR** — wide pipelines.
+- **Avoid** dense N×M grids; split into two figures or use **`sequenceDiagram`** when time-order dominates vertical space.
+
+## File layout
+
+| File | Role |
+| --- | --- |
+| **`SKILL.md`** (this) | Constraints + layout narrative |
+| **`legacy-graphs-pack-scaffold/SKILL.md`** | Legacy **`docs/GRAPHS.md`** only |
+| [`diagrams/palette/SKILL.md`](./diagrams/palette/SKILL.md) | Named ramps |
+| [`diagrams/scaffold-*/SKILL.md`](./diagrams/) | Per-kind scaffolds |
+| [`diagrams/examples/SKILL.md`](./diagrams/examples/SKILL.md) | Sample figures |
+
+## See also
+
+- [`internal-read-git-doc-exemplars`](../doc-exemplars/SKILL.md) — markdown rubric
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md) — hub contract
+- [`@git-docs`](../../../git/docs/SKILL.md)

--- a/.agents/skills/internal-read-git/doc-graphs/diagrams/diagrams-index/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/diagrams/diagrams-index/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-diagrams-index
+description: >-
+  Read-only: index of mermaid diagram scaffolds. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold index for diagram helpers.
+

--- a/.agents/skills/internal-read-git/doc-graphs/diagrams/examples/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/diagrams/examples/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-examples
+description: >-
+  Read-only: mermaid example figures. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for diagram examples.
+

--- a/.agents/skills/internal-read-git/doc-graphs/diagrams/palette/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/diagrams/palette/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-palette
+description: >-
+  Read-only: mermaid palette (classDef ramps). Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for diagram palette guidance.
+

--- a/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-dag/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-dag/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-dag
+description: >-
+  Read-only: mermaid DAG template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-decision/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-decision/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-decision
+description: >-
+  Read-only: mermaid decision-tree template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-domain-taxonomy/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-domain-taxonomy/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-domain-taxonomy
+description: >-
+  Read-only: mermaid skill-layer flow template (public/human/internal). Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-flowchart/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-flowchart/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-flowchart
+description: >-
+  Read-only: mermaid flowchart template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-sequence/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-sequence/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-sequence
+description: >-
+  Read-only: mermaid sequence diagram template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-stakeholder-flow/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-stakeholder-flow/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-stakeholder-flow
+description: >-
+  Read-only: mermaid stakeholder-flow template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-state/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-state/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-state
+description: >-
+  Read-only: mermaid state diagram template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-user-journey/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/diagrams/scaffold-user-journey/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: internal-read-git-doc-graphs-diagrams-scaffold-user-journey
+description: >-
+  Read-only: mermaid user-journey template. Parent internal-read-git-doc-graphs.
+---
+
+# Canonical internal scaffold
+
+This file is the canonical internal scaffold for this diagram type.
+

--- a/.agents/skills/internal-read-git/doc-graphs/legacy-graphs-pack-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-graphs/legacy-graphs-pack-scaffold/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: internal-read-git-doc-graphs-legacy-graphs-pack-scaffold
+description: >-
+  Read-only compact legacy graph scaffold. Keep this lightweight and link to in-pack skill DAG sources.
+---
+
+# Legacy graphs scaffold (compact)
+
+Use this only for repositories that still keep a legacy graphs page. Keep the content short and rely on in-pack skill links.
+
+## Rules
+
+- Keep diagrams acyclic and focused on core public skills.
+- Do not copy full command lists into this file.
+- Source operational behavior from `skills/**/SKILL.md`.
+
+## Minimal graph
+
+```mermaid
+flowchart TB
+  gitPull["@git-pull"] --> gitReview["@git-review"]
+  gitReview --> gitPush["@git-push"]
+  gitPush --> ghPr["@gh-pr"]
+  ghIssues["@gh-issues"] --> issueCmds["internal-write-gh-issue-commands"]
+  ghPr --> prCmds["internal-write-gh-pr-commands"]
+  cursorPlan[Cursor Plan] -.-> ghIssues
+```
+
+## See also
+
+- [`internal-read-git-doc-graphs`](../SKILL.md)
+- [`internal-read-git-repo-layout`](../../repo-layout/SKILL.md)
+- [`internal-read-git-workflows`](../../workflows/SKILL.md)

--- a/.agents/skills/internal-read-git/doc-index/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-index/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: internal-read-git-doc-index
+description: >-
+  Read-only: rules for doc page indexes (numbered lists, lexicographic order, no tables in Contents). Callers:
+  @git-docs, internal-write-gh-documentation. Does not write files.
+---
+
+# Internal: Doc index rules (`internal-read-git-doc-index`)
+
+**Read-only library.** **Normative rules** for **navigation** sections on **`docs/**`** pages.
+
+**Consumers:** **`@git-docs`**, **`internal-write-gh-documentation`**, **`internal-read-git-readme-tree`** (bootstrap text).
+
+**Default for agents** — When you add or fix **`## Contents`** (or similar nav blocks) in **`README.md`** / **`docs/**`** in **any** project, apply **these rules silently** as part of **`@git-docs`** or **`internal-write-gh-documentation`**—the user does **not** need to name **`internal-read-git-doc-index`** in chat.
+
+---
+
+## Rules
+
+1. **`## Contents`** (and **See also** when it is pure navigation): **numbered nested lists** only.
+2. **Lexicographic** ordering of children (stable convention per repo).
+3. **No markdown tables** for directory listings—GitHub file view is already tabular.
+4. Link to **source** **`SKILL.md`** where the doc mirrors a skill folder.
+
+## Do not
+
+- Duplicate full skeleton bodies here—reuse this file's rules and sibling doc libraries instead.
+
+## See also
+
+- [`internal-read-git-doc-explanation`](../doc-explanation/SKILL.md)
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md)
+- [`docs/README.md`](../../../../docs/README.md)

--- a/.agents/skills/internal-read-git/doc-reference/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-reference/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: internal-read-git-doc-reference
+description: >-
+  Read-only: legacy monolithic docs/REFERENCE.md + docs/reference/wiki templates (migration). Primary narrative
+  is docs/README.md + optional docs/ mirror per internal-read-git-repo-layout. Callers: @git-docs. Does not write files.
+---
+
+# Internal: Reference documentation template (`internal-read-git-doc-reference`)
+
+**Read-only library.** **Current** default narrative: **`docs/README.md`** + optional **`docs/`** mirror (**[`internal-read-git-repo-layout`](../repo-layout/SKILL.md)**). **Other** repos may add a **profile** wiki per **`internal-read-git-doc-wiki`**—**cursor-skills** does not ship **`docs/wiki/`**. This skill supplies **extra** **migration / legacy** tracks when a repo still wants **`docs/reference/**`** or **`docs/REFERENCE.md`**:
+
+1. **Legacy single file** — **[`wiki-reference-scaffold/SKILL.md`](./wiki-reference-scaffold/SKILL.md)** → **`docs/REFERENCE.md`** (monolithic catalog).
+2. **Legacy split wiki** — skill-local **[`reference-readme-scaffold/SKILL.md`](./reference-readme-scaffold/SKILL.md)**, **[`docs-hub-scaffold/SKILL.md`](./docs-hub-scaffold/SKILL.md)** → hub pages under **`docs/reference/**`** (older style; prefer **`docs/README.md`** + domain indexes for greenfield).
+
+**Consumers:** **Manual** scaffold (when user keeps or migrates **`docs/**`**), **`@git-docs`**.
+
+---
+
+## Do
+
+- For **wiki layout**, copy from **`docs/`** (this pack) or your repo’s existing **`docs/`** first, then split catalogs into **`docs/reference/*.md`** when **`wiki-reference-scaffold/SKILL.md`** would exceed **`@git-docs`** size limits.
+- For **legacy** repos, copy **`wiki-reference-scaffold/SKILL.md`** into **`docs/REFERENCE.md`**; replace placeholder rows with real skills.
+- Keep **public** skills **before** **internal** in any catalog tables.
+- Use consistent table columns (**Invoke** | **Source** | **Description**) or document your variant once per repo.
+
+## Do not
+
+- Run commands or edit the filesystem from this skill.
+
+---
+
+## Rendered paths
+
+| Layout | Paths |
+| --- | --- |
+| **Profile wiki** (preferred) | Often **`docs/README.md`** alone (**minimal**); or expanded sections per **`internal-read-git-doc-wiki`** when you need deeper hubs |
+| **Optional skills mirror** | **`docs/.../README.md`** (full tree when opted in) |
+| Minimal root | **`README.md`** at repo root |
+| Legacy wiki | **`docs/README.md`**, **`docs/reference/**`** |
+| Legacy monolith | **`docs/REFERENCE.md`** |
+| Flat variant | **`REFERENCE.md`** at repo root |
+
+---
+
+## See also
+
+- [`internal-read-git-doc-wiki`](../doc-wiki/SKILL.md) — doc depth orientation
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md) — hub contract
+- [`internal-read-git-doc-exemplars`](../doc-exemplars/SKILL.md) — markdown patterns + rubric
+- [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md) — diagram authoring (not required **`GRAPHS.md`**)
+- [`internal-read-git-doc-user-guide`](../doc-user-guide/SKILL.md) — **`USER_GUIDE.md`**
+- [`internal-read-git-readme-root`](../readme-root/SKILL.md) — root **`README.md`**

--- a/.agents/skills/internal-read-git/doc-reference/docs-hub-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-reference/docs-hub-scaffold/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: internal-read-git-doc-reference-docs-hub-scaffold
+description: >-
+  Read-only: docs hub README scaffold. Parent internal-read-git-doc-reference.
+---
+
+# Documentation index
+
+**Repository:** <name> — <one-line purpose>.
+
+Use this as a **wiki hub** starter when `docs/` is the human-facing surface and `skills/**/SKILL.md` remains normative.
+
+---
+
+## 📑 Contents
+
+1. [Location map](#location-map)
+2. [Browse](#browse)
+3. [Common commands](#common-commands)
+4. [Diagram policy](#diagram-policy)
+5. [See also](#see-also)
+
+---
+
+## 🧩 Location map
+
+| Location | Purpose |
+| --- | --- |
+| [`docs/README.md`](README.md) | Hub index and routing for human readers. |
+| [`docs/git.md`](git.md) | Public/local git workflow wiki. |
+| [`docs/gh.md`](gh.md) | GitHub issue/PR workflow wiki. |
+| [`docs/internal.md`](internal.md) | Internal read/write library map. |
+| [`skills/**/SKILL.md`](../skills/) | Source of truth for contracts and behavior. |
+
+---
+
+## 🧩 Browse
+
+| Topic | Description |
+| --- | --- |
+| [reference/README.md](reference/README.md) | Start here — map of reference pages |
+| <add more rows> | <link each `docs/reference/*.md`> |
+
+---
+
+## 🧩 Common commands
+
+1. `@git-review` for verification.
+2. `@git-docs` for in-place doc corrections.
+3. `@git-push` for commit + publish.
+4. `@gh-pr` after pull + push for PR metadata.
+
+---
+
+## 🧩 Diagram policy
+
+- Diagrams are welcome in the hub and key flow pages, but avoid adding Mermaid blocks everywhere.
+- Keep 0-2 diagrams per page unless the workflow is genuinely complex.
+- For GitHub rendering safety, quote labels containing special characters (for example `node["@gh-pr"]`).
+- For palette and scaffold examples, use [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md).
+
+---
+
+## 🔗 See also
+
+- **[docs/git.md](../../../../../docs/git.md)**, **[docs/gh.md](../../../../../docs/gh.md)**, **[docs/internal.md](../../../../../docs/internal.md)** — agent skills by domain (**this** pack)
+- **Pasteables** under **`docs/`**: see *Folder and file index* in [reference/README.md](reference/README.md) or your legacy [REFERENCE.md](REFERENCE.md)

--- a/.agents/skills/internal-read-git/doc-reference/reference-readme-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-reference/reference-readme-scaffold/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: internal-read-git-doc-reference-reference-readme-scaffold
+description: >-
+  Read-only: root README long-form scaffold. Parent internal-read-git-doc-reference.
+---
+
+# Reference wiki
+
+Deep dives and catalogs. **Diagrams:** use self-contained **`mermaid`** in each page; **color and spine** rules live only in **`internal-read-git-doc-graphs`** (**`SKILL.md`** + **`diagrams/*/SKILL.md`**)—do not paste authoring appendix tables into published docs.
+
+---
+
+## Contents
+
+| Page | Description |
+| --- | --- |
+| <e.g. [skills.md](skills.md)> | <Public + internal skill summaries — link to `SKILL.md`> |
+| <e.g. [pipelines.md](pipelines.md)> | <Verify / PR / context flows> |
+
+---
+
+## Folder and file index
+
+Link every domain **`README.md`** under **`skills/`** (and other top-level folders) so readers can jump from wiki to subtree owners.
+
+- **[docs/git.md](../../../../../docs/git.md)**, **[docs/gh.md](../../../../../docs/gh.md)**, **[docs/internal.md](../../../../../docs/internal.md)** (domain docs for `skills/`, **this** pack)
+- <add per-domain READMEs>
+
+---
+
+## Template sources (internal)
+
+| Role | Skill |
+| --- | --- |
+| Wiki hub | `internal-read-git-doc-reference` — child **`SKILL.md`** bodies (e.g. **`wiki-reference-scaffold`**) + repo **`docs/`** |
+| User guide | `internal-read-git-doc-user-guide` |
+| Diagram authoring | `internal-read-git-doc-graphs` |
+| Root / folder README | `internal-read-git-readme-root`, `internal-read-git-readme-tree` |
+
+---
+
+## Related
+
+- [Documentation index](../SKILL.md)
+- [USER_GUIDE.md](../USER_GUIDE.md)

--- a/.agents/skills/internal-read-git/doc-reference/wiki-reference-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-reference/wiki-reference-scaffold/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: internal-read-git-doc-reference-wiki-reference-scaffold
+description: >-
+  Read-only: legacy REFERENCE/wiki page scaffold. Parent internal-read-git-doc-reference.
+---
+
+# Skills reference
+
+Complete catalog of **every** skill in this repository: **public** skills first (user-invoked under `skills/git/` and `skills/gh/`), then **internal** libraries (`skills/<domain>/`). Invocation: `/flattened-name` or `@flattened-name` (path under `skills/` with `/` → `-`, e.g. `skills/gh/pr/SKILL.md` → **`gh-pr`**).
+
+**Install:** [README.md](../README.md) · **Doc index:** [README.md](README.md) (wiki) or this file (legacy) · **Workflows:** [USER_GUIDE.md](USER_GUIDE.md)
+
+---
+
+## Documentation set (`docs/`)
+
+**Preferred (wiki):** [README.md](README.md), [USER_GUIDE.md](USER_GUIDE.md), **`reference/**`** — scaffold **manual / agent-led** from **`internal-read-git-doc-reference`** child skills (**`reference-readme-scaffold`**, **`docs-hub-scaffold`**, …) **confirm-first**. **Legacy:** this monolithic **[REFERENCE.md](REFERENCE.md)**; optional **[GRAPHS.md](GRAPHS.md)**. Templates stay in **`skills/read/git/doc-*`**.
+
+| Path | Role |
+| --- | --- |
+| [README.md](README.md) | Doc hub index (wiki layout) |
+| [reference/README.md](reference/README.md) | Reference wiki start page |
+| [REFERENCE.md](REFERENCE.md) | This file — legacy full catalog |
+| [USER_GUIDE.md](USER_GUIDE.md) | Install, prerequisites, workflows |
+| [GRAPHS.md](GRAPHS.md) | Optional legacy diagram file |
+
+---
+
+## Folder and file index
+
+Hub **READMEs** (subtree scope and **Related** links)—use with **`docs/reference/**`** or small **mermaid** in each **README** when a diagram helps:
+
+- **[`docs/git.md`](../../../../../docs/git.md)**, **[`docs/gh.md`](../../../../../docs/gh.md)**, **[`docs/internal.md`](../../../../../docs/internal.md)** — domain wikis (**this** pack)
+- **`skills/git/**`**, **`skills/gh/**`**, **`skills/read/**`**, **`skills/write/**`** — normative **`SKILL.md`** per folder
+- **[`skills/write/plan/`](../../../../write/plan/)** — structured Q&A + safety (**`internal-write-plan-structured-qa`**, **`internal-write-plan-skill-safety`**)
+- **[`skills/read/git/SKILL.md`](../../../../read/git/SKILL.md)**, **[`skills/read/gh/SKILL.md`](../../../../read/gh/SKILL.md)**, **[`skills/read/plan/SKILL.md`](../../../../read/plan/SKILL.md)** — library root indexes
+
+**Scaffold sources** — **`skills/read/git/doc-index/`** skeleton child skills + diagram scaffolds under **`internal-read-git-doc-graphs`**, plus other **`internal-read-git-doc-*`** child **`SKILL.md`** bodies. **`@git-docs`** only aligns **existing** pages **in place**—it does **not** add new **`docs/`** files from scaffolds alone.
+
+| Scaffold role | Skill | Location |
+| --- | --- | --- |
+| **`docs/README.md`** + **`docs/reference/**`** | [`internal-read-git-doc-reference`](../SKILL.md) | [`reference-readme-scaffold/SKILL.md`](../reference-readme-scaffold/SKILL.md), [`docs-hub-scaffold/SKILL.md`](../docs-hub-scaffold/SKILL.md) |
+| **`docs/REFERENCE.md`** (legacy) | same | [`wiki-reference-scaffold/SKILL.md`](./SKILL.md) |
+| **Optional `docs/GRAPHS.md`** | [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md) | [`../doc-graphs/legacy-graphs-pack-scaffold/SKILL.md`](../doc-graphs/legacy-graphs-pack-scaffold/SKILL.md) |
+| **`docs/USER_GUIDE.md`** | [`internal-read-git-doc-user-guide`](../doc-user-guide/SKILL.md) | [`../doc-user-guide/user-guide-scaffold/SKILL.md`](../doc-user-guide/user-guide-scaffold/SKILL.md) |
+| **Root `README.md`** | [`internal-read-git-readme-root`](../readme-root/SKILL.md) | skill body + exemplar § |
+| **`docs/...` mirror `README.md`** | [`internal-read-git-readme-tree`](../readme-tree/SKILL.md) | Rules in **`SKILL.md`**; optional examples under [`doc-index/`](../doc-index/) |
+
+---
+
+## Public skills
+
+### Local git (`skills/git/`)
+
+| Invoke | Source | Description |
+| --- | --- | --- |
+| **`@git-review`** | [`skills/git/review/SKILL.md`](../../../../git/review/SKILL.md) | *Discover → install → evaluate → §8a docs.* |
+| **`@git-docs`** | [`skills/git/docs/SKILL.md`](../../../../git/docs/SKILL.md) | *Post-green doc accuracy: existing `.md` in place only; may no-op; Q&A for scope.* |
+| **`@git-main`** | [`skills/git/main/SKILL.md`](../../../../git/main/SKILL.md) | *Align to canonical main.* |
+| **`@git-pull`** | [`skills/git/pull/SKILL.md`](../../../../git/pull/SKILL.md) | *Fetch + merge main + conflicts playbook.* |
+| **`@git-push`** | [`skills/git/push/SKILL.md`](../../../../git/push/SKILL.md) | *Inventory → `@git-commit` if needed → branch gate → push.* |
+| **`@git-reset`** | [`skills/git/reset/SKILL.md`](../../../../git/reset/SKILL.md) | *Reset to target ref.* |
+| **`@git-start`** | [`skills/git/start/SKILL.md`](../../../../git/start/SKILL.md) | *Dirty-tree gate → @git-main → new branch → optional @git-push.* |
+| **`@git-zip`** | [`skills/git/zip/SKILL.md`](../../../../git/zip/SKILL.md) | *Orchestrates `@git-tag` when needed, then `git archive` export (GitHub-style); runnable blocks in `internal-write-git-zip`.* |
+
+### GitHub (`skills/gh/`)
+
+| Invoke | Source | Description |
+| --- | --- | --- |
+| **`@gh-pr`** | [`skills/gh/pr/SKILL.md`](../../../../gh/pr/SKILL.md) | *@git-pull → @git-review → @git-push → PR description → `gh pr`.* |
+| **`@gh-pr-*`** (list, view, close, skills) | [`skills/gh/pr/`](../../../../gh/pr/) | *PR helpers; create/edit only via **`@gh-pr`**; list **`internal-read-gh-pr-list`**; mutations **`internal-write-gh-pr-commands`**; hub **[`list-view-hub/SKILL.md`](../../../../read/gh/pr-list/list-view-hub/SKILL.md)**.* |
+| **`@gh-issue-*`** (create, list, view, pick, edit, close, delete-closed) | [`skills/gh/issues/`](../../../../gh/issues/) | *Issues CRUD + dedupe + label helpers; list **`internal-read-gh-issue-list`**; view/mutations **`internal-write-gh-issue-commands`**; template **`gh repo view`** in **`internal-read-gh-repo-forms-json`**.* |
+
+---
+
+## Internal skills
+
+Libraries under `skills/<domain>/`. Flattened names: path with `/` → `-` (e.g. `write/gh/evaluate` → **`internal-write-gh-evaluate`**).
+
+### Agent (`skills/write/plan/`)
+
+| Invoke | Source | Description |
+| --- | --- | --- |
+| **`internal-write-plan-structured-qa`** | [`skills/write/plan/structured-qa/SKILL.md`](../../../../write/plan/structured-qa/SKILL.md) | *AskQuestion / confirm UX.* |
+| **`internal-write-plan-skill-safety`** | [`skills/write/plan/skill-safety/SKILL.md`](../../../../write/plan/skill-safety/SKILL.md) | *What needs confirm.* |
+
+### Internal libraries (verify + docs + `gh`)
+
+| Invoke | Source | Description |
+| --- | --- | --- |
+| **`internal-read-git-configuration`** | [`../../../../read/git/configuration/SKILL.md`](../../../../read/git/configuration/SKILL.md) | *Resolve format/lint/test commands.* |
+| **`internal-read-git-discover-dependencies`** | [`../../../../read/git/discover-dependencies/SKILL.md`](../../../../read/git/discover-dependencies/SKILL.md) | *Scan repo for stacks and gaps.* |
+| **`internal-write-gh-documentation`** | [`../../../../write/gh/documentation/SKILL.md`](../../../../write/gh/documentation/SKILL.md) | *Sharpen existing markdown — §8a.* |
+| **`internal-read-git-readme-tree`** | [`../readme-tree/SKILL.md`](../readme-tree/SKILL.md) | *Read-only mirror bootstrap + checklist.* |
+| **`internal-write-gh-evaluate`** | [`../../../../write/gh/evaluate/SKILL.md`](../../../../write/gh/evaluate/SKILL.md) | *Run verify matrix.* |
+| **`internal-write-gh-install-dependencies`** | [`../../../../write/gh/install-dependencies/SKILL.md`](../../../../write/gh/install-dependencies/SKILL.md) | *Install / build — §3.* |
+| **`internal-read-git-repo-layout`** | [`../repo-layout/SKILL.md`](../repo-layout/SKILL.md) | *Layout rules — read-only.* |
+| **`internal-read-gh-repo-forms-json`** | [`../../../../read/gh/repo-forms-json/SKILL.md`](../../../../read/gh/repo-forms-json/SKILL.md) | *Sole `gh repo view --json` shapes for issue/PR templates.* |
+| **`internal-read-gh-pr-description`** | [`../../../../read/gh/pr-description/SKILL.md`](../../../../read/gh/pr-description/SKILL.md) | *PR templates + delta + title/body.* |
+| **`internal-read-gh-pr-body-sections`** | [`../../../../read/gh/pr-body-sections/SKILL.md`](../../../../read/gh/pr-body-sections/SKILL.md) | *Static PR body patterns.* |
+| **`internal-read-gh-issue-list`** | [`../../../../read/gh/issue-list/SKILL.md`](../../../../read/gh/issue-list/SKILL.md) | *`gh issue list` / `gh search issues` (read-only).* |
+| **`internal-write-gh-issue-commands`** | [`../../../../write/gh/issue-commands/SKILL.md`](../../../../write/gh/issue-commands/SKILL.md) | *`gh issue` view/create/edit/close/delete.* |
+| **`internal-read-gh-pr-list`** | [`../../../../read/gh/pr-list/SKILL.md`](../../../../read/gh/pr-list/SKILL.md) | *`gh pr list` / `view` / `diff --stat` (read-only).* |
+| **`internal-write-gh-pr-commands`** | [`../../../../write/gh/pr-commands/SKILL.md`](../../../../write/gh/pr-commands/SKILL.md) | *`gh pr create`, `gh pr edit`, `gh pr close`.* |
+| **`internal-read-git-doc-graphs`** | [`../doc-graphs/SKILL.md`](../doc-graphs/SKILL.md) | *README mermaid rules + `diagrams/`.* |
+| **`internal-read-git-doc-reference`** | [`../SKILL.md`](../SKILL.md) | *REFERENCE.md template.* |
+| **`internal-read-git-doc-user-guide`** | [`../doc-user-guide/SKILL.md`](../doc-user-guide/SKILL.md) | *USER_GUIDE.md template.* |
+| **`internal-read-git-doc-exemplars`** | [`../doc-exemplars/SKILL.md`](../doc-exemplars/SKILL.md) | *Public markdown patterns + adoption rubric.* |
+| **`internal-read-git-readme-root`** | [`../readme-root/SKILL.md`](../readme-root/SKILL.md) | *Root README template.* |
+| *…* | *…* | *`repo-stream`, `merge-conflicts`, `git-diff-summary`, …* |
+
+---
+
+## Pipeline order (verify)
+
+**`@git-review`:** discover-dependencies → install-dependencies → configuration → evaluate → internal-write-gh-documentation (§8a). Diagram: [GRAPHS.md](GRAPHS.md).
+
+---
+
+## See also
+
+- [Skills graphs](GRAPHS.md)
+- [User guide](USER_GUIDE.md)
+- [install.sh](../install.sh) — if your pack uses a copy script

--- a/.agents/skills/internal-read-git/doc-table/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-table/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: internal-read-git-doc-table
+description: >-
+  Read-only: markdown table conventions for doc reference sections (not indexes). Callers: @git-docs,
+  internal-write-gh-documentation. Does not write files.
+---
+
+# Internal: Doc table rules (`internal-read-git-doc-table`)
+
+**Read-only library.** **When** to use **markdown tables** on **`docs/`** pages: **reference** and **comparison** sections only—not **`## Contents`**.
+
+**Default for agents** — Whenever you touch a **markdown table** in **reference** material (including root **`README.md`** and **`docs/**`** in **any** Cursor project), apply **these rules silently** as part of **`@git-docs`**, **`internal-write-gh-documentation`**, or ad-hoc doc polish—the user does **not** need to name **`internal-read-git-doc-table`** in chat.
+
+---
+
+## Rules
+
+1. **Sort** rows by **first column** lexicographically.
+2. After the table, **call out** the **largest** row by the chosen metric and **why** it matters.
+3. Optional **summary** prose for aggregates—avoid double-counting with child pages.
+
+## See also
+
+- [`internal-read-git-doc-index`](../doc-index/SKILL.md)
+- [`internal-read-git-doc-explanation`](../doc-explanation/SKILL.md)

--- a/.agents/skills/internal-read-git/doc-user-guide/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-user-guide/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: internal-read-git-doc-user-guide
+description: >-
+  Read-only: TEMPLATE.md for legacy docs/USER_GUIDE.md (migration). README-only repos fold narrative into
+  internal-read-git-readme-root / root README. Callers: @git-docs. Does
+  not write files.
+---
+
+# Internal: User guide template (`internal-read-git-doc-user-guide`)
+
+**Read-only library.** Canonical **body** for **legacy** **`docs/USER_GUIDE.md`** when a repo still uses a **`docs/`** hub. **Default** for this pack: fold the same material into **root `README.md`** (**[`internal-read-git-readme-root`](../readme-root/SKILL.md)**). Full source: **`[TEMPLATE.md](./TEMPLATE.md)`**.
+
+**Consumers:** **`@git-docs`** when maintaining **`docs/USER_GUIDE.md`** in a legacy tree; otherwise prefer **`internal-read-git-readme-root`**.
+
+---
+
+## Do
+
+- **Install from scratch** (especially **macOS** **Terminal**, **raw** `brew` / `git` / `gh` commands).
+- Describe **happy path** workflows (e.g. **`gh-start` → work → `gh-pr`**).
+- Point **short** install blurbs at root **`README.md`**; keep **catalogs** under **`docs/*.md`** hubs (**this** pack: **`docs/git.md`**, **`docs/gh.md`**, **`docs/internal.md`**) or optional wiki-only layouts on other repos, or, in legacy repos, **`docs/reference/**`** / **`REFERENCE.md`**.
+- Document **`.cursor/`** or project-local artifact dirs with a **who writes what** table.
+
+## Do not
+
+- Duplicate long wiki tables — link **`docs/README.md`** (**this** pack), optional **`docs/README.md`**, or **`docs/reference/**`** (legacy).
+
+---
+
+## Rendered path
+
+| Layout | Path |
+| --- | --- |
+| **Domain docs** (**this** pack) | **`docs/README.md`** + **`docs/git.md`** / **`docs/gh.md`** / **`docs/internal.md`** — **[`internal-read-git-repo-layout`](../repo-layout/SKILL.md)** |
+| Legacy hub | **`docs/USER_GUIDE.md`** |
+| Variant | **`USER_GUIDE.md`** at repo root |
+
+---
+
+## See also
+
+- [`internal-read-git-doc-exemplars`](../doc-exemplars/SKILL.md) — public markdown patterns + rubric
+- [`internal-read-git-doc-reference`](../doc-reference/SKILL.md)
+- [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md)
+- [`internal-read-git-doc-wiki`](../doc-wiki/SKILL.md) — doc depth orientation
+- [`@git-docs`](../../../git/docs/SKILL.md)

--- a/.agents/skills/internal-read-git/doc-user-guide/user-guide-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-user-guide/user-guide-scaffold/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: internal-read-git-doc-user-guide-user-guide-scaffold
+description: >-
+  Read-only: legacy USER_GUIDE scaffold. Parent internal-read-git-doc-user-guide.
+---
+
+---
+template_for: docs/USER_GUIDE.md
+source_skill: internal-read-git-doc-user-guide
+instructions: >-
+  Copy into docs/USER_GUIDE.md. Replace skill names and paths with your pack. Link install to root README.
+---
+
+# User guide
+
+**Purpose:** **install from scratch**, **prerequisites**, **workflows**, **per-repo storage**, **troubleshooting**. Use **raw Terminal commands** (especially on **macOS**). **README-only repos:** fold this into **root `README.md`**; catalogs live in **`docs/README.md`** plus **`docs/git.md`**, **`docs/gh.md`**, **`docs/internal.md`**, … (**this** pack) or optional **`docs/`** mirror. **Legacy:** deep catalogs in **`docs/reference/**`** or **[REFERENCE.md](REFERENCE.md)**; hub index **`docs/README.md`** if present.
+
+**Root** **`README.md`** stays short; **`docs/<domain>/`** documents domains (**this** pack), or optional **`docs/.../README.md`** mirrors the **`skills/`** tree on other repos (no per-folder README under **`skills/`** when using that mirror policy).
+
+---
+
+## Prerequisites (macOS)
+
+Run in **Terminal** (replace versions with what your project needs).
+
+```bash
+# Xcode CLI tools (if prompted)
+xcode-select --install
+
+# Homebrew (if missing) — see https://brew.sh
+# /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Example toolchains (adapt)
+brew install git
+brew install gh && gh auth login
+# brew install node@22   # if your pack needs Node
+```
+
+**Cursor:** install the editor from vendor instructions; restart after adding skills. **Skills install:** from repo root, `./install.sh` (or your pack’s script)—see root **README**.
+
+---
+
+## Diagrams
+
+Prefer **small `mermaid` blocks** in **folder `README.md`** / **root `README.md`** (README-only), or in **`docs/reference/**`** (legacy). **Color / spine rules:** **`internal-read-git-doc-graphs`** **`SKILL.md`** + **`diagrams/`** child skills—optional legacy **`docs/GRAPHS.md`**, not default. Optional PNG export: **`diagrams/diagrams-index/SKILL.md`** in that library.
+
+---
+
+## Workflows
+
+Open a **target git repo** in Cursor. Invoke with `/skill-name` or `@skill-name`.
+
+| Goal | Skills |
+| --- | --- |
+| Issue → implement → PR | `@gh-issue-pick` / `@gh-issue-view` → `@git-start` → `@gh-pr` (runs pull, review, push, then PR) |
+| Verify (no push) | `@git-review` |
+| Commit + push | `@git-push` |
+| Pull request | `@gh-pr` (full chain: `@git-pull` → `@git-review` → `@git-push` → PR text) |
+| New branch from clean `main` | `@git-start` |
+| Doc accuracy (existing files, after green verify) | `@git-docs` — **not** part of **`@git-review`** evaluate; run after **`@git-review`** when you need a broader in-place pass |
+
+**Typical task:** **`@git-start`** creates a branch and runs **`@git-push`** (commit-if-needed + publish). Run **`@git-review`** before PR work if you want green locally first, or rely on **`@gh-pr`** which runs **`@git-review`** then **`@git-push`**, then PR text and **`gh pr create` / `edit`**.
+
+---
+
+## Documentation workflow
+
+| Situation | Skill | Notes |
+| --- | --- | --- |
+| Greenfield or missing mirror / large `docs/` reshuffle | Normal change set | Add or move **`docs/`** paths in git like any other source; use **`internal-read-git-readme-tree`** + **`internal-read-git-repo-layout`** as guides; **`internal-write-plan-skill-safety`** when the diff is huge. |
+| After code changes, before commit | `@git-commit` or `@git-push` §1–2 | **`@git-commit`** for a local savepoint; **`@git-push`** runs inventory then **`@git-commit`** only when needed. For doc-only tweaks before commit, **`@git-docs`** (existing **`.md`** in place). **New** paths → add them in a normal edit first. |
+| After tests pass (verify pipeline) | `@git-review` §8a | §8a light polish on **existing** paths (**`internal-write-gh-documentation`**). |
+
+Do **not** use **`@git-review`** alone to **reshape** the whole doc tree for big moves — do that as explicit file edits with the usual review and safety confirms.
+
+---
+
+## Per-repo storage (`<project>/.cursor/`)
+
+Optional **`.cursor/`** snippets — copy subtrees from this pack’s **`docs/`** (and diagram scaffolds under **`skills/read/git/doc-graphs/diagrams/`**) (see root **`README.md`** and **`docs/README.md`**). **`@git-zip`** writes the **`.zip`** **outside** the repo root by default—confirm paths per **`internal-write-plan-skill-safety`**.
+
+---
+
+## Troubleshooting
+
+| Issue | What to try |
+| --- | --- |
+| Skill not listed | Re-run your install script; restart Cursor |
+| Stack not detected | README + CI config at repo root |
+| Checks fail | Install toolchains; re-run `@git-review` |
+| `gh` CLI missing | Install GitHub CLI and `gh auth login` |
+
+---
+
+## See also
+
+- **[Skills reference](REFERENCE.md)**
+- **[Skills graphs](GRAPHS.md)**
+- **[Root README](../README.md)**

--- a/.agents/skills/internal-read-git/doc-wiki/SKILL.md
+++ b/.agents/skills/internal-read-git/doc-wiki/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: internal-read-git-doc-wiki
+description: >-
+  Read-only: light orientation for how deep docs/ can go on other repositories; this pack uses docs/README.md + docs/
+  mirror only. No structural scaffold workflow in pack skills. Does not write files.
+---
+
+# Internal: Doc depth orientation (`internal-read-git-doc-wiki`)
+
+**Read-only.** **This repository** (**cursor-skills**): documentation is **`docs/README.md`** (hub) + **`docs/`** mirroring **`skills/`**. There is **no** separate **`docs/wiki/`** profile tree checked in here.
+
+**Other repositories** may grow richer **`docs/`** trees (architecture notes, runbooks, per-service hubs). This skill **does not** prescribe manifests, bulk scaffolds, or agent-driven “wiki regen”—those are **normal repo edits** outside this pack’s **`@git-*`** shortcuts.
+
+**Consumers:** **`internal-read-git-repo-layout`**, **`internal-write-gh-documentation`**, **`internal-read-git-doc-reference`**, **`internal-read-git-repo-classification`** (optional hints only).
+
+## Bootstrap hints (when starting from scratch)
+
+1. **Pick hub depth** — Smallest useful surface is **`docs/README.md`** + links; add domain wikis (**`docs/git.md`**, **`docs/gh.md`**, …) when **`@`** skills multiply.
+2. **Keep domains aligned** — Mirror **`skills/`** folder names under **`docs/`** when you want a wiki beside the pack (**`internal-read-git-repo-layout`**).
+3. **API / schema docs** — Add **`docs/api/`** (or similar) only when the repo actually ships HTTP/GraphQL/proto contracts worth documenting (**`internal-read-git-discover-dependencies`** can hint at signals).
+4. **Shape** — Indexes, tables, diagrams: **`internal-read-git-doc-index`**, **`internal-read-git-doc-table`**, **`internal-read-git-doc-graphs`**, **`internal-read-git-doc-explanation`**.
+5. **Hub starter** — For a cursor-skills-style docs hub scaffold, start from **`internal-read-git-doc-reference/docs-hub-scaffold/SKILL.md`**.
+
+## Do not
+
+- Run commands or write files from this skill.
+- Treat this file as a mandatory multi-folder **`docs/wiki/`** scaffold for every consumer of the pack.
+
+## See also
+
+- [`internal-read-git-repo-classification`](../repo-classification/SKILL.md)
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md)
+- [`internal-read-git-readme-tree`](../readme-tree/SKILL.md)
+- [`docs/README.md`](../../../../docs/README.md)

--- a/.agents/skills/internal-read-git/docs-mirror-bootstrap/SKILL.md
+++ b/.agents/skills/internal-read-git/docs-mirror-bootstrap/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: internal-read-git-docs-mirror-bootstrap
+description: >-
+  Read-only: bootstrap docs/ mirror pages from README inventory using canonical internal doc libraries.
+---
+
+# Internal: docs mirror bootstrap
+
+**Read-only.** Use this when creating a docs mirror for the first time or after a large layout change. This is not part of `@git-review` and does not replace in-place updates from `@git-docs`.
+
+## Inputs
+
+- Repository root.
+- Scope (`skills/` subtree only, or full repository).
+
+## Steps
+
+1. Enumerate candidate `README.md` files in the chosen scope.
+2. Decide which paths should have a docs mirror page.
+3. Map each source path to a `docs/<parallel-path>/README.md` target.
+4. Draft each target page using canonical doc libraries:
+   - [`internal-read-git-doc-index`](../doc-index/SKILL.md)
+   - [`internal-read-git-doc-explanation`](../doc-explanation/SKILL.md)
+   - [`internal-read-git-doc-table`](../doc-table/SKILL.md) when reference tables are needed
+5. Apply wiki/layout constraints from:
+   - [`internal-read-git-repo-layout`](../repo-layout/SKILL.md)
+   - [`internal-read-git-doc-index`](../doc-index/SKILL.md)
+6. For diagram-heavy pages, use [`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md) and child templates.
+
+## Do not
+
+- Treat this as continuous mirror regeneration.
+- Replace `@git-docs` or `internal-write-gh-documentation` for routine in-place doc alignment.

--- a/.agents/skills/internal-read-git/git-diff-summary/SKILL.md
+++ b/.agents/skills/internal-read-git/git-diff-summary/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: internal-read-git-git-diff-summary
+description: >-
+  Read-only: local git diff/log narrative for PR evidence (no GitHub API). PR delta evidence contract and narrative
+  clustering for What changed. Command shapes live in delta-narrative/SKILL.md.
+  Caller: internal-read-gh-pr-description §6.
+---
+
+# Internal: Git diff summary (`internal-read-git-git-diff-summary`)
+
+**Read-only library.** **Local `git` only** (no **`gh`** / GitHub REST). **Sole owner** of the **evidence contract** and **inventory discipline** for computing the merge-aware delta from destination to **`HEAD`** for PR drafting. **Command and narrative shape:** **[`delta-narrative/SKILL.md`](./delta-narrative/SKILL.md)**.
+
+**Consumers:** **`internal-read-gh-pr-description`** §6 (run this skill **in full** before §7); humans writing commits; **`@gh-pr`** orchestration.
+
+---
+
+## Do
+
+1. **Inventory** by **theme** / subsystem, not raw file list (unless tiny branch).
+2. Use **[`delta-narrative/SKILL.md`](./delta-narrative/SKILL.md)** for the delta commands after **`@git-pull`** / **`@git-push`** in the PR flow.
+3. **Reuse** the same summary discipline for **commit** and **PR** to avoid drift.
+4. Point agents to **`delta-narrative/SKILL.md`** for copy-paste structure and short commit messages.
+
+## Do not
+
+- Run PR mutations.
+- Duplicate delta evidence steps inside **`internal-read-gh-pr-description`** — that skill **delegates** §6 here.
+
+## Evidence Contract
+
+Use the destination and **`HEAD`** values from **`@gh-pr`** / **`internal-read-gh-repo-stream`**. Output is for **drafting accuracy** and **triple pass** in **`internal-read-gh-pr-description`** §7—**do not** paste base/head identifiers, commit counts, or compare metadata into the PR body.
+
+**Full-branch coverage (required):** The PR description must reflect the **entire** meaningful delta from destination to **`HEAD`**.
+
+1. **Area checklist** — Build from the merge-aware file list and group paths by top-level directory / concern (e.g. **`skills/`**, **`docs/`**, **`.github/`**, **`README.md`**).
+2. **Commit themes** — Cluster the branch history across the whole branch.
+3. **Optional sanity checks** — Use the template when the graph is messy or the range looks surprising.
+4. **Destination and head pins** — Keep these internal for accuracy; do not post them in the PR body.
+
+**Short history** (roughly **≤ ~12** commits, one clear theme): you may **weave** commit themes into narrative bullets without pasting the log.
+
+**Long or multi-era history:** **do not** dump the raw log. **Summarize** older phases in **1–3 tight bullets** each.
+
+## Template
+
+- **[`delta-narrative/SKILL.md`](./delta-narrative/SKILL.md)** — delta commands, command range notes, and commit/PR narrative shape.
+
+## See also
+
+- [`internal-read-gh-pr-content`](../gh/pr-content/SKILL.md)
+- [`internal-read-gh-pr-description`](../gh/pr-description/SKILL.md)
+- [`delta-narrative/SKILL.md`](./delta-narrative/SKILL.md)
+- [`title-line`](../gh/pr-content/title-line/SKILL.md)

--- a/.agents/skills/internal-read-git/git-diff-summary/delta-narrative/SKILL.md
+++ b/.agents/skills/internal-read-git/git-diff-summary/delta-narrative/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: internal-read-git-git-diff-summary-delta-narrative
+description: >-
+  Read-only: git log/diff recipes and PR/commit narrative shape; optional full commit-body log for issue keywords.
+  Parent internal-read-git-git-diff-summary.
+---
+
+# Git diff summary (commit message or PR prep)
+
+Reusable shape for summarizing **`git diff`** or **`$BASE_GIT..HEAD`** before writing a **commit message** or **PR body**. **Normative PR delta commands** live here; **`internal-read-git-git-diff-summary`** owns when and how agents use the evidence.
+
+---
+
+## Steps (human or agent)
+
+1. **Inventory** — List changed **areas** (top-level dirs or subsystems), not every file, unless the branch is tiny. Run **`git diff --name-status "$BASE_GIT...HEAD"`** and group by concern.
+2. **Themes** — From **`git log --oneline "$BASE_GIT..HEAD"`**, group into **2–5 bullets** (what readers must know).
+3. **Risk** — One line: **merge risk**, **behavior change**, or **none**.
+4. **Omit** — Noise renames, generated lockfile-only churn unless that *is* the story.
+
+---
+
+## Shell recipes (PR delta)
+
+Use **`$BASE_GIT`** and **`HEAD`**. **Two-dot** for commits, **three-dot** for file list.
+
+```bash
+git log --oneline "$BASE_GIT..HEAD"
+```
+
+```bash
+git diff --name-status "$BASE_GIT...HEAD"
+```
+
+Optional:
+
+```bash
+git merge-base --is-ancestor "$BASE_GIT" HEAD
+git log --reverse --oneline "$BASE_GIT..HEAD"
+```
+
+### Issue keywords in commit range (PR / `@gh-pr`)
+
+For **`internal-read-gh-pr-description`** §6.6, scan **full** commit messages on the branch (not only **`git log -1`**) for **`Fixes #n`**, **`Refs #n`**, **`Closes #n`**, **`Resolves #n`**, and bare **`#nnn`** mentions. Use a **two-dot** range so merges behave as expected for your branch topology.
+
+```bash
+git log --pretty=format:'---%n%s%n%n%b' "$BASE_GIT..HEAD"
+```
+
+When the log is long, you may **cap** output for chat (for example **`--max-count=30`**) but **state the cap** if older commits were omitted.
+
+---
+
+## Commit message skeleton (short)
+
+```
+<area>: <imperative outcome>
+
+- <bullet tied to diff>
+- <bullet>
+
+Refs: #n
+```
+
+Use **50–72** char first line when possible; body wraps at ~72.
+
+---
+
+## Hand-off
+
+- **PR / issue title:** [`title-line`](../../gh/pr-content/title-line/SKILL.md).
+- **PR body:** [`pr-body-skeleton`](../../gh/pr-content/pr-body-skeleton/SKILL.md).
+- **Orchestration:** [`internal-read-git-git-diff-summary`](../SKILL.md), [`internal-read-gh-pr-description`](../../gh/pr-description/SKILL.md).

--- a/.agents/skills/internal-read-git/merge-conflicts/SKILL.md
+++ b/.agents/skills/internal-read-git/merge-conflicts/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: internal-read-git-merge-conflicts
+description: >-
+  Read-only playbook: principles and steps to resolve git merge conflicts when merging into the current branch (local
+  git only; no gh). Caller: @git-pull. Does not fetch, merge, or push.
+visibility: internal
+---
+
+# Internal: Merge conflict resolution
+
+**Read-only library.** **Local `git` only** (no **`gh`**). Use when **`@git-pull`** (or any parent) merges **`@{u}`** or **`ROOT_BRANCH`** and **`git`** leaves **unmerged paths**. **Ours** = current branch; **theirs** = the ref being merged (for example **`origin/main`** or a tracking branch).
+
+**Consumers:** **[`@git-pull`](../../../git/pull/SKILL.md)** — run this file **in full** whenever conflicts occur; conflict resolution is part of **`@git-pull`**, not **`@git-push`**.
+
+**Canonical merge phase:** `@git-pull` can merge in two phases (tracking branch first, canonical root second). In phase 2, prefer incoming (**theirs**) from `ROOT_BRANCH` in shared regions and adapt branch-only code around it.
+
+---
+
+## Principles
+
+- **Never blindly checkout sides** — Read conflict markers manually (`<<<<<<<`, `=======`, `>>>>>>>`), especially in manifests (`package.json`, `Cargo.toml`, `.gitignore`), where both sides' additions often need to be preserved together. Avoid `git checkout --theirs` / `--ours` across all files, which can silently wipe branch additions.
+- **Accept what main/root brought** — For shared files and root-owned regions, default to **incoming (theirs)** unless a small local tweak is required for the branch to compile or meet its goal.
+- **Avoid large rewrites of root code** — Do not replace big root blocks with older branch versions to “win” the merge. Keep root structure; adjust **branch additions** (new code, modules, tests) to fit.
+- **Branch goal** — After merging, the feature or fix the branch exists for should still be achievable; adapt call sites, imports, and branch-only logic—not revert upstream refactors wholesale.
+
+---
+
+## Procedure (execute in order)
+
+When any merge leaves unmerged paths:
+
+1. **Confirm merge in progress** — `git status` shows unmerged paths.
+
+2. **List conflicted files** — `git diff --name-only --diff-filter=U` (or `git status`).
+
+3. **Resolve each conflict**
+   - **Read the files first** to see the markers. **Never** blindly run `git checkout --theirs` or `git checkout --ours` across all files, especially for manifests (`package.json`, `.gitignore`, `Cargo.toml`).
+   - **Default to incoming (theirs)** for overlapping regions in files **main/root** owns (shared modules, config patterns, APIs updated on root). Prefer their version, then fix **branch-only** breakages (imports, types, tests) in the smallest follow-up edits.
+   - **Adapt branch code** — For files that are mostly **branch work**, keep branch intent but align with new root APIs and layout (move code, update signatures) rather than restoring pre-merge branch snapshots of root files.
+   - **Remove conflict markers** and leave one coherent result. **Do not** mass-reformat or restyle root code to match the branch; keep root formatting when you kept their side.
+
+4. **Stage** — `git add <file>` for each resolved file.
+
+5. **Complete merge** — `git status` has no unmerged paths; `git commit` (default merge message unless the user specifies otherwise).
+
+Then continue from the **parent** step that triggered the conflict (e.g. **`@git-pull`** §3 or §5).
+
+---
+
+## Do not (library)
+
+- **Fetch**, **merge** (except completing the in-progress merge via **`git commit`** after resolution), or **`git push`** — parent skill owns merge invocations; **`@git-push`** owns publish.
+
+---
+
+## See also
+
+- **[`@git-pull`](../../../git/pull/SKILL.md)** — source of truth for how `ROOT_BRANCH` is chosen before conflicts are resolved.
+- **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** — **`@git-pull`** merge-commit carve-out.
+- **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** **§4** — ambiguous tree before merge.

--- a/.agents/skills/internal-read-git/project-structure-eval/SKILL.md
+++ b/.agents/skills/internal-read-git/project-structure-eval/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: internal-read-git-project-structure-eval
+description: >-
+  Read-only: one-pass repository structure/readiness evaluation that combines repo classification and optional dependency discovery into
+  pillar status, posture, prioritized themes, and tracking recommendation. No installs, tests, or GitHub mutations.
+---
+
+# Internal: Project structure evaluation (`internal-read-git-project-structure-eval`)
+
+**Read-only library.** Produces a concise repository posture snapshot for planning and issue shaping:
+
+1. **Repo kind** + evidence
+2. **Pillar table** with `Have` / `Missing` / `Unknown` / `N/A`
+3. **Posture**: `good-shape` | `needs-foundation` | `mixed`
+4. **0-5 prioritized themes**
+5. **Tracking recommendation**: continue in plan vs open GitHub issues
+
+This skill combines signals from **[`internal-read-git-repo-classification`](../repo-classification/SKILL.md)** and optional **[`internal-read-git-discover-dependencies`](../discover-dependencies/SKILL.md)** output.
+
+## Consumers
+
+- **`@git-start`**, **`@gh-issues`**, Cursor Plan
+- `@gh-issues`, `@gh-issue-review`
+- Public router: `@git-project-structure-eval`
+
+## Non-goals
+
+- No dependency installs
+- No format/lint/test execution
+- No git mutation
+- No `gh` mutation
+- No file writes
+
+## Procedure
+
+1. **Collect context**
+   - Skim root and first-level structure (`skills/`, `docs/`, `src/`, `apps/`, `packages/`, `services/`, lockfiles, CI files).
+   - Reuse existing summary from `internal-read-git-repo-classification`.
+   - Optionally layer in dependency/CI/check-command clues from `internal-read-git-discover-dependencies`.
+2. **Select primary kind**
+   - Use one primary kind from `repo-classification` and mention relevant modifiers.
+3. **Evaluate pillars**
+   - Score each pillar as `Have`, `Missing`, `Unknown`, or `N/A`.
+   - Include one short rationale per pillar.
+4. **Determine posture**
+   - `good-shape`: mostly `Have`, few/no critical `Missing`.
+   - `needs-foundation`: several critical `Missing`.
+   - `mixed`: meaningful strengths with material gaps.
+5. **Return impact-ordered themes**
+   - 0-5 themes, highest impact first.
+6. **Return tracking recommendation**
+   - Keep in planning flow when scope is uncertain.
+   - Open GitHub issue(s) when implementation-ready actions are clear.
+
+## Pillars and status rules
+
+| Pillar | What to look for | Status guidance |
+| --- | --- | --- |
+| Repository shape clarity | Clear top-level structure and ownership hints (`README`, domain docs, folder conventions) | `Have` when navigation is clear; `Missing` when structure is opaque |
+| Workflow contracts | Public/internal skill boundaries and orchestration docs are coherent | `Have` when contracts are consistent; `Missing` for contradictory guidance |
+| Verification surface | Meaningful evaluation path exists for repo kind (`N/A` for checks that do not apply) | For markdown-first repos, code-only CI gates can be `N/A` |
+| Documentation integrity | Core docs/indexes and links align with current tree/contracts | `Missing` when docs drift; `Unknown` if evidence is incomplete |
+| Safety and mutation controls | Confirm-first policies for risky operations are explicit | `Missing` if high-risk actions can occur without explicit confirmation |
+
+## N/A vs Missing guidance
+
+- Use **`N/A`** when a pillar genuinely does not apply to the repository kind.
+  - Example: markdown-first pack without runtime services => service-deploy readiness is `N/A`.
+- Use **`Missing`** when the pillar should apply but required evidence is absent.
+  - Example: repo has executable code and CI references tests, but no clear local verification path.
+- Use **`Unknown`** when evidence is insufficient and additional inspection is required.
+
+## Output contract (chat shape)
+
+1. **Repo kind**: `<primary-kind>` (+ modifiers)
+2. **Evidence**: 2-5 bullets
+3. **Pillar table**: `Pillar | Status | Rationale`
+4. **Posture**: `good-shape` | `needs-foundation` | `mixed`
+5. **Themes**: 0-5 impact-ordered bullets
+6. **Tracking recommendation**: `stay-in-plan` or `open-issue`
+
+## See also
+
+- [`internal-read-git-repo-classification`](../repo-classification/SKILL.md)
+- [`internal-read-git-discover-dependencies`](../discover-dependencies/SKILL.md)
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md)
+- [`@gh-issues`](../../../gh/issues/SKILL.md)
+- [`@gh-issue-review`](../../../gh/issues/review/SKILL.md)

--- a/.agents/skills/internal-read-git/readme-root/SKILL.md
+++ b/.agents/skills/internal-read-git/readme-root/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: internal-read-git-readme-root
+description: >-
+  Read-only: minimal repository root README.md (link docs hub); optional Appendix D CI. Full narrative lives in
+  docs/ for this pack. Callers: @git-docs, internal-write-gh-documentation. Does not write files.
+---
+
+# Internal: Root README template (`internal-read-git-readme-root`)
+
+**Read-only library.** **This pack (cursor-skills):** root **`README.md`** stays **short**—opening **Quick guide** (what/why + a few usage examples), **`./install.sh`** (flags + env), link **[`docs/README.md`](../../../../docs/README.md)**, short **Documentation** pointer, optional **Usage flow** Mermaid—no full skill catalog in root. **Legacy / other repos:** full **superset** scaffold lives in **[`./root-readme-scaffold/SKILL.md`](./root-readme-scaffold/SKILL.md)** and **Appendix A** below.
+
+**Consumers:** **`@git-docs`**, **`internal-write-gh-documentation`** (alignment target), **`internal-read-git-readme-tree`** (bootstrap cross-links).
+
+---
+
+## Do
+
+- **Default (this pack):** Root = **short** entry: optional opening **Quick guide** (what/why + brief examples), **`./install.sh`** (install + verify flags), **link [`docs/README.md`](../../../../docs/README.md)**; optional link **[`docs/README.md`](../../../../docs/README.md)**; optional **Usage flow** diagram (**`internal-read-git-doc-graphs`**).
+- Prefer the **brief pack variant** in **[`./root-readme-scaffold/SKILL.md`](./root-readme-scaffold/SKILL.md)**: emoji on top-level `##` headings, one compact comparison table when useful, and at most 0-2 Mermaid blocks in root.
+- **Legacy / monolithic root:** Use **Appendix A** + **[`./root-readme-scaffold/SKILL.md`](./root-readme-scaffold/SKILL.md)** (Quick guide, mermaid, Contents, …).
+- Keep install **minimal**; **prompt** the user to run **Terminal batches** for heavy setup (**public `gh-*`** execution contract).
+- Optional **Appendix D** (CI/coverage) when real signals exist.
+
+## Do not
+
+- Put full per-skill catalogs in root—use **`docs/git.md`**, **`docs/gh.md`**, **`docs/internal.md`**, … (**this** pack) or optional **`docs/`** mirror elsewhere.
+- **Stuff** long reference into root when **`docs/README.md`** can own it.
+
+---
+
+## Appendix A — Template: main (root) README
+
+**Full scaffold:** **[`./root-readme-scaffold/SKILL.md`](./root-readme-scaffold/SKILL.md)**.
+
+Use for **repository root** `README.md`. Replace placeholders.
+
+**Principles** (full root README — legacy or non-mirror repos)
+
+- **Docs mirror pack:** prefer **minimal** root + **`docs/`** hub per **`internal-read-git-repo-layout`** §2.
+- **Subtree scope:** Summarize at high level; **do not** paste full inventories—**[`docs/README.md`](../../../../docs/README.md)** and **`docs/<domain>/README.md`** files own domain indexes (**this** pack).
+- **`## Contents` (root):** **numbered nested lists** only—**no markdown table** for the index.
+- **Tables:** OK in **reference** sections—not for directory listings.
+- **Section titles:** keep emoji on major `##` headings for scanability in pack-facing docs.
+- **Mermaid:** at least one **colored** diagram when the root is long-form (**`internal-read-git-doc-graphs`** + **`skills/read/git/doc-graphs/diagrams/*/SKILL.md`** scaffolds; human index **`docs/README.md`**).
+- **Estimates:** optional **`## Estimates` / `## Economics`** for service-level roll-ups (**explicitly labeled estimates**).
+- **No forecasted features**—describe **current** behavior only.
+
+**Conventions:** **Timelines**: **newest → oldest**. **Data tables**: sort rows **lexicographically** on the first column; **call out largest** rows (**`internal-read-git-doc-table`**).
+
+---
+
+## Appendix D — Optional: coverage and CI quick block (root only)
+
+Use when the repo has **real** signals (not placeholder). Omit the whole section if unknown.
+
+```markdown
+## Health
+
+- **CI:** [![CI](<badge-url>)](<actions-or-ci-url>) — <what it runs>
+- **Coverage:** <e.g. `npm run test -- --coverage` or link to report> — <threshold or “see CI”>
+```
+
+---
+
+## Exemplar (this repository)
+
+Live root **[`README.md`](../../../../README.md)** is **source of truth**: it stays brief, uses emoji on major `##` headings, includes a compact lane-comparison table, and keeps Mermaid focused on lane/flow visuals. Merge Appendix A only when the repo truly needs long-form root documentation.
+
+---
+
+## See also
+
+- [`internal-read-git-readme-tree`](../readme-tree/SKILL.md) — optional **`docs/`** mirror checklist + bootstrap
+- [`internal-read-git-doc-user-guide`](../doc-user-guide/SKILL.md)
+- [`internal-read-git-doc-reference`](../doc-reference/SKILL.md)

--- a/.agents/skills/internal-read-git/readme-root/root-readme-scaffold/SKILL.md
+++ b/.agents/skills/internal-read-git/readme-root/root-readme-scaffold/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: internal-read-git-readme-root-root-readme-scaffold
+description: >-
+  Read-only: monolithic root README scaffold. Parent internal-read-git-readme-root.
+---
+
+# TEMPLATE: repository root `README.md`
+
+**Prefix** blocks below come **first**; then use **`internal-read-git-readme-root`** + **`internal-read-git-doc-index`** for **Overview**, **See also**, **Contents** (**lists only**, no tables in Contents).
+
+---
+
+## 🧩 Brief pack variant (cursor-skills style)
+
+Use this when the repository keeps rich narrative in **`docs/`** and wants a short root landing page.
+
+Suggested structure:
+
+1. `# <Repo title>` + one-line value proposition.
+2. `## 🚀 Quick guide` with 2-4 first-run bullets.
+3. `## 📦 Install` with the minimal command block:
+
+```bash
+./install.sh
+```
+
+4. `## 🧭 Lane overview` with one small comparison table.
+5. Optional `## 🗺️ Example flow` (single Mermaid block) using GitHub-safe quoted labels:
+
+```mermaid
+flowchart LR
+  idea[Idea] --> exploreStep[Cursor Plan]
+  exploreStep --> ghIssuesStep["@gh-issues"]
+  ghIssuesStep --> prStep["@gh-pr"]
+```
+
+6. `## 📚 Learn more` with links to `docs/README.md`, `docs/git.md`, and `docs/gh.md`.
+
+Guidelines for this brief variant:
+
+- Keep **emoji** on major `##` titles.
+- Use **tables** only for compact comparisons; keep **`## Contents`** as numbered lists when present.
+- Keep Mermaid sparse (0-2 diagrams in root), and quote labels with special characters for GitHub compatibility.
+
+---
+
+# &lt;Repo title&gt;
+
+&lt;What this repository is for today.&gt;
+
+---
+
+## 🚀 Quick guide
+
+&lt;User-guide–style: first 2–3 things to do, where `skills/` or main code lives, how to invoke `@` skills.&gt;
+
+---
+
+## 🎯 Example usage
+
+```mermaid
+flowchart LR
+  classDef pub2 fill:#1976d2,color:#fff
+  classDef pub3 fill:#42a5f5,color:#111
+  classDef neu3 fill:#cfd8dc,color:#111
+  u[User] --> r["@git-review"]
+  r --> ok[Green tree]
+  class u neu3
+  class r pub2
+  class ok pub3
+```
+
+&lt;Replace nodes with **this repo’s** real skill names and paths.&gt;
+
+---
+
+## 🔭 Overview
+
+&lt;High-level architecture; colored mermaid if helpful.&gt;
+
+---
+
+## 💰 Estimates / economics (optional)
+
+*&lt;Explicitly labeled estimates&gt;* — e.g. marginal **cost per API call**, payload roll-ups aggregated from subtree READMEs. **Leaf-first** authoring: children hold granular tables; root **summarizes**.
+
+---
+
+## 📦 Install
+
+&lt;Minimal commands.&gt; **Prefer** prompting the user to run **Terminal batches by hand**; do not assume the agent runs installs.
+
+---
+
+## 🔗 See also
+
+1. [docs/README.md](docs/README.md) — documentation hub; domain indexes: [docs/git.md](docs/git.md), [docs/gh.md](docs/gh.md), [docs/internal.md](docs/internal.md) (**this** pack)
+2. …
+
+---
+
+## 📋 Contents
+
+1. … &lt;numbered nested lists, lexicographic; **no markdown table**&gt;
+
+---
+
+## 🏥 Health (optional)
+
+- **CI:** …
+
+---
+
+## Related
+
+&lt;Legacy cross-links if not covered above.&gt;

--- a/.agents/skills/internal-read-git/readme-tree/SKILL.md
+++ b/.agents/skills/internal-read-git/readme-tree/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: internal-read-git-readme-tree
+description: >-
+  Read-only: optional docs/ mirror parity checklist and greenfield hints vs skills/. No tree regen or bulk README apply
+  from pack skills—use @git-docs + internal-write-gh-documentation for in-place edits. Does not write files.
+---
+
+# Internal: Docs mirror notes (`internal-read-git-readme-tree`)
+
+**Read-only.** This pack keeps **`docs/**`** as a **human-facing mirror** of **`skills/`** when you choose that layout. **Agents** do **not** run a separate “mirror regen” step after **`@git-review`**. **`@git-docs`** and **`internal-write-gh-documentation`** edit **existing** markdown **in place**; if a **`docs/.../README.md`** is missing, add it in a normal edit (same PR) using the bootstrap bullets below.
+
+## Bootstrap (greenfield or new folders)
+
+1. **Domain layout** — **[`internal-read-git-repo-layout`](../repo-layout/SKILL.md)** — public skills under **`skills/<domain>/<verb>/`**; shared libraries under top-level **`skills/read/<domain>/**`** vs **`skills/write/<domain>/**`** depending on whether they mutate the machine or GitHub.
+2. **Mirror hub pages** — **`docs/<same-relpath>/README.md`**: short overview, **`## Contents`** as **numbered lists** only (**[`internal-read-git-doc-index`](../doc-index/SKILL.md)**), overview prose per **[`internal-read-git-doc-explanation`](../doc-explanation/SKILL.md)**.
+3. **Diagrams** — Add fenced **`mermaid`** only when a diagram clarifies flow; palette and hierarchy per **[`internal-read-git-doc-graphs`](../doc-graphs/SKILL.md)**. Example scaffolds live in **`skills/read/git/doc-graphs/diagrams/*/SKILL.md`** (optional references, not required files in consuming repos).
+4. **Tables** — Data tables in reference sections: sort rows, call out large rows (**[`internal-read-git-doc-table`](../doc-table/SKILL.md)**). Never use a markdown **table** for a pure index (**[`internal-read-git-doc-index`](../doc-index/SKILL.md)**).
+
+## Optional parity checklist (human)
+
+If this repo uses a **`docs/`** mirror: skip **`.gitignore`**d paths; spot-check that important **`skills/.../`** dirs have a sibling **`docs/.../README.md`** when that is your convention; **`## Contents`** ordered lexicographically; relative links into **`skills/`** still resolve.
+
+## Do not
+
+- Treat this skill as part of **`@git-review`** after green evaluate—the verify pipeline ends at **`internal-write-gh-documentation`** (**§8a**).
+
+## See also
+
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md)
+- [`internal-read-git-docs-mirror-bootstrap`](../docs-mirror-bootstrap/SKILL.md)
+- [`internal-write-gh-documentation`](../../../write/gh/documentation/SKILL.md)
+- [`@git-docs`](../../../git/docs/SKILL.md)
+- [`internal-read-git-readme-root`](../readme-root/SKILL.md)

--- a/.agents/skills/internal-read-git/repo-classification/SKILL.md
+++ b/.agents/skills/internal-read-git/repo-classification/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: internal-read-git-repo-classification
+description: >-
+  Read-only: classify repository kind (markdown-first vs code vs multi-service/monorepo vs tooling-heavy) from tree
+  skim plus optional internal-read-git-discover-dependencies summary. Recommendations for doc stance only—no writes. Callers
+  may use output to scope @git-docs inventory or planning chat.
+---
+
+# Internal: Repository classification (`internal-read-git-repo-classification`)
+
+**Read-only library.** Produces a **short label**, **evidence bullets**, and **suggested documentation stance** for the open workspace. **Does not** replace **[`internal-read-git-discover-dependencies`](../discover-dependencies/SKILL.md)** (toolchains, CI, check commands)—combine a **quick tree skim** with that skill’s summary when available.
+
+**Consumers:** Any skill or session that benefits from **scope** (e.g. which **`docs/**`** paths exist, how heavy wiki scaffolding might be). **Optional**—no required wiring across the pack.
+
+## Do
+
+1. **Skim** repo root and one level down: **`skills/`**, **`docs/`**, **`src/`**, **`apps/`**, **`packages/`**, **`services/`**, `package.json`, lockfiles, CI config, dominant extensions (`.md` vs `.ts`/`.go`/`.py`).
+2. **Optionally** ingest **`internal-read-git-discover-dependencies`** output: languages/stacks, “docs-only” vs real code checks, monorepo/workspace signals.
+3. **Emit for chat** (recommendations only):
+   - **Primary label** — one of: **`markdown-docs-first`**, **`code-app-or-library`**, **`multi-service-monorepo`**, **`scripts-tooling-heavy`**, or **`mixed`** (state why).
+   - **Evidence** — **2–5** bullets (paths, artifacts, CI).
+   - **Suggested doc stance** — e.g. minimal **`docs/README.md`** only vs full **[`internal-read-git-doc-wiki`](../doc-wiki/SKILL.md)** **`coding`** profile vs **`skill-pack`** / **`knowledge`**; whether **`docs/api/`** is plausible (see **`internal-read-git-doc-wiki`** §3).
+
+## Kind reference (signals)
+
+| Kind | Typical signals |
+| --- | --- |
+| **Markdown / docs-first** | Mostly **`.md`**; **`skills/**/SKILL.md`** trees; little or no app **`src/`**; no or trivial build/test stack. |
+| **Code present** | Lockfiles, **`src/`** / language-specific roots, CI running tests/build; single product or library. |
+| **Multi-service / monorepo** | **`services/`**, **`apps/*`**, **`packages/*`**, **`pnpm-workspace.yaml`**, **`go.work`**, multiple deployables. |
+| **Tooling-heavy** | **`tools/`**, Make/Task **`justfile`**, small CLIs, automation entrypoints; docs may still matter but the codebase is automation-centric. |
+
+**Modifiers:** A repo can be **`markdown-docs-first` + `scripts-tooling-heavy`** (e.g. skill pack with **`install.sh`**). Prefer the label that best answers “what is the main artifact?”
+
+## Do not
+
+- Run commands, write files, or mutate git from this skill.
+- Treat classification as **authoritative** without user confirmation when it drives large doc or structural changes.
+- Duplicate **`internal-read-git-doc-wiki`** profile tables—**link** there for path-level detail.
+
+## See also
+
+- [`internal-read-git-discover-dependencies`](../discover-dependencies/SKILL.md)
+- [`internal-read-git-doc-wiki`](../doc-wiki/SKILL.md)
+- [`internal-read-git-repo-layout`](../repo-layout/SKILL.md)
+- [`@git-docs`](../../../git/docs/SKILL.md) — in-place updates on **existing** **`.md`** only

--- a/.agents/skills/internal-read-git/repo-layout/SKILL.md
+++ b/.agents/skills/internal-read-git/repo-layout/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: internal-read-git-repo-layout
+description: >-
+  Read-only: domain-driven skills/, docs/README.md + optional docs/ mirror (this pack), diagram examples under
+  skills/read/git/doc-graphs/diagrams/*/SKILL.md, minimal root README. Consumed by @git-docs (read-only alignment); not @git-review.
+---
+
+# Internal: Repo layout (domain-driven)
+
+**Read-only.** Canonical **shape** for repositories that use this skill pack: **`skills/`** (workflows), **`docs/README.md`** + optional **`docs/...`** beside **`skills/`** (per-folder **`README.md`** and workflow markdown), **`skills/read/git/doc-graphs/diagrams/*/SKILL.md`** (optional mermaid examples), and a **minimal** root **`README.md`**. **Does not** run commands or verify—**[`@git-docs`](../../../git/docs/SKILL.md)** aligns **existing** markdown to this contract (**in place** only).
+
+**Consumers:** **`@git-docs`** (post-green **content** sync on **existing** **`.md`** only—**no** structural file ops from that skill). **Single source** for layout rules—do not duplicate these tables in other skills.
+
+## Do
+
+- Serve as the **single** read-only contract for **`skills/`** + documentation hub shape; callers **read** it and **link** here instead of copying prose.
+
+## Do not
+
+- Run commands, create files, or verify—**[`@git-docs`](../../../git/docs/SKILL.md)** applies **in-place** doc alignment only.
+
+---
+
+## 1. Skills (`skills/`)
+
+Treat **`skills/`** as a **single aggregate** of agent workflows, partitioned by **domain** (bounded context):
+
+| Domain | Typical path | Group together |
+| --- | --- | --- |
+| **GitHub (`gh`)** | `skills/gh/...` | **`pr`**, **`issues/*`** — **`@gh-*`** only; local git lives under **`skills/git/`** |
+| **Cross-cutting internal** | `skills/read/<domain>/**`, `skills/write/<domain>/**` | **`read/gh`**: **`gh`** inventory and PR/issue form helpers (issues, PRs, **`repo-stream`**, **`repo-forms-json`**). **`read/git`**: verify prep (**`discover-dependencies`**, **`configuration`**), doc/markdown rules (**`doc-*`**, **`readme-*`**, **`repo-layout`**, **`repo-classification`**, **`doc-wiki`**), **`git-diff-summary`**, **`merge-conflicts`**. **`write/gh`**: install, evaluate, documentation, issue/pr **command** fences. **`write/git`**: zip, tag, working-tree align. **`write/plan`**: safety + structured Q&A. |
+| **Public wikis + scaffolds** | **`docs/git.md`**, **`docs/gh.md`**, **`internal-read-git-doc-graphs`** `diagrams/` … | **Not** invocable skills—**`.md`** only (diagrams use **fenced `mermaid`** inside those files). |
+
+**Rules**
+
+1. **One skill per folder** — each leaf is `.../<name>/SKILL.md` with YAML **`name`** + **`description`** matching the pack’s conventions.
+2. **Similar verbs, same parent** — e.g. all `gh-*` public skills live under **`skills/gh/`**, not scattered at `skills/` root.
+3. **Public vs library** — user-invoked flows stay shallow (`skills/<domain>/<verb>`); shared libraries and policies live under `skills/read/<domain>` and `skills/write/<domain>`.
+4. **Names mirror behavior** — folder names stay short and match the skill `name` prefix (`git-docs` → `skills/git/docs/`).
+
+When **moving** skill folders, update **relative links** in the same change set; **`internal-read-git-repo-layout`** stays the single source for layout rules.
+
+---
+
+## 2. Narrative wiki + optional mirror under `docs/`
+
+**Mirror:** when you use one, **`docs/<relpath>/README.md`** may sit beside each **`skills/`** directory; parity expectations are a **repo convention**, not an automated pack step—see **`internal-read-git-readme-tree`** for a short checklist.
+
+**Root `README.md`:** minimal—title, purpose, install pointer, link **`docs/README.md`** (**`internal-read-git-readme-root`**).
+
+**`skills/`:** one **`SKILL.md`** per leaf; with a mirror, avoid duplicate prose in **`skills/**/README.md`**—use **`docs/...`** or **`SKILL.md`** only.
+
+**Policy vs bodies:** “when/how” in **`internal-read-git-doc-*`**, **`internal-read-gh-pr-content`**, **`internal-read-git-git-diff-summary`**, **`internal-read-git-doc-graphs`**; long checklist/skeleton/scaffold bodies as **sibling `.md`** files next to the owning **`internal-*`** library; **`docs/`** wikis stay **short** indexes over **`skills/`**.
+
+**Hub scaffold:** use **`internal-read-git-doc-reference/docs-hub-scaffold/SKILL.md`** as the baseline for emoji headings, numbered `Contents`, and structural comparison tables in new/reshaped docs hubs.
+
+**Exemplars:** **`internal-read-git-doc-exemplars`**.
+
+---
+
+## 3. What this is not
+
+- **Not** **`@git-review`** — verify + **light** polish of **existing** paths only.
+- **Not** **`internal-write-gh-documentation`** in place of this file — that skill **edits** after green tests; **layout policy** stays here only.
+
+---
+
+## See also
+
+- [`internal-read-git-doc-wiki`](../doc-wiki/SKILL.md) — how deep **`docs/`** might go elsewhere
+- [`internal-read-git-readme-tree`](../readme-tree/SKILL.md) — mirror bootstrap + optional parity checklist
+- [`@git-docs`](../../../git/docs/SKILL.md) — post-green doc accuracy (**existing** files **in place**)
+- [`internal-write-gh-documentation`](../../write/gh/documentation/SKILL.md) — §8a polish existing docs after green evaluate
+- [`docs/README.md`](../../../../docs/README.md) — documentation hub (**this** pack)
+
+## 4. Naming hygiene
+
+- Avoid nested segments repeating the parent (`foo/foo/`). For this pack, keep planning internals under `skills/read/plan/core/` (not `skills/read/plan/plan/`).
+- When moving folders, keep `name:` path-faithful with `internal-<full-path-with-dashes>` for read/write internals.
+
+## 5. Workspace staging conventions (`.cursor/`)
+
+- `.cursor/plan.md` is the canonical planning hub.
+- `.cursor/plans/<slug>.md` is an overflow split linked from the hub.
+- `.cursor/gh/issues/` stores issue draft bodies/manifests.
+- `.cursor/gh/pr/` stores PR draft fragments.

--- a/.agents/skills/internal-read-git/workflows/SKILL.md
+++ b/.agents/skills/internal-read-git/workflows/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: internal-read-git-workflows
+description: >-
+  Read-only in-pack git workflow references for public git skills, covering
+  branch/main/pull/push/reset/stash/revert/rebase/zip guidance.
+---
+
+# In-pack git workflows
+
+Use these sections as the in-repo workflow source for public `@git-*` skills.
+
+High-risk steps referenced here (for example `git fetch`, `git push`, `git reset --hard`, `git clean`, or any out-of-repo write in delegated libraries) must still run behind [`internal-write-plan-skill-safety`](../../write/plan/skill-safety/SKILL.md) and [`internal-write-plan-structured-qa`](../../write/plan/structured-qa/SKILL.md). `SKIP_QA_*` / `SKIP_QA_WRITE` does not bypass session-level master confirm for those actions.
+
+## Git start workflow
+
+1. Derive `BRANCH` from Jira / issue / activity context.
+2. Run full `@git-main` once. If `@git-main` aborts, stop `@git-start`.
+3. After `@git-main` succeeds, create the feature branch from clean `main`:
+   - `git checkout -b "$BRANCH"`
+4. Hand off to full `@git-push` unless the user explicitly skips publish.
+
+## Git main align workflow
+
+1. Validate repository context:
+   - `git rev-parse --is-inside-work-tree`
+2. Check out `main` before fetch/reset:
+   - `git checkout main`
+   - If local `main` is missing, create from `origin/main`.
+3. Fetch canonical refs:
+   - `git fetch origin`
+4. Resolve canonical main for standalone workflow:
+   - `CANONICAL_MAIN_REF=origin/main`
+   - `git rev-parse "$CANONICAL_MAIN_REF"` must succeed
+5. If tree is clean and `HEAD == $CANONICAL_MAIN_REF`, stop.
+6. Else align via `internal-write-git-working-tree-align` with:
+   - `ALIGN_REF="$CANONICAL_MAIN_REF"`
+   - `BRANCH=main`
+   - `MODE=combined`
+7. Do not `git pull` after reset/clean in this workflow.
+8. Do not push in this workflow.
+
+## Git pull workflow
+
+1. Capture current branch; fail if detached:
+   - `BRANCH=$(git branch --show-current)`
+2. Fetch refs:
+   - `git fetch origin`
+   - If `upstream` exists, `git fetch upstream`
+3. If branch has upstream tracking, merge `@{u}`; on conflict use `internal-read-git-merge-conflicts`.
+4. Resolve canonical root branch via `internal-read-gh-repo-stream`:
+   - `ROOT_BRANCH="$CANONICAL_MAIN_REF"` (`upstream/main` on fork, else `origin/main`)
+5. Merge `"$ROOT_BRANCH"`; on conflict use `internal-read-git-merge-conflicts`.
+6. Stop after merges complete; do not push in this workflow.
+
+## Git push workflow
+
+- **Read-only inventory** first (`git status --short`; optional **`HEAD...@{u}`** counts when upstream exists).
+- Run **full `@git-commit`** **only when** that inventory shows **something to commit**; if the tree is clean, **skip** commit (still run publish when there are **unpushed commits**).
+- **Publish** — **One** structured **Proceed** for branch intent + **`git push`** when the first attempt succeeds; **`origin`-aware** branch gate (**`main`** + **`origin`** → recommend new branch + later **`@gh-pr`**; no **`origin`** → single proceed on current branch). Use failure triage only when **`git push`** fails.
+- **Full verify** before opening/updating a PR is **`@git-review`** inside **`@gh-pr`** (see **`@gh-pr`** fixed order), not a prerequisite of standalone **`@git-push`**.
+
+## Git commit workflow
+
+- Run **`@git-commit`** for local savepoints only (no review gate, no push).
+- **Inventory first** — if **nothing to commit**, **no-op** with **no Q&A**.
+- **Single gate** when work exists — default **`git add -A`**, confirm **`COMMIT_SUBJECT`**, **Cancel / Proceed**, then stage + **one** commit (optional **one** follow-up for ambiguous paths only).
+- Use **`@git-push`** when publishing; use **`@git-review`** (or **`@gh-pr`**, which runs it) when you need a verify-backed gate before sharing work broadly.
+
+## Git tag workflow
+
+- **Optional publish-first** — When **`origin`** exists and the repo is **dirty**, **ahead** of **`@{u}`**, or the user asked to publish first, run **full `@git-push`** **before** **`@git-main`** + tag gates; otherwise skip with a short reason.
+- Then **`@git-main`**, optional **`@git-commit`** when **`@git-push`** did not run and the tree is still dirty, **read-only tag inventory**, then **fewer Q&A gates** (publish intent → local collision → remote collision → **Proceed**) per **`@git-tag`**.
+- **`@git-zip`** still hands off tag mutations only to **`@git-tag`**; export uses **`internal-write-git-zip`**.
+
+## Git reset align workflow
+
+- Resolve target ref, show impact, then align via reset/clean after confirm.
+
+## Git stash workflow
+
+- Save/list/show/apply/pop/drop with explicit confirmation for destructive steps.
+
+## Git branch workflow
+
+- Prune stale refs and optionally rename current branch.
+
+## Git rebase workflow
+
+- Rebase current branch onto target with conflict resolution.
+
+## Git revert workflow
+
+- Create inverse commits for selected commits (including merges when needed).
+
+## Git zip workflow
+
+- Export a **GitHub-style** **`.zip`** of **tracked files** at **`refs/tags/${TAG}`** via **`internal-write-git-zip`**.
+- **`@git-zip`** orchestrates only: **`@git-tag`** when a tag must be created or repointed, then export; or read-only tag verification plus export when the tag already exists.
+- **`@git-tag`** owns optional **publish-first `@git-push`**, sync **`main`**, label, and tag-push Q&A; **`@git-zip`** does not run tag-mutating fences from **`internal-write-git-tag`**.
+
+## See also
+
+- [`@git-zip`](../../../git/zip/SKILL.md)
+- [`@git-tag`](../../../git/tag/SKILL.md)
+- [`internal-write-git-tag`](../../../write/git/tag/SKILL.md)
+- [`internal-write-git-zip`](../../../write/git/zip/SKILL.md)
+- [`internal-write-git-commit`](../../../write/git/commit/SKILL.md)
+- [`internal-write-git-working-tree-align`](../../../write/git/working-tree-align/SKILL.md)

--- a/.agents/skills/internal-read-plan-confidence/SKILL.md
+++ b/.agents/skills/internal-read-plan-confidence/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: internal-read-plan-confidence
+description: Read-only confidence scoring for plan readiness and definition-of-done clarity.
+---
+
+# Plan confidence
+
+A plan is ready when all are explicit:
+
+- outcome and scope
+- non-goals
+- acceptance + regression verification
+- risks/unknowns and defaults
+
+If any are unclear, request another targeted clarifying question.

--- a/.agents/skills/internal-read-plan-core-generic-brief-profile/SKILL.md
+++ b/.agents/skills/internal-read-plan-core-generic-brief-profile/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: internal-read-plan-core-generic-brief-profile
+description: >-
+  Read-only profile for non-issue planning: produce a compact implementation brief with scope, constraints,
+  verification, and explicit unknowns.
+---
+
+# Profile: generic brief
+
+Use when work should be planned but not necessarily tracked as a GitHub issue.
+
+## Required sections
+
+- Goal/outcome.
+- Current situation.
+- Proposed approach.
+- Constraints and non-goals.
+- Validation strategy.
+- Risks/open questions.
+
+## Output shape
+
+- Title.
+- One-page brief in plain markdown with clear hand-off bullets for execution.
+
+## See also
+
+- [`../readiness-checklist/SKILL.md`](../readiness-checklist/SKILL.md)

--- a/.agents/skills/internal-read-plan-core-github-issue-profile/SKILL.md
+++ b/.agents/skills/internal-read-plan-core-github-issue-profile/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: internal-read-plan-core-github-issue-profile
+description: >-
+  Read-only profile for planning issue-ready artifacts: goal, current vs desired behavior, alternatives,
+  scope/change surface, non-regression, verification, and ambiguity-killing examples.
+---
+
+# Profile: github issue
+
+Use when the final output should be ready for **`@gh-issues`**.
+
+## Required sections
+
+- Goal and intended outcome.
+- Current behavior with concrete examples.
+- Desired behavior with concrete examples.
+- Scope and expected change surface.
+- Compatibility and non-regression expectations.
+- Verification approach (acceptance + regression tests).
+- Worked examples and edge cases.
+- Risks/open questions and alternatives (when meaningful forks exist).
+
+## Output shape
+
+- **Title:** concise statement aligned with **[`internal-read-gh-pr-content/title-line`](../../../gh/pr-content/title-line/SKILL.md)** rules.
+- **Body:** follow **[`internal-read-gh-issue-spec`](../../../gh/issue-spec/SKILL.md)** and compatible skeleton guidance in **[`internal-read-gh-issue-description-issue-body-skeleton`](../../../gh/issue-description/issue-body-skeleton/SKILL.md)**.
+
+## See also
+
+- [`internal-read-gh-issue-spec`](../../../gh/issue-spec/SKILL.md)
+- [`internal-read-gh-issue-description`](../../../gh/issue-description/SKILL.md)

--- a/.agents/skills/internal-read-plan-core-readiness-checklist/SKILL.md
+++ b/.agents/skills/internal-read-plan-core-readiness-checklist/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: internal-read-plan-core-readiness-checklist
+description: >-
+  Read-only readiness checklist for plan completion: minimum quality gates before handing artifacts to issue
+  publish or execution workflows.
+---
+
+# Readiness checklist
+
+Use before returning a final artifact.
+
+- [ ] Goal is explicit and testable.
+- [ ] Primary artifact path is explicit (default `.cursor/plan.md` unless user chose another path).
+- [ ] Current behavior is described with at least one concrete example.
+- [ ] Desired behavior is described with at least one concrete example.
+- [ ] Scope and non-goals are explicit.
+- [ ] Plan has clear domain sections with small, independent tasks.
+- [ ] Ship mode is explicit (work now vs defer/create issue).
+- [ ] Non-regression expectations are explicit.
+- [ ] Verification includes acceptance and regression intent.
+- [ ] Open questions and assumptions are listed.
+- [ ] If choices exist, alternatives and decision rationale are captured.
+- [ ] Out-of-scope ideas are either deferred into sub-plans or queued for an issue.
+
+If any gate is missing, ask a focused follow-up before finalizing.
+
+If you need a stable output shape, follow [`generic-brief-profile`](../generic-brief-profile/SKILL.md) or [`github-issue-profile`](../github-issue-profile/SKILL.md).
+
+- [ ] Confidence threshold is met (goal, scope, and verification are explicit enough to execute).

--- a/.agents/skills/internal-read-plan-core-turn-order/SKILL.md
+++ b/.agents/skills/internal-read-plan-core-turn-order/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: internal-read-plan-core-turn-order
+description: >-
+  Read-only turn-order guidance for planning conversations: choose the next question that most reduces delivery
+  ambiguity while keeping prompts short and decision-focused.
+---
+
+# Turn order
+
+1. Clarify goal and user-visible outcome.
+2. Capture current behavior (facts, examples, constraints).
+3. Capture desired behavior and acceptance target.
+4. Confirm change surface and non-goals.
+5. Clarify alternatives and decision rationale (if forks exist).
+6. Define verification and regression expectations.
+7. Gather edge cases/worked examples.
+8. Surface remaining risks or unknowns.
+
+When step 5 surfaces a **finite** set of forks (for example two or three concrete approaches), prefer **AskQuestion** with short labels per **[`internal-write-plan-structured-qa`](../../../../write/plan/structured-qa/SKILL.md)** **§1** instead of listing A/B/C only in chat prose.
+
+When multiple unknowns exist, ask the question that most reduces implementation risk first.
+Use repeated one-question refinement loops until readiness gates pass or the user chooses to stop.
+
+## See also
+
+- [`../readiness-checklist/SKILL.md`](../readiness-checklist/SKILL.md)
+- [`../../../../write/plan/structured-qa/SKILL.md`](../../../../write/plan/structured-qa/SKILL.md)
+
+- Insert a domain classifier step early (docs, unit-tests, integration, bug, enhancement, dependencies) so subsequent questions use the right template.

--- a/.agents/skills/internal-read-plan-core/SKILL.md
+++ b/.agents/skills/internal-read-plan-core/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: internal-read-plan-core
+description: >-
+  Read-only planning library: profile selection, turn order, readiness gates, and artifact shape for issue-ready or
+  generic execution briefs. Consumed from @gh-issues pre-flight and related planning chat (no public @plan-* skill).
+---
+
+# Internal: Agent planning library
+
+**Read-only library.** This is the single owner for planning profiles, question ordering, and readiness criteria used from **`@gh-issues`** pre-flight / **Sharpen** rounds (and other callers that embed the same libraries).
+
+## Do
+
+- Select one profile first:
+  - **[`github-issue-profile`](./github-issue-profile/SKILL.md)** for tracked work that should become a GitHub issue.
+  - **[`generic-brief-profile`](./generic-brief-profile/SKILL.md)** for non-GitHub planning artifacts.
+- Default to `.cursor/plan.md` as the primary artifact; split oversized domains to `.cursor/plans/<slug>.md` and link them from the primary file.
+- Drive the conversation with **[`turn-order`](./turn-order/SKILL.md)** so each turn resolves one high-impact unknown.
+- Validate completion with **[`readiness-checklist`](./readiness-checklist/SKILL.md)** before returning the final artifact.
+- Keep `.cursor/plan.md` as the single canonical hub when using file-backed plans; if split files are needed, link all sub-plans from the hub.
+- Use confidence/definition-of-done checks from [`internal-read-plan-confidence`](../confidence/SKILL.md) before handing off to **`@gh-issues`** publish steps or **`@git-start`**.
+- For disjoint goals, partition with [`internal-read-plan-parts`](../parts/SKILL.md).
+- Use **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** for finite choices and confirms inside planning interactions.
+
+## Do not
+
+- Run `gh` or `git` commands.
+- Perform any mutation flow (issue create/edit, branching, commits, PR creation).
+- Duplicate issue shape rules that are owned by **[`internal-read-gh-issue-spec`](../../gh/issue-spec/SKILL.md)**.
+
+## On invoke
+
+Profile pick → question turn order → readiness gates → emit stable artifact + hand-off.
+
+## See also
+
+- [`github-issue-profile`](./github-issue-profile/SKILL.md)
+- [`generic-brief-profile`](./generic-brief-profile/SKILL.md)
+- [`turn-order`](./turn-order/SKILL.md)
+- [`readiness-checklist`](./readiness-checklist/SKILL.md)
+- [`internal-read-gh-issue-spec`](../../gh/issue-spec/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)
+- [`internal-read-plan-parts`](../parts/SKILL.md)
+- [`internal-read-plan-confidence`](../confidence/SKILL.md)

--- a/.agents/skills/internal-read-plan-core/generic-brief-profile/SKILL.md
+++ b/.agents/skills/internal-read-plan-core/generic-brief-profile/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: internal-read-plan-core-generic-brief-profile
+description: >-
+  Read-only profile for non-issue planning: produce a compact implementation brief with scope, constraints,
+  verification, and explicit unknowns.
+---
+
+# Profile: generic brief
+
+Use when work should be planned but not necessarily tracked as a GitHub issue.
+
+## Required sections
+
+- Goal/outcome.
+- Current situation.
+- Proposed approach.
+- Constraints and non-goals.
+- Validation strategy.
+- Risks/open questions.
+
+## Output shape
+
+- Title.
+- One-page brief in plain markdown with clear hand-off bullets for execution.
+
+## See also
+
+- [`../readiness-checklist/SKILL.md`](../readiness-checklist/SKILL.md)

--- a/.agents/skills/internal-read-plan-core/github-issue-profile/SKILL.md
+++ b/.agents/skills/internal-read-plan-core/github-issue-profile/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: internal-read-plan-core-github-issue-profile
+description: >-
+  Read-only profile for planning issue-ready artifacts: goal, current vs desired behavior, alternatives,
+  scope/change surface, non-regression, verification, and ambiguity-killing examples.
+---
+
+# Profile: github issue
+
+Use when the final output should be ready for **`@gh-issues`**.
+
+## Required sections
+
+- Goal and intended outcome.
+- Current behavior with concrete examples.
+- Desired behavior with concrete examples.
+- Scope and expected change surface.
+- Compatibility and non-regression expectations.
+- Verification approach (acceptance + regression tests).
+- Worked examples and edge cases.
+- Risks/open questions and alternatives (when meaningful forks exist).
+
+## Output shape
+
+- **Title:** concise statement aligned with **[`internal-read-gh-pr-content/title-line`](../../../gh/pr-content/title-line/SKILL.md)** rules.
+- **Body:** follow **[`internal-read-gh-issue-spec`](../../../gh/issue-spec/SKILL.md)** and compatible skeleton guidance in **[`internal-read-gh-issue-description-issue-body-skeleton`](../../../gh/issue-description/issue-body-skeleton/SKILL.md)**.
+
+## See also
+
+- [`internal-read-gh-issue-spec`](../../../gh/issue-spec/SKILL.md)
+- [`internal-read-gh-issue-description`](../../../gh/issue-description/SKILL.md)

--- a/.agents/skills/internal-read-plan-core/readiness-checklist/SKILL.md
+++ b/.agents/skills/internal-read-plan-core/readiness-checklist/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: internal-read-plan-core-readiness-checklist
+description: >-
+  Read-only readiness checklist for plan completion: minimum quality gates before handing artifacts to issue
+  publish or execution workflows.
+---
+
+# Readiness checklist
+
+Use before returning a final artifact.
+
+- [ ] Goal is explicit and testable.
+- [ ] Primary artifact path is explicit (default `.cursor/plan.md` unless user chose another path).
+- [ ] Current behavior is described with at least one concrete example.
+- [ ] Desired behavior is described with at least one concrete example.
+- [ ] Scope and non-goals are explicit.
+- [ ] Plan has clear domain sections with small, independent tasks.
+- [ ] Ship mode is explicit (work now vs defer/create issue).
+- [ ] Non-regression expectations are explicit.
+- [ ] Verification includes acceptance and regression intent.
+- [ ] Open questions and assumptions are listed.
+- [ ] If choices exist, alternatives and decision rationale are captured.
+- [ ] Out-of-scope ideas are either deferred into sub-plans or queued for an issue.
+
+If any gate is missing, ask a focused follow-up before finalizing.
+
+If you need a stable output shape, follow [`generic-brief-profile`](../generic-brief-profile/SKILL.md) or [`github-issue-profile`](../github-issue-profile/SKILL.md).
+
+- [ ] Confidence threshold is met (goal, scope, and verification are explicit enough to execute).

--- a/.agents/skills/internal-read-plan-core/turn-order/SKILL.md
+++ b/.agents/skills/internal-read-plan-core/turn-order/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: internal-read-plan-core-turn-order
+description: >-
+  Read-only turn-order guidance for planning conversations: choose the next question that most reduces delivery
+  ambiguity while keeping prompts short and decision-focused.
+---
+
+# Turn order
+
+1. Clarify goal and user-visible outcome.
+2. Capture current behavior (facts, examples, constraints).
+3. Capture desired behavior and acceptance target.
+4. Confirm change surface and non-goals.
+5. Clarify alternatives and decision rationale (if forks exist).
+6. Define verification and regression expectations.
+7. Gather edge cases/worked examples.
+8. Surface remaining risks or unknowns.
+
+When step 5 surfaces a **finite** set of forks (for example two or three concrete approaches), prefer **AskQuestion** with short labels per **[`internal-write-plan-structured-qa`](../../../../write/plan/structured-qa/SKILL.md)** **§1** instead of listing A/B/C only in chat prose.
+
+When multiple unknowns exist, ask the question that most reduces implementation risk first.
+Use repeated one-question refinement loops until readiness gates pass or the user chooses to stop.
+
+## See also
+
+- [`../readiness-checklist/SKILL.md`](../readiness-checklist/SKILL.md)
+- [`../../../../write/plan/structured-qa/SKILL.md`](../../../../write/plan/structured-qa/SKILL.md)
+
+- Insert a domain classifier step early (docs, unit-tests, integration, bug, enhancement, dependencies) so subsequent questions use the right template.

--- a/.agents/skills/internal-read-plan-domain-questions/SKILL.md
+++ b/.agents/skills/internal-read-plan-domain-questions/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: internal-read-plan-domain-questions
+description: Read-only domain classifier and question picker for planning loops.
+---
+
+# Domain questions
+
+Classify the current goal, then ask the next highest-impact question:
+
+- docs
+- unit-tests
+- integration-tests
+- enhancement
+- bug
+- dependencies
+
+Use one-question loops and stop when confidence gates are met.

--- a/.agents/skills/internal-read-plan-parts/SKILL.md
+++ b/.agents/skills/internal-read-plan-parts/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: internal-read-plan-parts
+description: Read-only planner for splitting one goal into disjoint domain plan parts.
+---
+
+# Plan parts
+
+- Partition multi-goal requests into independent sections in `.cursor/plan.md`.
+- Keep each part with goal, scope, verification, and hand-off.
+- When needed, move large parts into `.cursor/plans/<slug>.md` linked from the hub.
+
+**Consumers:** **`@gh-issues`** uses these boundaries for the optional [Multi-intent clustering](../../../gh/issues/SKILL.md#multi-intent-clustering-optional) path: each **disjoint** part maps to **at most one** shipped issue after per-theme dedupe (or merges into an **edit #n** row when overlap wins). Parts are not a substitute for user confirmation on split vs merge.

--- a/.agents/skills/internal-read-plan-qa-batch/SKILL.md
+++ b/.agents/skills/internal-read-plan-qa-batch/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: internal-read-plan-qa-batch
+description: Read-only builder for structured AskQuestion batches in planning.
+---
+
+# Q&A batch builder
+
+- Build finite-choice AskQuestion rounds with short labels.
+- When planning alternatives are a **finite** set, surface them as **AskQuestion** options per **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** **§1**, not as prose-only lists the user must parse in chat.
+- Include one freeform outlet only when needed.
+- Keep prompts aligned with `internal-write-plan-structured-qa`.

--- a/.agents/skills/internal-read-plan/SKILL.md
+++ b/.agents/skills/internal-read-plan/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: internal-read-plan
+description: >-
+  Internal planning read-only libraries for profile selection, turn order, and readiness checks. Consumed by
+  @gh-issues pre-flight shaping and related chat workflows (not a separate public @ invoke).
+---
+
+# `skills/read/plan/`
+
+Read-only planning libraries that support issue pre-flight and **Sharpen / Abort / Ship** shaping inside **`@gh-issues`** (and similar callers), backed by **`internal-write-plan-structured-qa`**.
+
+- `core/` provides profile selection, turn order, and readiness orchestration.
+- Child profiles/checklists keep issue-ready and generic brief guidance consistent.
+- Default planning artifact is `.cursor/plan.md` with optional linked sub-plans in `.cursor/plans/`.
+
+No git or GitHub mutations should be executed from this layer.
+
+- `parts/` manages disjoint multi-goal plan sections by domain.
+- `domain-questions/` picks high-impact clarifying questions by domain.
+- `confidence/` measures how close the task is to a well-defined executable brief.
+- `qa-batch/` builds structured AskQuestion batches for planning loops.

--- a/.agents/skills/internal-read-plan/confidence/SKILL.md
+++ b/.agents/skills/internal-read-plan/confidence/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: internal-read-plan-confidence
+description: Read-only confidence scoring for plan readiness and definition-of-done clarity.
+---
+
+# Plan confidence
+
+A plan is ready when all are explicit:
+
+- outcome and scope
+- non-goals
+- acceptance + regression verification
+- risks/unknowns and defaults
+
+If any are unclear, request another targeted clarifying question.

--- a/.agents/skills/internal-read-plan/core/SKILL.md
+++ b/.agents/skills/internal-read-plan/core/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: internal-read-plan-core
+description: >-
+  Read-only planning library: profile selection, turn order, readiness gates, and artifact shape for issue-ready or
+  generic execution briefs. Consumed from @gh-issues pre-flight and related planning chat (no public @plan-* skill).
+---
+
+# Internal: Agent planning library
+
+**Read-only library.** This is the single owner for planning profiles, question ordering, and readiness criteria used from **`@gh-issues`** pre-flight / **Sharpen** rounds (and other callers that embed the same libraries).
+
+## Do
+
+- Select one profile first:
+  - **[`github-issue-profile`](./github-issue-profile/SKILL.md)** for tracked work that should become a GitHub issue.
+  - **[`generic-brief-profile`](./generic-brief-profile/SKILL.md)** for non-GitHub planning artifacts.
+- Default to `.cursor/plan.md` as the primary artifact; split oversized domains to `.cursor/plans/<slug>.md` and link them from the primary file.
+- Drive the conversation with **[`turn-order`](./turn-order/SKILL.md)** so each turn resolves one high-impact unknown.
+- Validate completion with **[`readiness-checklist`](./readiness-checklist/SKILL.md)** before returning the final artifact.
+- Keep `.cursor/plan.md` as the single canonical hub when using file-backed plans; if split files are needed, link all sub-plans from the hub.
+- Use confidence/definition-of-done checks from [`internal-read-plan-confidence`](../confidence/SKILL.md) before handing off to **`@gh-issues`** publish steps or **`@git-start`**.
+- For disjoint goals, partition with [`internal-read-plan-parts`](../parts/SKILL.md).
+- Use **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** for finite choices and confirms inside planning interactions.
+
+## Do not
+
+- Run `gh` or `git` commands.
+- Perform any mutation flow (issue create/edit, branching, commits, PR creation).
+- Duplicate issue shape rules that are owned by **[`internal-read-gh-issue-spec`](../../gh/issue-spec/SKILL.md)**.
+
+## On invoke
+
+Profile pick → question turn order → readiness gates → emit stable artifact + hand-off.
+
+## See also
+
+- [`github-issue-profile`](./github-issue-profile/SKILL.md)
+- [`generic-brief-profile`](./generic-brief-profile/SKILL.md)
+- [`turn-order`](./turn-order/SKILL.md)
+- [`readiness-checklist`](./readiness-checklist/SKILL.md)
+- [`internal-read-gh-issue-spec`](../../gh/issue-spec/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)
+- [`internal-read-plan-parts`](../parts/SKILL.md)
+- [`internal-read-plan-confidence`](../confidence/SKILL.md)

--- a/.agents/skills/internal-read-plan/core/generic-brief-profile/SKILL.md
+++ b/.agents/skills/internal-read-plan/core/generic-brief-profile/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: internal-read-plan-core-generic-brief-profile
+description: >-
+  Read-only profile for non-issue planning: produce a compact implementation brief with scope, constraints,
+  verification, and explicit unknowns.
+---
+
+# Profile: generic brief
+
+Use when work should be planned but not necessarily tracked as a GitHub issue.
+
+## Required sections
+
+- Goal/outcome.
+- Current situation.
+- Proposed approach.
+- Constraints and non-goals.
+- Validation strategy.
+- Risks/open questions.
+
+## Output shape
+
+- Title.
+- One-page brief in plain markdown with clear hand-off bullets for execution.
+
+## See also
+
+- [`../readiness-checklist/SKILL.md`](../readiness-checklist/SKILL.md)

--- a/.agents/skills/internal-read-plan/core/github-issue-profile/SKILL.md
+++ b/.agents/skills/internal-read-plan/core/github-issue-profile/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: internal-read-plan-core-github-issue-profile
+description: >-
+  Read-only profile for planning issue-ready artifacts: goal, current vs desired behavior, alternatives,
+  scope/change surface, non-regression, verification, and ambiguity-killing examples.
+---
+
+# Profile: github issue
+
+Use when the final output should be ready for **`@gh-issues`**.
+
+## Required sections
+
+- Goal and intended outcome.
+- Current behavior with concrete examples.
+- Desired behavior with concrete examples.
+- Scope and expected change surface.
+- Compatibility and non-regression expectations.
+- Verification approach (acceptance + regression tests).
+- Worked examples and edge cases.
+- Risks/open questions and alternatives (when meaningful forks exist).
+
+## Output shape
+
+- **Title:** concise statement aligned with **[`internal-read-gh-pr-content/title-line`](../../../gh/pr-content/title-line/SKILL.md)** rules.
+- **Body:** follow **[`internal-read-gh-issue-spec`](../../../gh/issue-spec/SKILL.md)** and compatible skeleton guidance in **[`internal-read-gh-issue-description-issue-body-skeleton`](../../../gh/issue-description/issue-body-skeleton/SKILL.md)**.
+
+## See also
+
+- [`internal-read-gh-issue-spec`](../../../gh/issue-spec/SKILL.md)
+- [`internal-read-gh-issue-description`](../../../gh/issue-description/SKILL.md)

--- a/.agents/skills/internal-read-plan/core/readiness-checklist/SKILL.md
+++ b/.agents/skills/internal-read-plan/core/readiness-checklist/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: internal-read-plan-core-readiness-checklist
+description: >-
+  Read-only readiness checklist for plan completion: minimum quality gates before handing artifacts to issue
+  publish or execution workflows.
+---
+
+# Readiness checklist
+
+Use before returning a final artifact.
+
+- [ ] Goal is explicit and testable.
+- [ ] Primary artifact path is explicit (default `.cursor/plan.md` unless user chose another path).
+- [ ] Current behavior is described with at least one concrete example.
+- [ ] Desired behavior is described with at least one concrete example.
+- [ ] Scope and non-goals are explicit.
+- [ ] Plan has clear domain sections with small, independent tasks.
+- [ ] Ship mode is explicit (work now vs defer/create issue).
+- [ ] Non-regression expectations are explicit.
+- [ ] Verification includes acceptance and regression intent.
+- [ ] Open questions and assumptions are listed.
+- [ ] If choices exist, alternatives and decision rationale are captured.
+- [ ] Out-of-scope ideas are either deferred into sub-plans or queued for an issue.
+
+If any gate is missing, ask a focused follow-up before finalizing.
+
+If you need a stable output shape, follow [`generic-brief-profile`](../generic-brief-profile/SKILL.md) or [`github-issue-profile`](../github-issue-profile/SKILL.md).
+
+- [ ] Confidence threshold is met (goal, scope, and verification are explicit enough to execute).

--- a/.agents/skills/internal-read-plan/core/turn-order/SKILL.md
+++ b/.agents/skills/internal-read-plan/core/turn-order/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: internal-read-plan-core-turn-order
+description: >-
+  Read-only turn-order guidance for planning conversations: choose the next question that most reduces delivery
+  ambiguity while keeping prompts short and decision-focused.
+---
+
+# Turn order
+
+1. Clarify goal and user-visible outcome.
+2. Capture current behavior (facts, examples, constraints).
+3. Capture desired behavior and acceptance target.
+4. Confirm change surface and non-goals.
+5. Clarify alternatives and decision rationale (if forks exist).
+6. Define verification and regression expectations.
+7. Gather edge cases/worked examples.
+8. Surface remaining risks or unknowns.
+
+When step 5 surfaces a **finite** set of forks (for example two or three concrete approaches), prefer **AskQuestion** with short labels per **[`internal-write-plan-structured-qa`](../../../../write/plan/structured-qa/SKILL.md)** **§1** instead of listing A/B/C only in chat prose.
+
+When multiple unknowns exist, ask the question that most reduces implementation risk first.
+Use repeated one-question refinement loops until readiness gates pass or the user chooses to stop.
+
+## See also
+
+- [`../readiness-checklist/SKILL.md`](../readiness-checklist/SKILL.md)
+- [`../../../../write/plan/structured-qa/SKILL.md`](../../../../write/plan/structured-qa/SKILL.md)
+
+- Insert a domain classifier step early (docs, unit-tests, integration, bug, enhancement, dependencies) so subsequent questions use the right template.

--- a/.agents/skills/internal-read-plan/domain-questions/SKILL.md
+++ b/.agents/skills/internal-read-plan/domain-questions/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: internal-read-plan-domain-questions
+description: Read-only domain classifier and question picker for planning loops.
+---
+
+# Domain questions
+
+Classify the current goal, then ask the next highest-impact question:
+
+- docs
+- unit-tests
+- integration-tests
+- enhancement
+- bug
+- dependencies
+
+Use one-question loops and stop when confidence gates are met.

--- a/.agents/skills/internal-read-plan/parts/SKILL.md
+++ b/.agents/skills/internal-read-plan/parts/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: internal-read-plan-parts
+description: Read-only planner for splitting one goal into disjoint domain plan parts.
+---
+
+# Plan parts
+
+- Partition multi-goal requests into independent sections in `.cursor/plan.md`.
+- Keep each part with goal, scope, verification, and hand-off.
+- When needed, move large parts into `.cursor/plans/<slug>.md` linked from the hub.
+
+**Consumers:** **`@gh-issues`** uses these boundaries for the optional [Multi-intent clustering](../../../gh/issues/SKILL.md#multi-intent-clustering-optional) path: each **disjoint** part maps to **at most one** shipped issue after per-theme dedupe (or merges into an **edit #n** row when overlap wins). Parts are not a substitute for user confirmation on split vs merge.

--- a/.agents/skills/internal-read-plan/qa-batch/SKILL.md
+++ b/.agents/skills/internal-read-plan/qa-batch/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: internal-read-plan-qa-batch
+description: Read-only builder for structured AskQuestion batches in planning.
+---
+
+# Q&A batch builder
+
+- Build finite-choice AskQuestion rounds with short labels.
+- When planning alternatives are a **finite** set, surface them as **AskQuestion** options per **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** **§1**, not as prose-only lists the user must parse in chat.
+- Include one freeform outlet only when needed.
+- Keep prompts aligned with `internal-write-plan-structured-qa`.

--- a/.agents/skills/internal-write-gh-documentation/SKILL.md
+++ b/.agents/skills/internal-write-gh-documentation/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: internal-write-gh-documentation
+description: >-
+  Sharpen existing docs/** (wiki sections, docs/** indexes, optional slimmer domain layouts on other repos),
+  minimal root README.md, and legacy paths if present. Runs as @git-review §8a after green evaluate. Does not create new
+  doc pages. Broader post-green pass: @git-docs. Not a substitute for @git-review §8a.
+---
+
+# Internal: Project documentation (`internal-write-gh-documentation`)
+
+**Library.** Single **batch** for **`@git-review`** **§8a**: after **[`internal-write-gh-evaluate`](../evaluate/SKILL.md)** succeeds, **edit existing** markdown only.
+
+**Write safety:** before any documentation mutation, set a clear **Goal**, present **AskQuestion** confirmation options when scope is non-trivial, and only proceed after explicit **Proceed/confirm** per **`internal-write-plan-skill-safety`** + **`internal-write-plan-structured-qa`**.
+
+**Consumers:** **`@git-review`** §8a only. For **missing `docs/.../README.md`** or mirror layout questions, read **`internal-read-git-readme-tree`** (read-only bootstrap + parity checklist) and **`internal-read-git-repo-layout`**—**do not** invent a bulk “regen” step here. For **post-green** doc accuracy (**existing** paths **in place**; **no** new/deleted/moved **`.md`**), **`@git-docs`**—read **`internal-read-git-repo-layout`** so links match the tree.
+
+**Scope:** **Complement** what already exists—align lists, links, and commands with **current** tree and CI. **Do not** bulk regen **`docs/`** here.
+
+---
+
+## Do
+
+1. **Repo root** — Target **open** project (not necessarily cursor-skills).
+2. **Inventory** — Always: **minimal** root **`README.md`**, **`docs/**`**. Include **existing** paths only: **`docs/README.md`** (simple repos may use **only** this file under **`docs/`**); if present, also profile wiki dirs (**`docs/architecture/`**, **`docs/organization/`**, **`docs/domains/`**, **`docs/workflows/`**, **`docs/data/`**, **`docs/conventions/`**, **`docs/operations/`**, **`docs/api/`**, **`docs/services/`**). If legacy **`skills/**/README.md`** (other repos) or root **`USER_GUIDE.md`** / **`REFERENCE.md`** still exist, include only when present—this pack keeps **no** README under **`skills/`** when mirror policy applies. **Do not** **create** new **`docs/`** pages here. If **no** **`docs/`** hub exists, point the user to **`internal-read-git-repo-layout`** / **`internal-read-git-readme-tree`**—**`@git-docs`** does not create new pages.
+3. **Sharpen** — Patch in place: commands, lists, links, **colored** mermaid; match **current** tree, CI, and **`internal-write-gh-evaluate`**. **Implicit markdown conventions (no user citation required)** — apply together with this step whenever the file has **`## Contents`**, **overview** prose, **tables**, or **mermaid**: **`internal-read-git-doc-index`** (numbered lists; **no** index tables), **`internal-read-git-doc-explanation`** (explanation sections), **`internal-read-git-doc-table`** (reference tables: sort + largest-row callout), **`internal-read-git-doc-graphs`** (when to diagram + palette), **`internal-read-git-doc-exemplars`** (tone/rubric), **`internal-read-git-readme-root`** (minimal root README when path is repo root), **`internal-read-git-repo-layout`** (hub vs mirror). **Do not** duplicate long prose from those libraries in chat—open the linked **`SKILL.md`** when needed.
+4. **Do not** use this library as a shortcut for **`@git-docs`** or **`@git-commit`**—those skills own broader in-place doc edits and staging/commits respectively.
+
+---
+
+## Do not
+
+- **Create** new `.md` files (including scaffold / “missing page” fills).
+- Run if Evaluate **failed**.
+- `git commit` / `git push`.
+
+---
+
+## Verification
+
+- [ ] Only existing paths were modified.
+- [ ] Docs match repo + checks; **`## Contents`** avoids markdown **tables** for pure indexes; **reference tables** follow **`internal-read-git-doc-table`** when edited.
+
+---
+
+## Notes
+
+- Prefer **mermaid** in `.md` for flowcharts (**`skills/read/git/doc-graphs/diagrams/`** + **`internal-read-git-doc-graphs`**).
+- **`SKILL.md`** conventions: keep **`name`** / **`description`** accurate; link delegates instead of duplicating command fences.
+
+## See also
+
+- [`internal-read-git-readme-tree`](../../read/git/readme-tree/SKILL.md) — read-only mirror bootstrap + checklist
+- [`internal-read-git-repo-layout`](../../read/git/repo-layout/SKILL.md)
+- [`@git-docs`](../../../git/docs/SKILL.md)
+- [`@git-review`](../../../git/review/SKILL.md) §8a

--- a/.agents/skills/internal-write-gh-evaluate/SKILL.md
+++ b/.agents/skills/internal-write-gh-evaluate/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: internal-write-gh-evaluate
+description: >-
+  Evaluate batch: run umbrella (if any), format (prefer fix/write), lint, test, coverage per configured stacks.
+  Sole definition of which verify commands run—@git-review orchestrates; this library holds the matrix.
+---
+
+# Internal: Evaluate (format / lint / test / coverage)
+
+**Library.** **§4–§7** analogue for **`@git-review`**: run checks after **[`internal-write-gh-install-dependencies`](../install-dependencies/SKILL.md)** using the plan from **[`internal-read-git-configuration`](../../../read/git/configuration/SKILL.md)**. **Intent:** leave the workspace **working and formatted**, not only report failures.
+
+**Write safety:** when a formatter/fixer will write files, capture a short **Goal**, use **AskQuestion** confirmation when the write set is large, and execute only after explicit **Proceed/confirm** in line with **`internal-write-plan-skill-safety`** and **`internal-write-plan-structured-qa`**.
+
+**Consumers:** **[`@git-review`](../../../git/review/SKILL.md)** §4–7.
+
+---
+
+## 4. Umbrella (when defined)
+
+If README/CI defines a **single** entry (`make check`, `npm run check`, `pnpm run validate`, `task check`, …): run **first**.
+
+- Pass + covers analysis + tests (+ coverage if expected): may **skip** separate format/lint/test **unless** README/CI requires parity for separate steps. Still run **coverage-only** step when configuration says umbrella did not enforce it.
+- **Fail:** report command and output; **do not** run **[`internal-write-gh-documentation`](../documentation/SKILL.md)** until green.
+
+---
+
+## 5. Format (if umbrella did not cover or did not run)
+
+Prettier, Ruff format, Black, `cargo fmt`, `gofmt`, … from `package.json` / config.
+
+- Prefer **fix** (write) when the project defines it (`npm run format`, `ruff format` without `--review`, `cargo fmt` without `--review`, …) so sources end **formatted**.
+- If only **check** mode exists (`prettier --review`, `cargo fmt --review`, …), run it; on failure, run the matching **fix** command from README or scripts when documented, then re-review.
+- **Skip** if no formatter for that stack.
+
+---
+
+## 6. Lint
+
+`cargo clippy`, `ruff check`, `flake8`, `eslint`, `golangci-lint`, `go vet`, … per stack **present**.
+
+---
+
+## 7. Test and coverage
+
+### 7a. Tests
+
+`npm test`, `pnpm test`, `cargo test`, `pytest`, `go test ./...`, … per stack.
+
+**Docs-only:** skip §7a with reason; treat evaluate as passed for documentation step if format/lint skipped or passed.
+
+### 7b. Coverage
+
+Only if discovery found an expectation. Run documented script/Makefile/CI-local commands; report thresholds and artifacts.
+
+---
+
+## Do not
+
+- Install deps (that was Prepare).
+- **[`internal-write-gh-documentation`](../documentation/SKILL.md)** — **`@git-review`** **§8a** runs it **after** green Evaluate; do **not** run it inside this skill.
+
+## See also
+
+- **`@git-review`** — orchestrator for **[`internal-write-gh-evaluate`](../evaluate/SKILL.md)** §4–7.

--- a/.agents/skills/internal-write-gh-install-dependencies/SKILL.md
+++ b/.agents/skills/internal-write-gh-install-dependencies/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: internal-write-gh-install-dependencies
+description: >-
+  Prepare batch: install deps and build per README/CI for stacks present. Used by @git-review §3.
+  Destructive cleans require user confirm per internal-write-plan-structured-qa.
+---
+
+# Internal: Install dependencies (prepare)
+
+**Library.** Single **Prepare** batch for **`@git-review`**: install/build so format, lint, and tests can run.
+**Safety gate:** When the agent executes network installs or destructive cleans, require **Goal + structured confirm** via **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** before execution.
+**Master-confirm rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** do not bypass session-level confirm for destructive cleans or agent-run install/write actions.
+
+**Consumers:** **[`@git-review`](../../../git/review/SKILL.md)** §3, after **[`internal-read-git-discover-dependencies`](../../read/git/discover-dependencies/SKILL.md)** + gap map.
+
+**Default posture:** **Prompt the user** with **copy-paste Terminal command batches** and a **one-line reason**; the user runs installs **by hand**. The agent **may** run installs only when the user has **explicitly** asked the agent to execute prepare in this session—otherwise treat **network GET / package installs** as **user-run**. **Destructive** wipes (`rm -rf node_modules`, full venv delete) still require **structured confirm** regardless.
+
+---
+
+## Commands (by stack — minimal defaults)
+
+When the user will run commands themselves, print the exact block(s). When executing as agent, use **in README order** when documented; else:
+
+- **Node:** Lockfile-first (`npm ci`, `yarn install --frozen-lockfile`, `pnpm install --frozen-lockfile`) else `npm install` / `yarn` / `pnpm`; respect workspaces.
+- **Python:** `pip install -e .`, `uv sync`, `poetry install`, `pip install -r requirements.txt`, … per `pyproject.toml` / README.
+- **Rust:** `cargo fetch` / `cargo build` as needed for Clippy/tests.
+- **Go:** `go mod download`; `go build ./...` if required.
+- **Ruby / JVM / .NET:** follow README.
+
+**Before** `rm -rf node_modules`, full venv wipe, or similar: **structured confirm** (**[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** destructive-install row + **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** **§3a**)—not chat-only yes/no.
+
+---
+
+## Do not
+
+- Run format, lint, or test **as verification**—that is **[`internal-write-gh-evaluate`](../evaluate/SKILL.md)**.
+- Commit or push.
+
+## See also
+
+- **[`internal-read-git-configuration`](../../read/git/configuration/SKILL.md)** — next step: resolve evaluate commands.

--- a/.agents/skills/internal-write-gh-issue-commands-close-as-duplicate/SKILL.md
+++ b/.agents/skills/internal-write-gh-issue-commands-close-as-duplicate/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: internal-write-gh-issue-commands-close-as-duplicate
+description: >-
+  Read-only: close issue as duplicate (gh shapes). Parent internal-write-gh-issue-commands.
+---
+
+# Close as duplicate
+
+GitHub does not merge issue bodies; use **duplicate** semantics.
+
+**After user Proceed:**
+
+1. Comment on the duplicate with a link to the canonical issue: `gh issue comment <dup> --body "Duplicate of #<canonical> …"`.
+2. Close the duplicate: `gh issue close <dup>` (or `gh issue close <dup> --reason "not planned"` if your `gh` version supports reason flags—match local `gh issue close --help`).
+
+Replace `<dup>` / `<canonical>` with numeric ids. **Confirm before** any `gh issue comment` / `gh issue close`.

--- a/.agents/skills/internal-write-gh-issue-commands-delete-closed-issues/SKILL.md
+++ b/.agents/skills/internal-write-gh-issue-commands-delete-closed-issues/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: internal-write-gh-issue-commands-delete-closed-issues
+description: >-
+  Read-only: bulk delete closed issues (gh shapes). Parent internal-write-gh-issue-commands.
+---
+
+# Bulk delete closed issues
+
+**Normative CLI shapes** — **list:** [`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md); **delete:** [`internal-write-gh-issue-commands`](./SKILL.md). **Public skill:** **`@gh-issue-delete-closed`**.
+
+**Before you run anything**
+
+1. **Goal** — Why delete closed issues.
+2. **Preview** — List closed issues (ids + titles); confirm count matches intent.
+3. **Structured confirm** — **Proceed** / **Cancel** per **`internal-write-plan-structured-qa`** + **`internal-write-plan-skill-safety`**.
+4. **Permissions** — Deleting issues requires appropriate **GitHub** role; **`gh`** errors are authoritative.
+
+**After Proceed:** Run **`gh issue delete <n> --yes`** (or per **`gh issue delete --help`**) one issue at a time; stop on failure.
+
+**Do not** delete **open** issues from this checklist unless the flow was explicitly re-scoped.

--- a/.agents/skills/internal-write-gh-issue-commands-issue-create-prompt/SKILL.md
+++ b/.agents/skills/internal-write-gh-issue-commands-issue-create-prompt/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: internal-write-gh-issue-commands-issue-create-prompt
+description: >-
+  Read-only: gh issue create checklist and body-file patterns. Parent internal-write-gh-issue-commands.
+---
+
+# Issue create prompt
+
+**Before mutation:** Goal + **AskQuestion** + Proceed ([`internal-write-plan-structured-qa`](../../../plan/structured-qa/SKILL.md)).
+
+**Steps**
+
+1. Run [`internal-read-gh-issue-dedupe`](../../../../read/gh/issue-dedupe/SKILL.md) with candidate title + body summary (read-only).
+2. Draft **title** from [title line](../../../../read/gh/pr-content/title-line/SKILL.md); **body** from [issue body skeleton](../../../../read/gh/issue-description/issue-body-skeleton/SKILL.md) (and template merge from **`internal-read-gh-issue-description`**).
+3. **Labels (default path):** run [`internal-read-gh-issue-labels`](../../../../read/gh/issue-labels/SKILL.md) after title/body drafting. Confirm **`gh label create`** separately when needed ([`internal-write-plan-skill-safety`](../../../plan/skill-safety/SKILL.md)). On Proceed, pass **`--label "a,b"`** to **`gh issue create`** (or **`--add-label` / `--remove-label`** on **`gh issue edit`**) when the user accepts label changes; skip labels only on explicit decline.
+4. **Projects (default path for current-repo ship):** run [`internal-read-gh-issue-projects-relationships`](../../../../read/gh/issue-projects-relationships/SKILL.md) after the target **`owner/repo`** is known. Include **`--project "…"`** on **`gh issue create`** or **`--add-project "…"`** on **`gh issue edit`** in the mutation summary when there is a single unambiguous board title (or a user-supplied title); use **`gh project item-add`** from [`internal-write-gh-issue-commands`](../SKILL.md) only as a documented fallback. If discovery fails, scope is missing, or titles collide, record **skip** + reason in chat—never treat a skipped attach as success without saying so.
+5. Prefer body files in `.cursor/gh/issues/` for batch creation (for example `.cursor/gh/issues/<slug>.md`).
+6. On Proceed: run the agreed **`gh issue create`** / **`gh issue edit`** line from [`internal-write-gh-issue-commands`](../SKILL.md) (labels + project flags as accepted); never skip dedupe when the user asked for a **new** tracked issue.

--- a/.agents/skills/internal-write-gh-issue-commands/SKILL.md
+++ b/.agents/skills/internal-write-gh-issue-commands/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: internal-write-gh-issue-commands
+description: >-
+  Normative gh issue view, delete, edit, create, and close CLI shapes (write / GitHub). List/search inventory lives in
+  internal-read-gh-issue-list. Callers run structured Q&A before mutating commands. Mutation fences grouped at end;
+  execution is agent-led per parent skill.
+---
+
+# Internal: GitHub issue CLI (`internal-write-gh-issue-commands`)
+
+**Write library (GitHub / `gh`).** **`gh issue`** command shapes for **view**, **delete**, **edit**, **create**, and **close**, consumed by **`@gh-issue-view`**, **`@gh-issue-delete-closed`** (delete only), **`@gh-issue-close`**, **`@gh-issue-review`** (view path), and **`@gh-issues`** (router owns create-or-edit). **Mutations** require **Goal + AskQuestion + Proceed** in the **public** skill via **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)**.
+**Master-confirm rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** do not bypass session-level confirm for any GitHub mutation in this library.
+
+**List / search** — **[`internal-read-gh-issue-list`](../../read/gh/issue-list/SKILL.md)** (sole **`gh issue list`** / **`gh search issues`** fences).
+
+**`gh repo view`** for **issue/PR templates** is **not** here—use **[`internal-read-gh-repo-forms-json`](../../read/gh/repo-forms-json/SKILL.md)**.
+
+## View (single issue)
+
+**Full extract (preferred for planning/execution):**
+
+```bash
+gh issue view <N> --json id,number,title,body,state,stateReason,url,author,assignees,labels,milestone,projectCards,closed,closedAt,createdAt,updatedAt,reactionGroups,comments
+```
+
+**Full extract with explicit repo:**
+
+```bash
+gh issue view <N> --repo owner/repo --json id,number,title,body,state,stateReason,url,author,assignees,labels,milestone,projectCards,closed,closedAt,createdAt,updatedAt,reactionGroups,comments
+```
+
+**By number** (current repo):
+
+```bash
+gh issue view <N> --json number,title,body,state,url,labels,assignees
+```
+
+**With comments** (when user needs thread for planning):
+
+```bash
+gh issue view <N> --json number,title,body,state,url,labels,assignees,comments
+```
+
+**From URL** — resolve **`owner/repo`** and **`N`** from `https://github.com/owner/repo/issues/N`, then:
+
+```bash
+gh issue view <N> --repo owner/repo --json number,title,body,state,url,labels,assignees,comments
+```
+
+**`#123` in chat** — treat as numeric **`<N>`** for default **`gh`** repo context.
+
+## Delete one closed issue
+
+**Only after** structured **Proceed** in **`@gh-issue-delete-closed`**. Flag availability varies by **`gh`** version—check **`gh issue delete --help`**.
+
+```bash
+gh issue delete <N> --yes
+```
+
+Use **`--repo owner/repo`** when not in default context.
+
+## Edit issue (after Proceed)
+
+**Only after** structured **Proceed** in **`@gh-issues`** when the chosen path is edit. Compose flags from **[`internal-read-gh-issue-description`](../../read/gh/issue-description/SKILL.md)** output and **[`internal-read-gh-issue-labels`](../../read/gh/issue-labels/SKILL.md)** when labels change. Multi-intent **Proceed — batch** may include **multiple** `gh issue edit` lines (and/or creates) in one confirmed batch—in the summarized order.
+
+```bash
+gh issue edit <N> --title "New title"
+```
+
+```bash
+gh issue edit <N> --body-file /path/to/body.md
+```
+
+```bash
+gh issue edit <N> --add-label "bug" --remove-label "triage"
+```
+
+## Create issue (after Proceed)
+
+**Only after** structured **Proceed** in **`@gh-issues`** when the chosen path is create. Full checklist and body file patterns: **[`issue-create-prompt/SKILL.md`](./issue-create-prompt/SKILL.md)**. When **`@gh-issues`** multi-intent batching applies, **several** `gh issue create` (and/or `gh issue edit`) commands may run **in sequence** after **one** parent Proceed, in the order fixed in that Proceed summary.
+
+```bash
+gh issue create --title "…" --body-file /path/to/body.md
+```
+
+```bash
+gh issue create --title "…" --body-file /path/to/body.md --label "bug,area:skills"
+```
+
+## Project attach (same Proceed batch as create/edit)
+
+**Plan + summarize** before **`gh`** using **[`internal-read-gh-issue-projects-relationships`](../../read/gh/issue-projects-relationships/SKILL.md)** (discovery, auth, ambiguity, GHES fallbacks). **Additive** only: do not skip structured Q&A / Proceed; if attach is skipped after a failed command, say so explicitly (not a silent success).
+
+**Create** — add by **project title** (requires **`project`** scope; see **`gh issue create --help`**):
+
+```bash
+gh issue create --title "…" --body-file /path/to/body.md --project "Project title"
+```
+
+```bash
+gh issue create --title "…" --body-file /path/to/body.md --label "bug,area:skills" --project "Project title" --repo owner/repo
+```
+
+**Edit** — when the issue exists but is missing from a board (**`gh issue edit --help`** lists **`--add-project`**):
+
+```bash
+gh issue edit <N> --add-project "Project title"
+```
+
+```bash
+gh issue edit <N> --add-project "Project title" --repo owner/repo
+```
+
+**Fallback** — add an existing issue URL to a project by **number** (when title-based attach is unsuitable or failed once with an unambiguous **`PROJECT_NUMBER`**):
+
+```bash
+gh project item-add <PROJECT_NUMBER> --owner OWNER_LOGIN --url https://github.com/owner/repo/issues/<N>
+```
+
+**Link project to repo** (maintainer setup; only when the user explicitly asked—may be a separate Proceed):
+
+```bash
+gh project link <PROJECT_NUMBER> --owner OWNER_LOGIN --repo owner/repo
+```
+
+## Close issue (after Proceed)
+
+**Only after** structured **Proceed** in **`@gh-issue-close`**.
+
+```bash
+gh issue close <N> --comment "…"
+```
+
+## See also
+
+- **[`internal-read-gh-issue-projects-relationships`](../../read/gh/issue-projects-relationships/SKILL.md)** — project discovery + issue relationship playbook (read-only).
+- **[`internal-read-gh-issue-list`](../../read/gh/issue-list/SKILL.md)** — **`gh issue list`** / **`gh search issues`** (read-only inventory).
+- **[`internal-write-gh-pr-commands`](../pr-commands/SKILL.md)** — **`gh pr create`**, **`gh pr edit`**, and **`gh pr close`** command shapes.
+- **[`internal-read-gh-repo-forms-json`](../../read/gh/repo-forms-json/SKILL.md)** — **`gh repo view --json`** for template metadata.
+- [`@gh-issue-review`](../../../gh/issues/review/SKILL.md)
+- [`@gh-issue-view`](../../../gh/issues/view/SKILL.md)
+- [`@gh-issue-list`](../../../gh/issues/list/SKILL.md)
+- [`@gh-issue-pick`](../../../gh/issues/pick/SKILL.md)
+- [`@gh-issue-delete-closed`](../../../gh/issues/delete-closed/SKILL.md)
+- [`@gh-issues`](../../../gh/issues/SKILL.md) · [`@gh-issue-close`](../../../gh/issues/close/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/internal-write-gh-issue-commands/close-as-duplicate/SKILL.md
+++ b/.agents/skills/internal-write-gh-issue-commands/close-as-duplicate/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: internal-write-gh-issue-commands-close-as-duplicate
+description: >-
+  Read-only: close issue as duplicate (gh shapes). Parent internal-write-gh-issue-commands.
+---
+
+# Close as duplicate
+
+GitHub does not merge issue bodies; use **duplicate** semantics.
+
+**After user Proceed:**
+
+1. Comment on the duplicate with a link to the canonical issue: `gh issue comment <dup> --body "Duplicate of #<canonical> …"`.
+2. Close the duplicate: `gh issue close <dup>` (or `gh issue close <dup> --reason "not planned"` if your `gh` version supports reason flags—match local `gh issue close --help`).
+
+Replace `<dup>` / `<canonical>` with numeric ids. **Confirm before** any `gh issue comment` / `gh issue close`.

--- a/.agents/skills/internal-write-gh-issue-commands/delete-closed-issues/SKILL.md
+++ b/.agents/skills/internal-write-gh-issue-commands/delete-closed-issues/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: internal-write-gh-issue-commands-delete-closed-issues
+description: >-
+  Read-only: bulk delete closed issues (gh shapes). Parent internal-write-gh-issue-commands.
+---
+
+# Bulk delete closed issues
+
+**Normative CLI shapes** — **list:** [`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md); **delete:** [`internal-write-gh-issue-commands`](./SKILL.md). **Public skill:** **`@gh-issue-delete-closed`**.
+
+**Before you run anything**
+
+1. **Goal** — Why delete closed issues.
+2. **Preview** — List closed issues (ids + titles); confirm count matches intent.
+3. **Structured confirm** — **Proceed** / **Cancel** per **`internal-write-plan-structured-qa`** + **`internal-write-plan-skill-safety`**.
+4. **Permissions** — Deleting issues requires appropriate **GitHub** role; **`gh`** errors are authoritative.
+
+**After Proceed:** Run **`gh issue delete <n> --yes`** (or per **`gh issue delete --help`**) one issue at a time; stop on failure.
+
+**Do not** delete **open** issues from this checklist unless the flow was explicitly re-scoped.

--- a/.agents/skills/internal-write-gh-issue-commands/issue-create-prompt/SKILL.md
+++ b/.agents/skills/internal-write-gh-issue-commands/issue-create-prompt/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: internal-write-gh-issue-commands-issue-create-prompt
+description: >-
+  Read-only: gh issue create checklist and body-file patterns. Parent internal-write-gh-issue-commands.
+---
+
+# Issue create prompt
+
+**Before mutation:** Goal + **AskQuestion** + Proceed ([`internal-write-plan-structured-qa`](../../../plan/structured-qa/SKILL.md)).
+
+**Steps**
+
+1. Run [`internal-read-gh-issue-dedupe`](../../../../read/gh/issue-dedupe/SKILL.md) with candidate title + body summary (read-only).
+2. Draft **title** from [title line](../../../../read/gh/pr-content/title-line/SKILL.md); **body** from [issue body skeleton](../../../../read/gh/issue-description/issue-body-skeleton/SKILL.md) (and template merge from **`internal-read-gh-issue-description`**).
+3. **Labels (default path):** run [`internal-read-gh-issue-labels`](../../../../read/gh/issue-labels/SKILL.md) after title/body drafting. Confirm **`gh label create`** separately when needed ([`internal-write-plan-skill-safety`](../../../plan/skill-safety/SKILL.md)). On Proceed, pass **`--label "a,b"`** to **`gh issue create`** (or **`--add-label` / `--remove-label`** on **`gh issue edit`**) when the user accepts label changes; skip labels only on explicit decline.
+4. **Projects (default path for current-repo ship):** run [`internal-read-gh-issue-projects-relationships`](../../../../read/gh/issue-projects-relationships/SKILL.md) after the target **`owner/repo`** is known. Include **`--project "…"`** on **`gh issue create`** or **`--add-project "…"`** on **`gh issue edit`** in the mutation summary when there is a single unambiguous board title (or a user-supplied title); use **`gh project item-add`** from [`internal-write-gh-issue-commands`](../SKILL.md) only as a documented fallback. If discovery fails, scope is missing, or titles collide, record **skip** + reason in chat—never treat a skipped attach as success without saying so.
+5. Prefer body files in `.cursor/gh/issues/` for batch creation (for example `.cursor/gh/issues/<slug>.md`).
+6. On Proceed: run the agreed **`gh issue create`** / **`gh issue edit`** line from [`internal-write-gh-issue-commands`](../SKILL.md) (labels + project flags as accepted); never skip dedupe when the user asked for a **new** tracked issue.

--- a/.agents/skills/internal-write-gh-pr-commands/SKILL.md
+++ b/.agents/skills/internal-write-gh-pr-commands/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: internal-write-gh-pr-commands
+description: >-
+  Normative gh pr create/edit/close shapes; optional gh project item-add for PR/issue URLs; read-only gh pr view JSON
+  for closingIssuesReferences. PR list/view lives in internal-read-gh-pr-list. Callers run structured Q&A before mutations.
+---
+
+# Internal: GitHub pull request mutations (`internal-write-gh-pr-commands`)
+
+**Write library (GitHub / `gh` / API).** **`gh pr create`**, **`gh pr edit`**, and **`gh pr close`** shapes consumed by **`@gh-pr`** and **`@gh-pr-close`**. **Mutations** require **Goal + AskQuestion + Proceed** in the **public** skill via **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)**.
+**Master-confirm rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** do not bypass session-level confirm for any GitHub mutation in this library.
+
+**List / view / diff stat** — **[`internal-read-gh-pr-list`](../../read/gh/pr-list/SKILL.md)** (sole read-only **`gh pr list`** / **`gh pr view`** / **`gh pr diff --stat`** fences).
+
+**`gh repo view`** for **PR templates** is **not** here—use **[`internal-read-gh-repo-forms-json`](../../read/gh/repo-forms-json/SKILL.md)**.
+
+## Platform note (read before Proceed)
+
+- GitHub does not provide issue-parity hard-delete behavior for pull requests in common `gh` setups.
+- PR archive APIs are admin-scoped and are not exposed as a packaged bulk mutation skill in this pack.
+- For cleanup policy work on closed PRs, use GitHub UI and repository/org governance outside this library.
+- **PR ↔ issue (Development / closing semantics):** There is **no** official `gh` flag to set the web **Development** sidebar link without **closing keywords in the PR body** or **manual UI**; platform gap is tracked as [`cli/cli#11405`](https://github.com/cli/cli/issues/11405). **`gh pr view --json closingIssuesReferences`** is **read-only** and reflects what GitHub already inferred (often from body keywords). See **[`internal-read-gh-pr-description`](../../read/gh/pr-description/SKILL.md)** §6.5–6.6 and [GitHub docs: linking PRs to issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+## Create PR (after Proceed)
+
+**Only for** **`@gh-pr`** **§9**, after the final structured **Proceed** there. Resolve `--repo`, `--base`, and `--head` through **`internal-read-gh-repo-stream`**. When the **§9** summary chose the **keyword path**, put **`Refs #n` / `Fixes #n` / `Closes #n`** in the PR body text (or body file)—there are **no** separate `gh pr create` flags for that linkage. Otherwise omit keyword lines and use **Projects** and/or UI per **[`internal-read-gh-issue-projects-relationships`](../../read/gh/issue-projects-relationships/SKILL.md)**.
+
+```bash
+gh pr create --repo owner/repo --base main --head feature-branch --title "Title" --body-file /path/to/body.md
+```
+
+## Edit PR (after Proceed)
+
+**Only for** **`@gh-pr`** **§9**, after the final structured **Proceed** there. Editing replaces title/body with regenerated content; keep issue keyword lines in the body **only when** the user confirmed that path (same rules as create).
+
+```bash
+gh pr edit <N> --repo owner/repo --title "Title" --body-file /path/to/body.md
+```
+
+## Optional: add PR and issues to a project (same Proceed batch as `@gh-pr` §9)
+
+When **`@gh-pr`** **§9** confirmed **project attach**, run **`gh project item-add`** once per URL **after** the PR number is known (create path: parse **`gh pr create`** output or run **`gh pr view --json url,number`** for the new PR). Use the **destination** repo URL shape for both PR and issues: **`https://github.com/OWNER/REPO/pull/<N>`** and **`https://github.com/OWNER/REPO/issues/<N>`** where **`OWNER/REPO`** matches **`PR_TARGET_REPO`** from **`internal-read-gh-repo-stream`**. Discovery, **`project`** token scope, and owner disambiguation: **[`internal-read-gh-issue-projects-relationships`](../../read/gh/issue-projects-relationships/SKILL.md)** + **[`internal-read-gh-project-list`](../../read/gh/project-list/SKILL.md)**.
+
+```bash
+gh project item-add <PROJECT_NUMBER> --owner OWNER_LOGIN --url https://github.com/owner/repo/pull/<PR_NUMBER>
+```
+
+```bash
+gh project item-add <PROJECT_NUMBER> --owner OWNER_LOGIN --url https://github.com/owner/repo/issues/<ISSUE_NUMBER>
+```
+
+**Fork:** **`owner/repo`** in URLs is the **upstream** destination (same as **`PR_TARGET_REPO`**), not the fork’s **`github.com/FORK_OWNER/…`** issue namespace unless the issue genuinely lives on the fork.
+
+## Read-only: verify linked issues metadata (after create/edit)
+
+```bash
+gh pr view <N> --repo owner/repo --json closingIssuesReferences,number,url,title
+```
+
+## Close PR (after Proceed)
+
+**Only for** **`@gh-pr-close`**, after **Goal** + **AskQuestion** + **Proceed**.
+
+```bash
+gh pr close <N>
+```
+
+Use **`--repo owner/upstream`** when closing against the fork’s upstream repo. Add **`--comment "…"`** when the user supplied a closing note.
+
+## See also
+
+- **[`internal-read-gh-pr-list`](../../read/gh/pr-list/SKILL.md)** — read-only **`gh pr list`** / **`view`** / **`diff --stat`**.
+- **[`internal-read-gh-pr-description`](../../read/gh/pr-description/SKILL.md)** — §6.5–7 linking + body rules.
+- **[`internal-read-gh-issue-projects-relationships`](../../read/gh/issue-projects-relationships/SKILL.md)** — project discovery + PR/issue **`item-add`** playbook.
+- **[`internal-write-gh-issue-commands`](../issue-commands/SKILL.md)** — **`gh issue`** view/create/edit/close/delete; issue **`item-add`** fallback fences.
+- **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)** — **`--repo`** targets for forks/upstream.
+- [`@gh-pr-close`](../../../gh/pr/close/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)
+- [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)

--- a/.agents/skills/internal-write-gh-project-commands-delete-closed-projects/SKILL.md
+++ b/.agents/skills/internal-write-gh-project-commands-delete-closed-projects/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: internal-write-gh-project-commands-delete-closed-projects
+description: >-
+  Read-only: bulk delete closed projects (gh shapes). Parent internal-write-gh-project-commands.
+---
+
+# Bulk delete closed projects
+
+**Normative CLI shapes** — **list:** [`internal-read-gh-project-list`](../../../../read/gh/project-list/SKILL.md); **delete:** [`internal-write-gh-project-commands`](../SKILL.md). **Public skill:** **`@gh-project-delete-closed`**.
+
+**Before you run anything**
+
+1. **Goal** — Why delete closed projects.
+2. **Preview** — List projects for the selected owner and filter to closed (`closed == true`); confirm count, number, and title match intent.
+3. **Structured confirm** — **Proceed** / **Cancel** per `internal-write-plan-structured-qa` + `internal-write-plan-skill-safety`.
+4. **Permissions** — Deleting projects requires appropriate GitHub role and `project` auth scope; `gh` errors are authoritative.
+
+**After Proceed:** run `gh project delete <NUMBER> --owner …` one project at a time; stop on first failure and report.
+
+**Do not** delete open projects from this checklist unless the flow was explicitly re-scoped.

--- a/.agents/skills/internal-write-gh-project-commands/SKILL.md
+++ b/.agents/skills/internal-write-gh-project-commands/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: internal-write-gh-project-commands
+description: >-
+  Normative gh project delete CLI shapes (write / GitHub). List/inventory lives in internal-read-gh-project-list.
+  Callers run Goal + AskQuestion + Proceed before mutations.
+---
+
+# Internal: GitHub project CLI (`internal-write-gh-project-commands`)
+
+**Write library (GitHub / `gh`).** **`gh project`** command shapes for delete flows consumed by **`@gh-project-delete-closed`**.
+
+**Mutations** require **Goal + AskQuestion + Proceed** in the public skill via **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)**.
+
+**Master-confirm rule:** `SKIP_QA_*` and `SKIP_QA_WRITE` do not bypass session-level confirm for any GitHub mutation in this library.
+
+**List / preview** lives in **[`internal-read-gh-project-list`](../../../read/gh/project-list/SKILL.md)**.
+
+## Delete one project
+
+Only after structured **Proceed** in **`@gh-project-delete-closed`**.
+
+```bash
+gh project delete <NUMBER> --owner "@me"
+```
+
+Use `--owner ORG_LOGIN` for organization-owned projects.
+
+## See also
+
+- **[`internal-read-gh-project-list`](../../../read/gh/project-list/SKILL.md)** — `gh project list` inventory fences.
+- [`@gh-project-delete-closed`](../../../gh/projects/delete-closed/SKILL.md)
+- [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/internal-write-gh-project-commands/delete-closed-projects/SKILL.md
+++ b/.agents/skills/internal-write-gh-project-commands/delete-closed-projects/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: internal-write-gh-project-commands-delete-closed-projects
+description: >-
+  Read-only: bulk delete closed projects (gh shapes). Parent internal-write-gh-project-commands.
+---
+
+# Bulk delete closed projects
+
+**Normative CLI shapes** — **list:** [`internal-read-gh-project-list`](../../../../read/gh/project-list/SKILL.md); **delete:** [`internal-write-gh-project-commands`](../SKILL.md). **Public skill:** **`@gh-project-delete-closed`**.
+
+**Before you run anything**
+
+1. **Goal** — Why delete closed projects.
+2. **Preview** — List projects for the selected owner and filter to closed (`closed == true`); confirm count, number, and title match intent.
+3. **Structured confirm** — **Proceed** / **Cancel** per `internal-write-plan-structured-qa` + `internal-write-plan-skill-safety`.
+4. **Permissions** — Deleting projects requires appropriate GitHub role and `project` auth scope; `gh` errors are authoritative.
+
+**After Proceed:** run `gh project delete <NUMBER> --owner …` one project at a time; stop on first failure and report.
+
+**Do not** delete open projects from this checklist unless the flow was explicitly re-scoped.

--- a/.agents/skills/internal-write-gh/SKILL.md
+++ b/.agents/skills/internal-write-gh/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: internal-write-gh
+description: >-
+  Internal GitHub-oriented mutating libraries for issue/PR commands plus install/evaluate/documentation batches.
+---
+
+# `skills/write/gh/`
+
+Mutating GitHub libraries used by public `@gh-*` and `@git-*` workflows.
+
+- `issue-commands`, `project-commands`, and `pr-commands` for GitHub CLI mutation fences.
+- `install-dependencies`, `evaluate`, `documentation` for verify/polish flows.
+
+Callers own confirmation gates before running mutating command blocks.

--- a/.agents/skills/internal-write-gh/documentation/SKILL.md
+++ b/.agents/skills/internal-write-gh/documentation/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: internal-write-gh-documentation
+description: >-
+  Sharpen existing docs/** (wiki sections, docs/** indexes, optional slimmer domain layouts on other repos),
+  minimal root README.md, and legacy paths if present. Runs as @git-review §8a after green evaluate. Does not create new
+  doc pages. Broader post-green pass: @git-docs. Not a substitute for @git-review §8a.
+---
+
+# Internal: Project documentation (`internal-write-gh-documentation`)
+
+**Library.** Single **batch** for **`@git-review`** **§8a**: after **[`internal-write-gh-evaluate`](../evaluate/SKILL.md)** succeeds, **edit existing** markdown only.
+
+**Write safety:** before any documentation mutation, set a clear **Goal**, present **AskQuestion** confirmation options when scope is non-trivial, and only proceed after explicit **Proceed/confirm** per **`internal-write-plan-skill-safety`** + **`internal-write-plan-structured-qa`**.
+
+**Consumers:** **`@git-review`** §8a only. For **missing `docs/.../README.md`** or mirror layout questions, read **`internal-read-git-readme-tree`** (read-only bootstrap + parity checklist) and **`internal-read-git-repo-layout`**—**do not** invent a bulk “regen” step here. For **post-green** doc accuracy (**existing** paths **in place**; **no** new/deleted/moved **`.md`**), **`@git-docs`**—read **`internal-read-git-repo-layout`** so links match the tree.
+
+**Scope:** **Complement** what already exists—align lists, links, and commands with **current** tree and CI. **Do not** bulk regen **`docs/`** here.
+
+---
+
+## Do
+
+1. **Repo root** — Target **open** project (not necessarily cursor-skills).
+2. **Inventory** — Always: **minimal** root **`README.md`**, **`docs/**`**. Include **existing** paths only: **`docs/README.md`** (simple repos may use **only** this file under **`docs/`**); if present, also profile wiki dirs (**`docs/architecture/`**, **`docs/organization/`**, **`docs/domains/`**, **`docs/workflows/`**, **`docs/data/`**, **`docs/conventions/`**, **`docs/operations/`**, **`docs/api/`**, **`docs/services/`**). If legacy **`skills/**/README.md`** (other repos) or root **`USER_GUIDE.md`** / **`REFERENCE.md`** still exist, include only when present—this pack keeps **no** README under **`skills/`** when mirror policy applies. **Do not** **create** new **`docs/`** pages here. If **no** **`docs/`** hub exists, point the user to **`internal-read-git-repo-layout`** / **`internal-read-git-readme-tree`**—**`@git-docs`** does not create new pages.
+3. **Sharpen** — Patch in place: commands, lists, links, **colored** mermaid; match **current** tree, CI, and **`internal-write-gh-evaluate`**. **Implicit markdown conventions (no user citation required)** — apply together with this step whenever the file has **`## Contents`**, **overview** prose, **tables**, or **mermaid**: **`internal-read-git-doc-index`** (numbered lists; **no** index tables), **`internal-read-git-doc-explanation`** (explanation sections), **`internal-read-git-doc-table`** (reference tables: sort + largest-row callout), **`internal-read-git-doc-graphs`** (when to diagram + palette), **`internal-read-git-doc-exemplars`** (tone/rubric), **`internal-read-git-readme-root`** (minimal root README when path is repo root), **`internal-read-git-repo-layout`** (hub vs mirror). **Do not** duplicate long prose from those libraries in chat—open the linked **`SKILL.md`** when needed.
+4. **Do not** use this library as a shortcut for **`@git-docs`** or **`@git-commit`**—those skills own broader in-place doc edits and staging/commits respectively.
+
+---
+
+## Do not
+
+- **Create** new `.md` files (including scaffold / “missing page” fills).
+- Run if Evaluate **failed**.
+- `git commit` / `git push`.
+
+---
+
+## Verification
+
+- [ ] Only existing paths were modified.
+- [ ] Docs match repo + checks; **`## Contents`** avoids markdown **tables** for pure indexes; **reference tables** follow **`internal-read-git-doc-table`** when edited.
+
+---
+
+## Notes
+
+- Prefer **mermaid** in `.md` for flowcharts (**`skills/read/git/doc-graphs/diagrams/`** + **`internal-read-git-doc-graphs`**).
+- **`SKILL.md`** conventions: keep **`name`** / **`description`** accurate; link delegates instead of duplicating command fences.
+
+## See also
+
+- [`internal-read-git-readme-tree`](../../read/git/readme-tree/SKILL.md) — read-only mirror bootstrap + checklist
+- [`internal-read-git-repo-layout`](../../read/git/repo-layout/SKILL.md)
+- [`@git-docs`](../../../git/docs/SKILL.md)
+- [`@git-review`](../../../git/review/SKILL.md) §8a

--- a/.agents/skills/internal-write-gh/evaluate/SKILL.md
+++ b/.agents/skills/internal-write-gh/evaluate/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: internal-write-gh-evaluate
+description: >-
+  Evaluate batch: run umbrella (if any), format (prefer fix/write), lint, test, coverage per configured stacks.
+  Sole definition of which verify commands run—@git-review orchestrates; this library holds the matrix.
+---
+
+# Internal: Evaluate (format / lint / test / coverage)
+
+**Library.** **§4–§7** analogue for **`@git-review`**: run checks after **[`internal-write-gh-install-dependencies`](../install-dependencies/SKILL.md)** using the plan from **[`internal-read-git-configuration`](../../../read/git/configuration/SKILL.md)**. **Intent:** leave the workspace **working and formatted**, not only report failures.
+
+**Write safety:** when a formatter/fixer will write files, capture a short **Goal**, use **AskQuestion** confirmation when the write set is large, and execute only after explicit **Proceed/confirm** in line with **`internal-write-plan-skill-safety`** and **`internal-write-plan-structured-qa`**.
+
+**Consumers:** **[`@git-review`](../../../git/review/SKILL.md)** §4–7.
+
+---
+
+## 4. Umbrella (when defined)
+
+If README/CI defines a **single** entry (`make check`, `npm run check`, `pnpm run validate`, `task check`, …): run **first**.
+
+- Pass + covers analysis + tests (+ coverage if expected): may **skip** separate format/lint/test **unless** README/CI requires parity for separate steps. Still run **coverage-only** step when configuration says umbrella did not enforce it.
+- **Fail:** report command and output; **do not** run **[`internal-write-gh-documentation`](../documentation/SKILL.md)** until green.
+
+---
+
+## 5. Format (if umbrella did not cover or did not run)
+
+Prettier, Ruff format, Black, `cargo fmt`, `gofmt`, … from `package.json` / config.
+
+- Prefer **fix** (write) when the project defines it (`npm run format`, `ruff format` without `--review`, `cargo fmt` without `--review`, …) so sources end **formatted**.
+- If only **check** mode exists (`prettier --review`, `cargo fmt --review`, …), run it; on failure, run the matching **fix** command from README or scripts when documented, then re-review.
+- **Skip** if no formatter for that stack.
+
+---
+
+## 6. Lint
+
+`cargo clippy`, `ruff check`, `flake8`, `eslint`, `golangci-lint`, `go vet`, … per stack **present**.
+
+---
+
+## 7. Test and coverage
+
+### 7a. Tests
+
+`npm test`, `pnpm test`, `cargo test`, `pytest`, `go test ./...`, … per stack.
+
+**Docs-only:** skip §7a with reason; treat evaluate as passed for documentation step if format/lint skipped or passed.
+
+### 7b. Coverage
+
+Only if discovery found an expectation. Run documented script/Makefile/CI-local commands; report thresholds and artifacts.
+
+---
+
+## Do not
+
+- Install deps (that was Prepare).
+- **[`internal-write-gh-documentation`](../documentation/SKILL.md)** — **`@git-review`** **§8a** runs it **after** green Evaluate; do **not** run it inside this skill.
+
+## See also
+
+- **`@git-review`** — orchestrator for **[`internal-write-gh-evaluate`](../evaluate/SKILL.md)** §4–7.

--- a/.agents/skills/internal-write-gh/install-dependencies/SKILL.md
+++ b/.agents/skills/internal-write-gh/install-dependencies/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: internal-write-gh-install-dependencies
+description: >-
+  Prepare batch: install deps and build per README/CI for stacks present. Used by @git-review §3.
+  Destructive cleans require user confirm per internal-write-plan-structured-qa.
+---
+
+# Internal: Install dependencies (prepare)
+
+**Library.** Single **Prepare** batch for **`@git-review`**: install/build so format, lint, and tests can run.
+**Safety gate:** When the agent executes network installs or destructive cleans, require **Goal + structured confirm** via **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** before execution.
+**Master-confirm rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** do not bypass session-level confirm for destructive cleans or agent-run install/write actions.
+
+**Consumers:** **[`@git-review`](../../../git/review/SKILL.md)** §3, after **[`internal-read-git-discover-dependencies`](../../read/git/discover-dependencies/SKILL.md)** + gap map.
+
+**Default posture:** **Prompt the user** with **copy-paste Terminal command batches** and a **one-line reason**; the user runs installs **by hand**. The agent **may** run installs only when the user has **explicitly** asked the agent to execute prepare in this session—otherwise treat **network GET / package installs** as **user-run**. **Destructive** wipes (`rm -rf node_modules`, full venv delete) still require **structured confirm** regardless.
+
+---
+
+## Commands (by stack — minimal defaults)
+
+When the user will run commands themselves, print the exact block(s). When executing as agent, use **in README order** when documented; else:
+
+- **Node:** Lockfile-first (`npm ci`, `yarn install --frozen-lockfile`, `pnpm install --frozen-lockfile`) else `npm install` / `yarn` / `pnpm`; respect workspaces.
+- **Python:** `pip install -e .`, `uv sync`, `poetry install`, `pip install -r requirements.txt`, … per `pyproject.toml` / README.
+- **Rust:** `cargo fetch` / `cargo build` as needed for Clippy/tests.
+- **Go:** `go mod download`; `go build ./...` if required.
+- **Ruby / JVM / .NET:** follow README.
+
+**Before** `rm -rf node_modules`, full venv wipe, or similar: **structured confirm** (**[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** destructive-install row + **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** **§3a**)—not chat-only yes/no.
+
+---
+
+## Do not
+
+- Run format, lint, or test **as verification**—that is **[`internal-write-gh-evaluate`](../evaluate/SKILL.md)**.
+- Commit or push.
+
+## See also
+
+- **[`internal-read-git-configuration`](../../read/git/configuration/SKILL.md)** — next step: resolve evaluate commands.

--- a/.agents/skills/internal-write-gh/issue-commands/SKILL.md
+++ b/.agents/skills/internal-write-gh/issue-commands/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: internal-write-gh-issue-commands
+description: >-
+  Normative gh issue view, delete, edit, create, and close CLI shapes (write / GitHub). List/search inventory lives in
+  internal-read-gh-issue-list. Callers run structured Q&A before mutating commands. Mutation fences grouped at end;
+  execution is agent-led per parent skill.
+---
+
+# Internal: GitHub issue CLI (`internal-write-gh-issue-commands`)
+
+**Write library (GitHub / `gh`).** **`gh issue`** command shapes for **view**, **delete**, **edit**, **create**, and **close**, consumed by **`@gh-issue-view`**, **`@gh-issue-delete-closed`** (delete only), **`@gh-issue-close`**, **`@gh-issue-review`** (view path), and **`@gh-issues`** (router owns create-or-edit). **Mutations** require **Goal + AskQuestion + Proceed** in the **public** skill via **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)**.
+**Master-confirm rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** do not bypass session-level confirm for any GitHub mutation in this library.
+
+**List / search** — **[`internal-read-gh-issue-list`](../../read/gh/issue-list/SKILL.md)** (sole **`gh issue list`** / **`gh search issues`** fences).
+
+**`gh repo view`** for **issue/PR templates** is **not** here—use **[`internal-read-gh-repo-forms-json`](../../read/gh/repo-forms-json/SKILL.md)**.
+
+## View (single issue)
+
+**Full extract (preferred for planning/execution):**
+
+```bash
+gh issue view <N> --json id,number,title,body,state,stateReason,url,author,assignees,labels,milestone,projectCards,closed,closedAt,createdAt,updatedAt,reactionGroups,comments
+```
+
+**Full extract with explicit repo:**
+
+```bash
+gh issue view <N> --repo owner/repo --json id,number,title,body,state,stateReason,url,author,assignees,labels,milestone,projectCards,closed,closedAt,createdAt,updatedAt,reactionGroups,comments
+```
+
+**By number** (current repo):
+
+```bash
+gh issue view <N> --json number,title,body,state,url,labels,assignees
+```
+
+**With comments** (when user needs thread for planning):
+
+```bash
+gh issue view <N> --json number,title,body,state,url,labels,assignees,comments
+```
+
+**From URL** — resolve **`owner/repo`** and **`N`** from `https://github.com/owner/repo/issues/N`, then:
+
+```bash
+gh issue view <N> --repo owner/repo --json number,title,body,state,url,labels,assignees,comments
+```
+
+**`#123` in chat** — treat as numeric **`<N>`** for default **`gh`** repo context.
+
+## Delete one closed issue
+
+**Only after** structured **Proceed** in **`@gh-issue-delete-closed`**. Flag availability varies by **`gh`** version—check **`gh issue delete --help`**.
+
+```bash
+gh issue delete <N> --yes
+```
+
+Use **`--repo owner/repo`** when not in default context.
+
+## Edit issue (after Proceed)
+
+**Only after** structured **Proceed** in **`@gh-issues`** when the chosen path is edit. Compose flags from **[`internal-read-gh-issue-description`](../../read/gh/issue-description/SKILL.md)** output and **[`internal-read-gh-issue-labels`](../../read/gh/issue-labels/SKILL.md)** when labels change. Multi-intent **Proceed — batch** may include **multiple** `gh issue edit` lines (and/or creates) in one confirmed batch—in the summarized order.
+
+```bash
+gh issue edit <N> --title "New title"
+```
+
+```bash
+gh issue edit <N> --body-file /path/to/body.md
+```
+
+```bash
+gh issue edit <N> --add-label "bug" --remove-label "triage"
+```
+
+## Create issue (after Proceed)
+
+**Only after** structured **Proceed** in **`@gh-issues`** when the chosen path is create. Full checklist and body file patterns: **[`issue-create-prompt/SKILL.md`](./issue-create-prompt/SKILL.md)**. When **`@gh-issues`** multi-intent batching applies, **several** `gh issue create` (and/or `gh issue edit`) commands may run **in sequence** after **one** parent Proceed, in the order fixed in that Proceed summary.
+
+```bash
+gh issue create --title "…" --body-file /path/to/body.md
+```
+
+```bash
+gh issue create --title "…" --body-file /path/to/body.md --label "bug,area:skills"
+```
+
+## Project attach (same Proceed batch as create/edit)
+
+**Plan + summarize** before **`gh`** using **[`internal-read-gh-issue-projects-relationships`](../../read/gh/issue-projects-relationships/SKILL.md)** (discovery, auth, ambiguity, GHES fallbacks). **Additive** only: do not skip structured Q&A / Proceed; if attach is skipped after a failed command, say so explicitly (not a silent success).
+
+**Create** — add by **project title** (requires **`project`** scope; see **`gh issue create --help`**):
+
+```bash
+gh issue create --title "…" --body-file /path/to/body.md --project "Project title"
+```
+
+```bash
+gh issue create --title "…" --body-file /path/to/body.md --label "bug,area:skills" --project "Project title" --repo owner/repo
+```
+
+**Edit** — when the issue exists but is missing from a board (**`gh issue edit --help`** lists **`--add-project`**):
+
+```bash
+gh issue edit <N> --add-project "Project title"
+```
+
+```bash
+gh issue edit <N> --add-project "Project title" --repo owner/repo
+```
+
+**Fallback** — add an existing issue URL to a project by **number** (when title-based attach is unsuitable or failed once with an unambiguous **`PROJECT_NUMBER`**):
+
+```bash
+gh project item-add <PROJECT_NUMBER> --owner OWNER_LOGIN --url https://github.com/owner/repo/issues/<N>
+```
+
+**Link project to repo** (maintainer setup; only when the user explicitly asked—may be a separate Proceed):
+
+```bash
+gh project link <PROJECT_NUMBER> --owner OWNER_LOGIN --repo owner/repo
+```
+
+## Close issue (after Proceed)
+
+**Only after** structured **Proceed** in **`@gh-issue-close`**.
+
+```bash
+gh issue close <N> --comment "…"
+```
+
+## See also
+
+- **[`internal-read-gh-issue-projects-relationships`](../../read/gh/issue-projects-relationships/SKILL.md)** — project discovery + issue relationship playbook (read-only).
+- **[`internal-read-gh-issue-list`](../../read/gh/issue-list/SKILL.md)** — **`gh issue list`** / **`gh search issues`** (read-only inventory).
+- **[`internal-write-gh-pr-commands`](../pr-commands/SKILL.md)** — **`gh pr create`**, **`gh pr edit`**, and **`gh pr close`** command shapes.
+- **[`internal-read-gh-repo-forms-json`](../../read/gh/repo-forms-json/SKILL.md)** — **`gh repo view --json`** for template metadata.
+- [`@gh-issue-review`](../../../gh/issues/review/SKILL.md)
+- [`@gh-issue-view`](../../../gh/issues/view/SKILL.md)
+- [`@gh-issue-list`](../../../gh/issues/list/SKILL.md)
+- [`@gh-issue-pick`](../../../gh/issues/pick/SKILL.md)
+- [`@gh-issue-delete-closed`](../../../gh/issues/delete-closed/SKILL.md)
+- [`@gh-issues`](../../../gh/issues/SKILL.md) · [`@gh-issue-close`](../../../gh/issues/close/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/internal-write-gh/issue-commands/close-as-duplicate/SKILL.md
+++ b/.agents/skills/internal-write-gh/issue-commands/close-as-duplicate/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: internal-write-gh-issue-commands-close-as-duplicate
+description: >-
+  Read-only: close issue as duplicate (gh shapes). Parent internal-write-gh-issue-commands.
+---
+
+# Close as duplicate
+
+GitHub does not merge issue bodies; use **duplicate** semantics.
+
+**After user Proceed:**
+
+1. Comment on the duplicate with a link to the canonical issue: `gh issue comment <dup> --body "Duplicate of #<canonical> …"`.
+2. Close the duplicate: `gh issue close <dup>` (or `gh issue close <dup> --reason "not planned"` if your `gh` version supports reason flags—match local `gh issue close --help`).
+
+Replace `<dup>` / `<canonical>` with numeric ids. **Confirm before** any `gh issue comment` / `gh issue close`.

--- a/.agents/skills/internal-write-gh/issue-commands/delete-closed-issues/SKILL.md
+++ b/.agents/skills/internal-write-gh/issue-commands/delete-closed-issues/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: internal-write-gh-issue-commands-delete-closed-issues
+description: >-
+  Read-only: bulk delete closed issues (gh shapes). Parent internal-write-gh-issue-commands.
+---
+
+# Bulk delete closed issues
+
+**Normative CLI shapes** — **list:** [`internal-read-gh-issue-list`](../../../read/gh/issue-list/SKILL.md); **delete:** [`internal-write-gh-issue-commands`](./SKILL.md). **Public skill:** **`@gh-issue-delete-closed`**.
+
+**Before you run anything**
+
+1. **Goal** — Why delete closed issues.
+2. **Preview** — List closed issues (ids + titles); confirm count matches intent.
+3. **Structured confirm** — **Proceed** / **Cancel** per **`internal-write-plan-structured-qa`** + **`internal-write-plan-skill-safety`**.
+4. **Permissions** — Deleting issues requires appropriate **GitHub** role; **`gh`** errors are authoritative.
+
+**After Proceed:** Run **`gh issue delete <n> --yes`** (or per **`gh issue delete --help`**) one issue at a time; stop on failure.
+
+**Do not** delete **open** issues from this checklist unless the flow was explicitly re-scoped.

--- a/.agents/skills/internal-write-gh/issue-commands/issue-create-prompt/SKILL.md
+++ b/.agents/skills/internal-write-gh/issue-commands/issue-create-prompt/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: internal-write-gh-issue-commands-issue-create-prompt
+description: >-
+  Read-only: gh issue create checklist and body-file patterns. Parent internal-write-gh-issue-commands.
+---
+
+# Issue create prompt
+
+**Before mutation:** Goal + **AskQuestion** + Proceed ([`internal-write-plan-structured-qa`](../../../plan/structured-qa/SKILL.md)).
+
+**Steps**
+
+1. Run [`internal-read-gh-issue-dedupe`](../../../../read/gh/issue-dedupe/SKILL.md) with candidate title + body summary (read-only).
+2. Draft **title** from [title line](../../../../read/gh/pr-content/title-line/SKILL.md); **body** from [issue body skeleton](../../../../read/gh/issue-description/issue-body-skeleton/SKILL.md) (and template merge from **`internal-read-gh-issue-description`**).
+3. **Labels (default path):** run [`internal-read-gh-issue-labels`](../../../../read/gh/issue-labels/SKILL.md) after title/body drafting. Confirm **`gh label create`** separately when needed ([`internal-write-plan-skill-safety`](../../../plan/skill-safety/SKILL.md)). On Proceed, pass **`--label "a,b"`** to **`gh issue create`** (or **`--add-label` / `--remove-label`** on **`gh issue edit`**) when the user accepts label changes; skip labels only on explicit decline.
+4. **Projects (default path for current-repo ship):** run [`internal-read-gh-issue-projects-relationships`](../../../../read/gh/issue-projects-relationships/SKILL.md) after the target **`owner/repo`** is known. Include **`--project "…"`** on **`gh issue create`** or **`--add-project "…"`** on **`gh issue edit`** in the mutation summary when there is a single unambiguous board title (or a user-supplied title); use **`gh project item-add`** from [`internal-write-gh-issue-commands`](../SKILL.md) only as a documented fallback. If discovery fails, scope is missing, or titles collide, record **skip** + reason in chat—never treat a skipped attach as success without saying so.
+5. Prefer body files in `.cursor/gh/issues/` for batch creation (for example `.cursor/gh/issues/<slug>.md`).
+6. On Proceed: run the agreed **`gh issue create`** / **`gh issue edit`** line from [`internal-write-gh-issue-commands`](../SKILL.md) (labels + project flags as accepted); never skip dedupe when the user asked for a **new** tracked issue.

--- a/.agents/skills/internal-write-gh/pr-commands/SKILL.md
+++ b/.agents/skills/internal-write-gh/pr-commands/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: internal-write-gh-pr-commands
+description: >-
+  Normative gh pr create/edit/close shapes; optional gh project item-add for PR/issue URLs; read-only gh pr view JSON
+  for closingIssuesReferences. PR list/view lives in internal-read-gh-pr-list. Callers run structured Q&A before mutations.
+---
+
+# Internal: GitHub pull request mutations (`internal-write-gh-pr-commands`)
+
+**Write library (GitHub / `gh` / API).** **`gh pr create`**, **`gh pr edit`**, and **`gh pr close`** shapes consumed by **`@gh-pr`** and **`@gh-pr-close`**. **Mutations** require **Goal + AskQuestion + Proceed** in the **public** skill via **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)**.
+**Master-confirm rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** do not bypass session-level confirm for any GitHub mutation in this library.
+
+**List / view / diff stat** — **[`internal-read-gh-pr-list`](../../read/gh/pr-list/SKILL.md)** (sole read-only **`gh pr list`** / **`gh pr view`** / **`gh pr diff --stat`** fences).
+
+**`gh repo view`** for **PR templates** is **not** here—use **[`internal-read-gh-repo-forms-json`](../../read/gh/repo-forms-json/SKILL.md)**.
+
+## Platform note (read before Proceed)
+
+- GitHub does not provide issue-parity hard-delete behavior for pull requests in common `gh` setups.
+- PR archive APIs are admin-scoped and are not exposed as a packaged bulk mutation skill in this pack.
+- For cleanup policy work on closed PRs, use GitHub UI and repository/org governance outside this library.
+- **PR ↔ issue (Development / closing semantics):** There is **no** official `gh` flag to set the web **Development** sidebar link without **closing keywords in the PR body** or **manual UI**; platform gap is tracked as [`cli/cli#11405`](https://github.com/cli/cli/issues/11405). **`gh pr view --json closingIssuesReferences`** is **read-only** and reflects what GitHub already inferred (often from body keywords). See **[`internal-read-gh-pr-description`](../../read/gh/pr-description/SKILL.md)** §6.5–6.6 and [GitHub docs: linking PRs to issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+## Create PR (after Proceed)
+
+**Only for** **`@gh-pr`** **§9**, after the final structured **Proceed** there. Resolve `--repo`, `--base`, and `--head` through **`internal-read-gh-repo-stream`**. When the **§9** summary chose the **keyword path**, put **`Refs #n` / `Fixes #n` / `Closes #n`** in the PR body text (or body file)—there are **no** separate `gh pr create` flags for that linkage. Otherwise omit keyword lines and use **Projects** and/or UI per **[`internal-read-gh-issue-projects-relationships`](../../read/gh/issue-projects-relationships/SKILL.md)**.
+
+```bash
+gh pr create --repo owner/repo --base main --head feature-branch --title "Title" --body-file /path/to/body.md
+```
+
+## Edit PR (after Proceed)
+
+**Only for** **`@gh-pr`** **§9**, after the final structured **Proceed** there. Editing replaces title/body with regenerated content; keep issue keyword lines in the body **only when** the user confirmed that path (same rules as create).
+
+```bash
+gh pr edit <N> --repo owner/repo --title "Title" --body-file /path/to/body.md
+```
+
+## Optional: add PR and issues to a project (same Proceed batch as `@gh-pr` §9)
+
+When **`@gh-pr`** **§9** confirmed **project attach**, run **`gh project item-add`** once per URL **after** the PR number is known (create path: parse **`gh pr create`** output or run **`gh pr view --json url,number`** for the new PR). Use the **destination** repo URL shape for both PR and issues: **`https://github.com/OWNER/REPO/pull/<N>`** and **`https://github.com/OWNER/REPO/issues/<N>`** where **`OWNER/REPO`** matches **`PR_TARGET_REPO`** from **`internal-read-gh-repo-stream`**. Discovery, **`project`** token scope, and owner disambiguation: **[`internal-read-gh-issue-projects-relationships`](../../read/gh/issue-projects-relationships/SKILL.md)** + **[`internal-read-gh-project-list`](../../read/gh/project-list/SKILL.md)**.
+
+```bash
+gh project item-add <PROJECT_NUMBER> --owner OWNER_LOGIN --url https://github.com/owner/repo/pull/<PR_NUMBER>
+```
+
+```bash
+gh project item-add <PROJECT_NUMBER> --owner OWNER_LOGIN --url https://github.com/owner/repo/issues/<ISSUE_NUMBER>
+```
+
+**Fork:** **`owner/repo`** in URLs is the **upstream** destination (same as **`PR_TARGET_REPO`**), not the fork’s **`github.com/FORK_OWNER/…`** issue namespace unless the issue genuinely lives on the fork.
+
+## Read-only: verify linked issues metadata (after create/edit)
+
+```bash
+gh pr view <N> --repo owner/repo --json closingIssuesReferences,number,url,title
+```
+
+## Close PR (after Proceed)
+
+**Only for** **`@gh-pr-close`**, after **Goal** + **AskQuestion** + **Proceed**.
+
+```bash
+gh pr close <N>
+```
+
+Use **`--repo owner/upstream`** when closing against the fork’s upstream repo. Add **`--comment "…"`** when the user supplied a closing note.
+
+## See also
+
+- **[`internal-read-gh-pr-list`](../../read/gh/pr-list/SKILL.md)** — read-only **`gh pr list`** / **`view`** / **`diff --stat`**.
+- **[`internal-read-gh-pr-description`](../../read/gh/pr-description/SKILL.md)** — §6.5–7 linking + body rules.
+- **[`internal-read-gh-issue-projects-relationships`](../../read/gh/issue-projects-relationships/SKILL.md)** — project discovery + PR/issue **`item-add`** playbook.
+- **[`internal-write-gh-issue-commands`](../issue-commands/SKILL.md)** — **`gh issue`** view/create/edit/close/delete; issue **`item-add`** fallback fences.
+- **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)** — **`--repo`** targets for forks/upstream.
+- [`@gh-pr-close`](../../../gh/pr/close/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)
+- [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)

--- a/.agents/skills/internal-write-gh/project-commands/SKILL.md
+++ b/.agents/skills/internal-write-gh/project-commands/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: internal-write-gh-project-commands
+description: >-
+  Normative gh project delete CLI shapes (write / GitHub). List/inventory lives in internal-read-gh-project-list.
+  Callers run Goal + AskQuestion + Proceed before mutations.
+---
+
+# Internal: GitHub project CLI (`internal-write-gh-project-commands`)
+
+**Write library (GitHub / `gh`).** **`gh project`** command shapes for delete flows consumed by **`@gh-project-delete-closed`**.
+
+**Mutations** require **Goal + AskQuestion + Proceed** in the public skill via **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)**.
+
+**Master-confirm rule:** `SKIP_QA_*` and `SKIP_QA_WRITE` do not bypass session-level confirm for any GitHub mutation in this library.
+
+**List / preview** lives in **[`internal-read-gh-project-list`](../../../read/gh/project-list/SKILL.md)**.
+
+## Delete one project
+
+Only after structured **Proceed** in **`@gh-project-delete-closed`**.
+
+```bash
+gh project delete <NUMBER> --owner "@me"
+```
+
+Use `--owner ORG_LOGIN` for organization-owned projects.
+
+## See also
+
+- **[`internal-read-gh-project-list`](../../../read/gh/project-list/SKILL.md)** — `gh project list` inventory fences.
+- [`@gh-project-delete-closed`](../../../gh/projects/delete-closed/SKILL.md)
+- [`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)
+- [`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)

--- a/.agents/skills/internal-write-gh/project-commands/delete-closed-projects/SKILL.md
+++ b/.agents/skills/internal-write-gh/project-commands/delete-closed-projects/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: internal-write-gh-project-commands-delete-closed-projects
+description: >-
+  Read-only: bulk delete closed projects (gh shapes). Parent internal-write-gh-project-commands.
+---
+
+# Bulk delete closed projects
+
+**Normative CLI shapes** — **list:** [`internal-read-gh-project-list`](../../../../read/gh/project-list/SKILL.md); **delete:** [`internal-write-gh-project-commands`](../SKILL.md). **Public skill:** **`@gh-project-delete-closed`**.
+
+**Before you run anything**
+
+1. **Goal** — Why delete closed projects.
+2. **Preview** — List projects for the selected owner and filter to closed (`closed == true`); confirm count, number, and title match intent.
+3. **Structured confirm** — **Proceed** / **Cancel** per `internal-write-plan-structured-qa` + `internal-write-plan-skill-safety`.
+4. **Permissions** — Deleting projects requires appropriate GitHub role and `project` auth scope; `gh` errors are authoritative.
+
+**After Proceed:** run `gh project delete <NUMBER> --owner …` one project at a time; stop on first failure and report.
+
+**Do not** delete open projects from this checklist unless the flow was explicitly re-scoped.

--- a/.agents/skills/internal-write-git-commit/SKILL.md
+++ b/.agents/skills/internal-write-git-commit/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: internal-write-git-commit
+description: >-
+  Runnable local git add/commit command blocks for @git-commit. Caller owns structured Q&A and Proceed before mutating
+  steps. No push and no GitHub API.
+---
+
+# Internal: git commit commands (`internal-write-git-commit`)
+
+**Library.** **Runnable** **`git add`** / **`git commit`** sequences for **`@git-commit`**. **Caller** owns **structured Q&A** and **Proceed** before mutating blocks.
+
+## Preconditions (read-only)
+
+```bash
+TOP=$(git rev-parse --show-toplevel)
+```
+
+## Inspect working tree (read-only)
+
+```bash
+git -C "$TOP" status --short
+```
+
+## Stage tracked changes only (mutating)
+
+```bash
+git -C "$TOP" add -u
+```
+
+## Stage tracked and untracked changes (mutating)
+
+**Default for [`@git-commit`](../../../git/commit/SKILL.md)** — use this block unless the caller’s **single gate** (or one follow-up) narrows scope to tracked-only or selected paths.
+
+```bash
+git -C "$TOP" add -A
+```
+
+## Stage selected paths (mutating)
+
+Set **`PATHS`** as a shell-safe path list provided by the caller.
+
+```bash
+git -C "$TOP" add -- $PATHS
+```
+
+## Create commit (mutating)
+
+Set **`COMMIT_SUBJECT`** before this block.
+
+```bash
+git -C "$TOP" diff --cached --quiet || git -C "$TOP" commit -m "$COMMIT_SUBJECT"
+```
+
+## See also
+
+- [`@git-commit`](../../../git/commit/SKILL.md)
+- [`@git-push`](../../../git/push/SKILL.md)

--- a/.agents/skills/internal-write-git-tag/SKILL.md
+++ b/.agents/skills/internal-write-git-tag/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: internal-write-git-tag
+description: >-
+  Normative local git tag + tag push commands (check origin, ISO date yyyy-mm-dd tag name); optional replace local
+  annotated tag (force) and optional force-push to origin when the caller's Q&A records explicit override. Mutating
+  fences are run only under @git-tag (Proceed there). @git-zip may use read-only blocks here for verification before
+  internal-write-git-zip. No gh / GitHub API. Caller runs structured Q&A and Proceed before mutating fences.
+---
+
+# Internal: git tag commands (`internal-write-git-tag`)
+
+**Library.** **Runnable** **`git tag`** / **`git push`** **mutating** sequences are owned by **[`@git-tag`](../../../git/tag/SKILL.md)**—that public skill runs **Create** / **Replace** / **Push** after **Gate 2** / **Gate 3** / **Gate 4 — Proceed**. **[`@git-zip`](../../../git/zip/SKILL.md)** does **not** invoke these mutating blocks; it **orchestrates** **`@git-tag`** when a tag must be created or repointed, and may use **read-only** sections of this file (**Check `origin` exists**, **Inspect local tag**, **Inspect remote tag**, **Fetch remote tags**) to verify **`refs/tags/${TAG}`** on the **existing-tag** export path before **`internal-write-git-zip`**.
+
+**Caller** (always **`@git-tag`** for **mutations**) owns **structured Q&A** and **Proceed** before any mutating block using **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)**. **Never** run **Replace local** or **Push ... (force)** unless the user explicitly chose those options in **`@git-tag`** **Gate 2** / **Gate 3**. When **`@git-tag`** runs **Push**, do so **before** any follow-on **`@git-zip`** **Plain archive** so **`origin`** matches the tagged tree being zipped.
+
+**Master-confirm rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** do not bypass session-level confirm for tag replacement, remote tag pushes, or force pushes.
+
+## Preconditions (read-only)
+
+Resolve **before** user confirm rounds.
+
+```bash
+TOP=$(git rev-parse --show-toplevel)
+DATE=$(date +%Y-%m-%d)
+```
+
+**Default tag:** **`TAG="${DATE}"`** unless the caller **`export TAG=...`** before read/mutate blocks (then use that **`TAG`**). Blocks below resolve **`TAG="${TAG:-$DATE}"`**.
+
+**Optional target ref** (default **`HEAD`**): export **`GIT_TAG_TARGET=HEAD`** or another commit-ish before **Create** / **Replace** blocks.
+
+## Check `origin` exists (read-only)
+
+Use **before** promising **`git push origin ...`**. Non-zero exit if **`origin`** is missing.
+
+```bash
+git remote get-url origin
+```
+
+## Fetch remote tags (read-only; requires `origin`)
+
+Run before selecting or comparing tags on **`origin`** when `origin` exists.
+
+```bash
+git fetch origin --tags --prune
+```
+
+## Inspect local tag (read-only)
+
+```bash
+TAG="${TAG:-$DATE}"
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+  echo "local:refs/tags/${TAG}=$(git rev-parse "refs/tags/${TAG}^{}")"
+else
+  echo "local:missing refs/tags/${TAG}"
+fi
+```
+
+## Inspect remote tag (read-only; requires `origin`)
+
+Fails if **`origin`** is absent—caller should have run **Check `origin` exists** first.
+
+```bash
+TAG="${TAG:-$DATE}"
+git ls-remote --tags origin "refs/tags/${TAG}"
+```
+
+Empty output => no tag with that exact name on **`origin`** yet.
+
+## Inspect latest local tag (read-only)
+
+Use when a caller needs a **latest** local tag name for display or manual **`TAG=`** choice (not a silent default for **`@git-zip`**).
+
+```bash
+LATEST_LOCAL_TAG="$(git tag --list --sort=-v:refname | sed -n '1p')"
+if [[ -n "$LATEST_LOCAL_TAG" ]]; then
+  echo "latest_local_tag:$LATEST_LOCAL_TAG"
+else
+  echo "latest_local_tag:none"
+fi
+```
+
+## Inspect previous reachable tag (read-only)
+
+Use after branch/main alignment to summarize candidate release history.
+
+```bash
+PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+if [[ -n "$PREV_TAG" ]]; then
+  echo "prev_tag:$PREV_TAG"
+else
+  echo "prev_tag:none"
+fi
+```
+
+## Inspect commits since previous tag (read-only)
+
+Set **`LOG_LIMIT`** if needed (default **25**). If there is no previous tag, show the latest commits from **`HEAD`**.
+
+```bash
+LOG_LIMIT="${LOG_LIMIT:-25}"
+if [[ -n "${PREV_TAG:-}" ]]; then
+  git log --oneline "${PREV_TAG}..HEAD" | sed -n "1,${LOG_LIMIT}p"
+else
+  git log --oneline HEAD | sed -n "1,${LOG_LIMIT}p"
+fi
+```
+
+## Create annotated tag only if missing (mutating)
+
+**Only after** caller **`@git-tag`** **Proceed**. **Idempotent** first-time create. **No-op** when **`refs/tags/${TAG}`** already exists — use **Replace local annotated tag (force)** when the user chose to repoint the tag.
+
+```bash
+cd "$TOP"
+TAG="${TAG:-$DATE}"
+GIT_TAG_TARGET="${GIT_TAG_TARGET:-HEAD}"
+if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+  git tag -a "$TAG" -m "$TAG" "$GIT_TAG_TARGET"
+fi
+```
+
+## Replace local annotated tag (force) (mutating)
+
+**Only after** caller **`@git-tag`** **Gate 4 — Proceed** and an explicit **"replace local"** / **"force local"** choice (**Gate 2**). Moves **`refs/tags/${TAG}`** to **`GIT_TAG_TARGET`** (annotated).
+
+```bash
+cd "$TOP"
+TAG="${TAG:-$DATE}"
+GIT_TAG_TARGET="${GIT_TAG_TARGET:-HEAD}"
+git tag -fa "$TAG" -m "$TAG" "$GIT_TAG_TARGET"
+```
+
+## Push one tag to `origin` (mutating)
+
+**Only after** caller **`@git-tag`** **Proceed** for **push** when the remote **does not** already have this tag **or** it matches what you are publishing without needing **`--force`**. Requires **`origin`**.
+
+```bash
+TAG="${TAG:-$DATE}"
+git push origin "refs/tags/${TAG}:refs/tags/${TAG}"
+```
+
+If this fails because **`origin`** has a different object for **`${TAG}`**, the caller should have offered **force push** per **`@git-tag`** **Gate 3** and then run **Push one tag to `origin` (force)** instead.
+
+## Push one tag to `origin` (force) (mutating)
+
+**Only after** caller **`@git-tag`** **Gate 4 — Proceed** and an explicit **"force push"** / **"overwrite remote tag"** choice (**Gate 3**). **Destructive** on **`origin`**: replaces the remote tag ref. Requires **`origin`**.
+
+```bash
+TAG="${TAG:-$DATE}"
+git push --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+```
+
+## See also
+
+- [`internal-write-git-zip`](../zip/SKILL.md) — zip archive naming (**`${PROJECT}-${DATE}.zip`**) is separate from **tag** name (**`${TAG}`** / default **`${DATE}`**)
+- [`@git-tag`](../../../git/tag/SKILL.md) — public orchestration (**mutations**)
+- [`@git-zip`](../../../git/zip/SKILL.md) — orchestrates **`@git-tag`** then **`internal-write-git-zip`**; **read-only** use of this file for verification on the existing-tag path only

--- a/.agents/skills/internal-write-git-working-tree-align/SKILL.md
+++ b/.agents/skills/internal-write-git-working-tree-align/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: internal-write-git-working-tree-align
+description: >-
+  Read-only playbook: local git reset/clean (no gh). Dirty-tree confirm (no stash), discover clean targets, git clean
+  dry-run, confirm and execute git reset --hard to a caller-supplied ref and git clean. Optional non-git prunes table.
+  Callers: @git-main (MODE=combined), @git-reset (MODE=split). Does NOT fetch, checkout branches, or resolve ALIGN_REF.
+---
+
+# Internal: Working tree align (reset + clean)
+
+**Read-only library.** **Local `git` only** (no **`gh`**). Parent skills set **`$ALIGN_REF`** (resolved ref string, e.g. **`upstream/main`**, **`origin/feature-x`**) and **`$BRANCH`** (current branch name for messages). This library does **not** fetch, **not** `git checkout`, and **not** compute **`$ALIGN_REF`**—use **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)** + parent workflow for that.
+
+**Prompts** — apply **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** + **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** (**§3a**: **Goal** + **AskQuestion**, **Abort** / **Proceed**). **Never** **`git stash`**.
+**Master-confirm rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** do not bypass session-level confirm for **`git reset --hard`**, **`git clean`**, or optional global prune commands.
+
+---
+
+## Parameters (set by caller)
+
+| Parameter | Meaning |
+| --- | --- |
+| **`$ALIGN_REF`** | Tip to match after **`git reset --hard`** (already fetched and valid). |
+| **`$BRANCH`** | Current branch name (for **Goal** lines). |
+| **`MODE`** | **`combined`** (**`@git-main`**) — one confirm may cover **reset + clean** (split if dry-run huge). **`split`** (**`@git-reset`**) — **separate** confirm before reset and before clean. |
+
+---
+
+## 1. Dirty tree (no stash)
+
+**When:** **`git status --short`** is **not** empty **before** reset/clean (caller skips this block if the tree is already clean).
+
+1. Show **`git status --short`** (and a one-line summary; for **`@git-reset`**, include modified / untracked / staged counts).
+2. **Stop** and **AskQuestion** per **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** **§3a** with a **Goal** line chosen by the **caller**:
+   - **`@git-main`** style: align local **`main`** to **`$ALIGN_REF`** and remove untracked/ignored files per planned **`git clean`**—destroying uncommitted work.
+   - **`@git-reset`** style: align branch **`$BRANCH`** to **`$ALIGN_REF`** and run the planned **`git clean`**—permanently discarding local diffs.
+3. Options:
+   - **Keep work / abort** — end the **parent** skill; user should commit, copy files aside, or use another workflow.
+   - **Trash and align** — user explicitly accepts destruction; continue to **§2**.
+4. **Do not** stash. **Do not** offer stash as a third path (**`@git-reset`**: if vague, default **abort** until **trash and align** is explicit).
+
+---
+
+## 2. Discover — what `git clean` may touch
+
+**Read-only.** Scan the worktree (repo root; monorepo hints from README if obvious). **Brief** bullets: stack signals and **large** paths likely listed by **`git clean -fdxn`**.
+
+Common ignored / untracked targets (examples):
+
+- **Node:** `node_modules/`, `dist/`, `build/`, `.next/`, `coverage/`
+- **Python:** `.venv/`, `__pycache__/`, `.pytest_cache/`, `.ruff_cache/`
+- **Rust:** `target/`
+- **Go:** `vendor/` or untracked binaries
+- **JVM / .NET:** `target/`, `build/`, `bin/`, `obj/`
+- **Terraform:** `.terraform/`
+
+For richer stack detection patterns, align with **`@git-review`** / **[`internal-read-git-discover-dependencies`](../../read/git/discover-dependencies/SKILL.md)** when helpful.
+
+---
+
+## 3. Clean dry-run
+
+Before any **`git clean`** that removes files:
+
+```bash
+git clean -fdxn
+```
+
+Show output (truncate if enormous: counts + top directories). If the user prefers **keeping ignored** files, plan **`git clean -fd`** / **`git clean -fdn`** instead and say so before confirm.
+
+---
+
+## 4. Confirm and execute
+
+### MODE `combined` (`@git-main`)
+
+- State **`git reset --hard "$ALIGN_REF"`** + the **`git clean`** command from **§3** (**`-fdx`** default, or **`-fd`** if keeping ignored).
+- **One** **Goal** + **AskQuestion** (**Abort** / **Proceed**) may cover **both** reset and clean when **§1** was **trash and align** or only untracked/ignored remain. **Split** into **two** confirms if the dry-run is **large** or **surprising**.
+- **Only after Proceed:**  
+  - **`git reset --hard "$ALIGN_REF"`**  
+  - **`git clean -fdx`** (or **`git clean -fd`** if keep-ignored)
+
+**Do not** run **`git pull`** after this block (caller rule).
+
+### MODE `split` (`@git-reset`)
+
+1. **Reset confirm** — State branch **`$BRANCH`** and **`git reset --hard "$ALIGN_REF"`**. Remind that **tracked** files match **`$ALIGN_REF`** and uncommitted **tracked** edits are discarded (**§1** already handled consent when dirty). **Goal** + **AskQuestion** (**Abort** / **Proceed**).
+2. **Execute reset** — Only after Proceed: **`git reset --hard "$ALIGN_REF"`** (stay on **`$BRANCH`**).
+3. **Clean confirm** — Remind: **`git clean -fdx`** (or **`git clean -fd`**) matches **§3** dry-run. **Goal** + **AskQuestion** (**Abort** / **Proceed**).
+4. **Execute clean** — Only after Proceed: **`git clean -fdx`** or **`git clean -fd`**.
+
+---
+
+## 5. Optional — non-git / global caches
+
+**Only** if the user **explicitly** asked (**`@git-main`**) or per table (**`@git-reset`**). **Each** command: **own** **Goal** + **AskQuestion** (**Abort** / **Proceed**). Skip if not applicable.
+
+| Topic | When to offer | Example | Confirm |
+| --- | --- | --- | --- |
+| **Docker** | `Dockerfile` / compose present **or** user asked | `docker builder prune -f` | **Goal** + **AskQuestion** before run |
+| **Docker (aggressive)** | User explicitly asks | `docker system prune` / `-a` | **Goal** + **AskQuestion** (explicit **Proceed**) |
+| **Podman** | Containerfile / user asked | `podman builder prune`, `podman system prune` | Same as Docker |
+| **npm (global cache)** | User asked | `npm cache clean --force` | **Goal** + **AskQuestion** |
+| **Playwright** | User asked; Playwright in deps | User cache under **`$HOME`** | **Goal** + **AskQuestion** before delete |
+| **Rust / extra** | User asks | project script / third-party tool | **Goal** + **AskQuestion** per command |
+| **Other** | README, Makefile, user names a tool | project-specific | **Goal** + **AskQuestion** per command |
+
+---
+
+## Do not (library)
+
+- **`git stash`**
+- **`git push`**
+- Fetch or resolve **`$ALIGN_REF`** (caller’s responsibility)
+
+## See also
+
+- **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)** — **`CANONICAL_MAIN_REF`**, **`$TARGET`** priority (**`@git-reset`** §4).
+- **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** — reset/clean triggers.

--- a/.agents/skills/internal-write-git-zip/SKILL.md
+++ b/.agents/skills/internal-write-git-zip/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: internal-write-git-zip
+description: >-
+  Normative local shell: default git archive (GitHub-style zip, tracked tree only, no .git); optional full-tree zip
+  including .git for rare full-clone portable backups. No gh / GitHub API. Caller runs Q&A first; this library holds
+  runnable command blocks. Consumed by @git-zip.
+---
+
+# Internal: git zip commands (`internal-write-git-zip`)
+
+**Library.** **Runnable** **`git archive`** (default). **Caller** ([`git-zip`](../../../git/zip/SKILL.md)) owns **structured Q&A** and **Proceed** before invoking these steps via **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)**. **Tag** create/replace/push is owned by **[`@git-tag`](../../../git/tag/SKILL.md)** via **`internal-write-git-tag`**; **`@git-zip`** calls **`@git-tag`** when needed, then sets **`ARCH_REF=refs/tags/${TAG}`** and invokes this file for export only.
+**Master-confirm rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** do not bypass session-level confirm for out-of-repo archive writes or optional full-tree backup writes.
+
+**Default behavior:** **`git archive --format=zip`** — same class of artifact as GitHub **"Source code (zip)"** for a ref (**no** **`.git`**, **no** untracked files). Primary caller **`@git-zip`** sets **`ARCH_REF=refs/tags/${TAG}`** (default **`TAG=${DATE}`**) after **`@git-tag`** or after read-only tag verification. Other callers may set **`ARCH_REF`** themselves (including **`HEAD`**) only with their own Q&A and scope.
+
+## Preconditions (read-only)
+
+Resolve repo root and naming facts **before** the Q&A rounds in the public skill. **Do not** write archives until **Proceed** after path/tag confirmation.
+
+```bash
+TOP=$(git rev-parse --show-toplevel)
+PROJECT=$(basename "$TOP")
+DATE=$(date +%Y-%m-%d)
+```
+
+Export **`TOP`**, **`PROJECT`**, **`DATE`**. Choose **`DEST_DIR`** with the user (default: parent of **`TOP`**). **Caller** sets **`ARCH_REF`**:
+
+- **`refs/tags/${TAG}`** — snapshot of the **annotated tag** (**`@git-zip`** public paths always use this after **`@git-tag`** or existing-tag verification; default **`TAG=${DATE}`**).
+- **`HEAD`** — only for **non-`@git-zip`** callers that explicitly export the current commit with their own confirmation.
+
+## Variables
+
+Substitute **`TOP`**, **`DEST_DIR`**, **`DATE`**, **`PROJECT`**, **`ARCH_REF`**. Output basename: **`${PROJECT}-${DATE}.zip`**.
+
+## Plain archive (default — contents only)
+
+**Tracked files at `ARCH_REF` only** — **no** **`.git`**.
+
+```bash
+mkdir -p "$DEST_DIR"
+OUT="${DEST_DIR}/${PROJECT}-${DATE}.zip"
+git -C "$TOP" archive --format=zip --output "$OUT" "$ARCH_REF"
+```
+
+Optional **top-level folder inside the zip** (closer to GitHub's **`owner-repo-ref/`** layout):
+
+```bash
+git -C "$TOP" archive --format=zip --prefix="${PROJECT}/" --output "$OUT" "$ARCH_REF"
+```
+
+## Optional full-tree backup (includes `.git`)
+
+**Not** **`@git-zip`** default — portable **clone** of the working tree **including** **`.git`** (large). Only when the user explicitly asks for **full repository** backup, not GitHub-style.
+
+```bash
+cd "$TOP"
+mkdir -p "$DEST_DIR"
+OUT="${DEST_DIR}/${PROJECT}-${DATE}-full.zip"
+zip -qr "$OUT" . -x "*.zip"
+```
+
+## See also
+
+- [`@git-tag`](../../../git/tag/SKILL.md) — tag create/replace/push (**mutations**); run before **`@git-zip`** export when the tag is not already settled
+- [`internal-read-git-workflows`](../../../read/git/workflows/SKILL.md#git-zip-workflow) — naming + **GitHub vs full-tree**
+- [`@git-zip`](../../../git/zip/SKILL.md) — public orchestration: **`@git-tag`** (when needed), then **`git archive`** at **`refs/tags/${TAG}`**
+- [`internal-write-git-tag`](../tag/SKILL.md) — **Create** / **Replace** / **Push** (**`@git-tag`** only); read-only **Inspect** shapes for **`@git-zip`** verification on the existing-tag path

--- a/.agents/skills/internal-write-git/SKILL.md
+++ b/.agents/skills/internal-write-git/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: internal-write-git
+description: >-
+  Internal git-oriented mutating libraries for local tree alignment, commit savepoints, tag operations, and archive generation.
+---
+
+# `skills/write/git/`
+
+Mutating git libraries used by public workflows.
+
+- `working-tree-align` for reset/clean alignment routines.
+- `commit` for local staging + commit savepoint fences.
+- `tag` for local/remote tag command fences.
+- `zip` for archive generation command fences.
+
+Callers should apply structured safety/confirmation before destructive operations, online mutations, and out-of-repo writes via [`internal-write-plan-skill-safety`](../plan/skill-safety/SKILL.md) and [`internal-write-plan-structured-qa`](../plan/structured-qa/SKILL.md). `SKIP_QA_*` / `SKIP_QA_WRITE` never bypass session-level master confirm for those high-risk actions.

--- a/.agents/skills/internal-write-git/commit/SKILL.md
+++ b/.agents/skills/internal-write-git/commit/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: internal-write-git-commit
+description: >-
+  Runnable local git add/commit command blocks for @git-commit. Caller owns structured Q&A and Proceed before mutating
+  steps. No push and no GitHub API.
+---
+
+# Internal: git commit commands (`internal-write-git-commit`)
+
+**Library.** **Runnable** **`git add`** / **`git commit`** sequences for **`@git-commit`**. **Caller** owns **structured Q&A** and **Proceed** before mutating blocks.
+
+## Preconditions (read-only)
+
+```bash
+TOP=$(git rev-parse --show-toplevel)
+```
+
+## Inspect working tree (read-only)
+
+```bash
+git -C "$TOP" status --short
+```
+
+## Stage tracked changes only (mutating)
+
+```bash
+git -C "$TOP" add -u
+```
+
+## Stage tracked and untracked changes (mutating)
+
+**Default for [`@git-commit`](../../../git/commit/SKILL.md)** — use this block unless the caller’s **single gate** (or one follow-up) narrows scope to tracked-only or selected paths.
+
+```bash
+git -C "$TOP" add -A
+```
+
+## Stage selected paths (mutating)
+
+Set **`PATHS`** as a shell-safe path list provided by the caller.
+
+```bash
+git -C "$TOP" add -- $PATHS
+```
+
+## Create commit (mutating)
+
+Set **`COMMIT_SUBJECT`** before this block.
+
+```bash
+git -C "$TOP" diff --cached --quiet || git -C "$TOP" commit -m "$COMMIT_SUBJECT"
+```
+
+## See also
+
+- [`@git-commit`](../../../git/commit/SKILL.md)
+- [`@git-push`](../../../git/push/SKILL.md)

--- a/.agents/skills/internal-write-git/tag/SKILL.md
+++ b/.agents/skills/internal-write-git/tag/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: internal-write-git-tag
+description: >-
+  Normative local git tag + tag push commands (check origin, ISO date yyyy-mm-dd tag name); optional replace local
+  annotated tag (force) and optional force-push to origin when the caller's Q&A records explicit override. Mutating
+  fences are run only under @git-tag (Proceed there). @git-zip may use read-only blocks here for verification before
+  internal-write-git-zip. No gh / GitHub API. Caller runs structured Q&A and Proceed before mutating fences.
+---
+
+# Internal: git tag commands (`internal-write-git-tag`)
+
+**Library.** **Runnable** **`git tag`** / **`git push`** **mutating** sequences are owned by **[`@git-tag`](../../../git/tag/SKILL.md)**—that public skill runs **Create** / **Replace** / **Push** after **Gate 2** / **Gate 3** / **Gate 4 — Proceed**. **[`@git-zip`](../../../git/zip/SKILL.md)** does **not** invoke these mutating blocks; it **orchestrates** **`@git-tag`** when a tag must be created or repointed, and may use **read-only** sections of this file (**Check `origin` exists**, **Inspect local tag**, **Inspect remote tag**, **Fetch remote tags**) to verify **`refs/tags/${TAG}`** on the **existing-tag** export path before **`internal-write-git-zip`**.
+
+**Caller** (always **`@git-tag`** for **mutations**) owns **structured Q&A** and **Proceed** before any mutating block using **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)**. **Never** run **Replace local** or **Push ... (force)** unless the user explicitly chose those options in **`@git-tag`** **Gate 2** / **Gate 3**. When **`@git-tag`** runs **Push**, do so **before** any follow-on **`@git-zip`** **Plain archive** so **`origin`** matches the tagged tree being zipped.
+
+**Master-confirm rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** do not bypass session-level confirm for tag replacement, remote tag pushes, or force pushes.
+
+## Preconditions (read-only)
+
+Resolve **before** user confirm rounds.
+
+```bash
+TOP=$(git rev-parse --show-toplevel)
+DATE=$(date +%Y-%m-%d)
+```
+
+**Default tag:** **`TAG="${DATE}"`** unless the caller **`export TAG=...`** before read/mutate blocks (then use that **`TAG`**). Blocks below resolve **`TAG="${TAG:-$DATE}"`**.
+
+**Optional target ref** (default **`HEAD`**): export **`GIT_TAG_TARGET=HEAD`** or another commit-ish before **Create** / **Replace** blocks.
+
+## Check `origin` exists (read-only)
+
+Use **before** promising **`git push origin ...`**. Non-zero exit if **`origin`** is missing.
+
+```bash
+git remote get-url origin
+```
+
+## Fetch remote tags (read-only; requires `origin`)
+
+Run before selecting or comparing tags on **`origin`** when `origin` exists.
+
+```bash
+git fetch origin --tags --prune
+```
+
+## Inspect local tag (read-only)
+
+```bash
+TAG="${TAG:-$DATE}"
+if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+  echo "local:refs/tags/${TAG}=$(git rev-parse "refs/tags/${TAG}^{}")"
+else
+  echo "local:missing refs/tags/${TAG}"
+fi
+```
+
+## Inspect remote tag (read-only; requires `origin`)
+
+Fails if **`origin`** is absent—caller should have run **Check `origin` exists** first.
+
+```bash
+TAG="${TAG:-$DATE}"
+git ls-remote --tags origin "refs/tags/${TAG}"
+```
+
+Empty output => no tag with that exact name on **`origin`** yet.
+
+## Inspect latest local tag (read-only)
+
+Use when a caller needs a **latest** local tag name for display or manual **`TAG=`** choice (not a silent default for **`@git-zip`**).
+
+```bash
+LATEST_LOCAL_TAG="$(git tag --list --sort=-v:refname | sed -n '1p')"
+if [[ -n "$LATEST_LOCAL_TAG" ]]; then
+  echo "latest_local_tag:$LATEST_LOCAL_TAG"
+else
+  echo "latest_local_tag:none"
+fi
+```
+
+## Inspect previous reachable tag (read-only)
+
+Use after branch/main alignment to summarize candidate release history.
+
+```bash
+PREV_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+if [[ -n "$PREV_TAG" ]]; then
+  echo "prev_tag:$PREV_TAG"
+else
+  echo "prev_tag:none"
+fi
+```
+
+## Inspect commits since previous tag (read-only)
+
+Set **`LOG_LIMIT`** if needed (default **25**). If there is no previous tag, show the latest commits from **`HEAD`**.
+
+```bash
+LOG_LIMIT="${LOG_LIMIT:-25}"
+if [[ -n "${PREV_TAG:-}" ]]; then
+  git log --oneline "${PREV_TAG}..HEAD" | sed -n "1,${LOG_LIMIT}p"
+else
+  git log --oneline HEAD | sed -n "1,${LOG_LIMIT}p"
+fi
+```
+
+## Create annotated tag only if missing (mutating)
+
+**Only after** caller **`@git-tag`** **Proceed**. **Idempotent** first-time create. **No-op** when **`refs/tags/${TAG}`** already exists — use **Replace local annotated tag (force)** when the user chose to repoint the tag.
+
+```bash
+cd "$TOP"
+TAG="${TAG:-$DATE}"
+GIT_TAG_TARGET="${GIT_TAG_TARGET:-HEAD}"
+if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+  git tag -a "$TAG" -m "$TAG" "$GIT_TAG_TARGET"
+fi
+```
+
+## Replace local annotated tag (force) (mutating)
+
+**Only after** caller **`@git-tag`** **Gate 4 — Proceed** and an explicit **"replace local"** / **"force local"** choice (**Gate 2**). Moves **`refs/tags/${TAG}`** to **`GIT_TAG_TARGET`** (annotated).
+
+```bash
+cd "$TOP"
+TAG="${TAG:-$DATE}"
+GIT_TAG_TARGET="${GIT_TAG_TARGET:-HEAD}"
+git tag -fa "$TAG" -m "$TAG" "$GIT_TAG_TARGET"
+```
+
+## Push one tag to `origin` (mutating)
+
+**Only after** caller **`@git-tag`** **Proceed** for **push** when the remote **does not** already have this tag **or** it matches what you are publishing without needing **`--force`**. Requires **`origin`**.
+
+```bash
+TAG="${TAG:-$DATE}"
+git push origin "refs/tags/${TAG}:refs/tags/${TAG}"
+```
+
+If this fails because **`origin`** has a different object for **`${TAG}`**, the caller should have offered **force push** per **`@git-tag`** **Gate 3** and then run **Push one tag to `origin` (force)** instead.
+
+## Push one tag to `origin` (force) (mutating)
+
+**Only after** caller **`@git-tag`** **Gate 4 — Proceed** and an explicit **"force push"** / **"overwrite remote tag"** choice (**Gate 3**). **Destructive** on **`origin`**: replaces the remote tag ref. Requires **`origin`**.
+
+```bash
+TAG="${TAG:-$DATE}"
+git push --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+```
+
+## See also
+
+- [`internal-write-git-zip`](../zip/SKILL.md) — zip archive naming (**`${PROJECT}-${DATE}.zip`**) is separate from **tag** name (**`${TAG}`** / default **`${DATE}`**)
+- [`@git-tag`](../../../git/tag/SKILL.md) — public orchestration (**mutations**)
+- [`@git-zip`](../../../git/zip/SKILL.md) — orchestrates **`@git-tag`** then **`internal-write-git-zip`**; **read-only** use of this file for verification on the existing-tag path only

--- a/.agents/skills/internal-write-git/working-tree-align/SKILL.md
+++ b/.agents/skills/internal-write-git/working-tree-align/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: internal-write-git-working-tree-align
+description: >-
+  Read-only playbook: local git reset/clean (no gh). Dirty-tree confirm (no stash), discover clean targets, git clean
+  dry-run, confirm and execute git reset --hard to a caller-supplied ref and git clean. Optional non-git prunes table.
+  Callers: @git-main (MODE=combined), @git-reset (MODE=split). Does NOT fetch, checkout branches, or resolve ALIGN_REF.
+---
+
+# Internal: Working tree align (reset + clean)
+
+**Read-only library.** **Local `git` only** (no **`gh`**). Parent skills set **`$ALIGN_REF`** (resolved ref string, e.g. **`upstream/main`**, **`origin/feature-x`**) and **`$BRANCH`** (current branch name for messages). This library does **not** fetch, **not** `git checkout`, and **not** compute **`$ALIGN_REF`**—use **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)** + parent workflow for that.
+
+**Prompts** — apply **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** + **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** (**§3a**: **Goal** + **AskQuestion**, **Abort** / **Proceed**). **Never** **`git stash`**.
+**Master-confirm rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** do not bypass session-level confirm for **`git reset --hard`**, **`git clean`**, or optional global prune commands.
+
+---
+
+## Parameters (set by caller)
+
+| Parameter | Meaning |
+| --- | --- |
+| **`$ALIGN_REF`** | Tip to match after **`git reset --hard`** (already fetched and valid). |
+| **`$BRANCH`** | Current branch name (for **Goal** lines). |
+| **`MODE`** | **`combined`** (**`@git-main`**) — one confirm may cover **reset + clean** (split if dry-run huge). **`split`** (**`@git-reset`**) — **separate** confirm before reset and before clean. |
+
+---
+
+## 1. Dirty tree (no stash)
+
+**When:** **`git status --short`** is **not** empty **before** reset/clean (caller skips this block if the tree is already clean).
+
+1. Show **`git status --short`** (and a one-line summary; for **`@git-reset`**, include modified / untracked / staged counts).
+2. **Stop** and **AskQuestion** per **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)** **§3a** with a **Goal** line chosen by the **caller**:
+   - **`@git-main`** style: align local **`main`** to **`$ALIGN_REF`** and remove untracked/ignored files per planned **`git clean`**—destroying uncommitted work.
+   - **`@git-reset`** style: align branch **`$BRANCH`** to **`$ALIGN_REF`** and run the planned **`git clean`**—permanently discarding local diffs.
+3. Options:
+   - **Keep work / abort** — end the **parent** skill; user should commit, copy files aside, or use another workflow.
+   - **Trash and align** — user explicitly accepts destruction; continue to **§2**.
+4. **Do not** stash. **Do not** offer stash as a third path (**`@git-reset`**: if vague, default **abort** until **trash and align** is explicit).
+
+---
+
+## 2. Discover — what `git clean` may touch
+
+**Read-only.** Scan the worktree (repo root; monorepo hints from README if obvious). **Brief** bullets: stack signals and **large** paths likely listed by **`git clean -fdxn`**.
+
+Common ignored / untracked targets (examples):
+
+- **Node:** `node_modules/`, `dist/`, `build/`, `.next/`, `coverage/`
+- **Python:** `.venv/`, `__pycache__/`, `.pytest_cache/`, `.ruff_cache/`
+- **Rust:** `target/`
+- **Go:** `vendor/` or untracked binaries
+- **JVM / .NET:** `target/`, `build/`, `bin/`, `obj/`
+- **Terraform:** `.terraform/`
+
+For richer stack detection patterns, align with **`@git-review`** / **[`internal-read-git-discover-dependencies`](../../read/git/discover-dependencies/SKILL.md)** when helpful.
+
+---
+
+## 3. Clean dry-run
+
+Before any **`git clean`** that removes files:
+
+```bash
+git clean -fdxn
+```
+
+Show output (truncate if enormous: counts + top directories). If the user prefers **keeping ignored** files, plan **`git clean -fd`** / **`git clean -fdn`** instead and say so before confirm.
+
+---
+
+## 4. Confirm and execute
+
+### MODE `combined` (`@git-main`)
+
+- State **`git reset --hard "$ALIGN_REF"`** + the **`git clean`** command from **§3** (**`-fdx`** default, or **`-fd`** if keeping ignored).
+- **One** **Goal** + **AskQuestion** (**Abort** / **Proceed**) may cover **both** reset and clean when **§1** was **trash and align** or only untracked/ignored remain. **Split** into **two** confirms if the dry-run is **large** or **surprising**.
+- **Only after Proceed:**  
+  - **`git reset --hard "$ALIGN_REF"`**  
+  - **`git clean -fdx`** (or **`git clean -fd`** if keep-ignored)
+
+**Do not** run **`git pull`** after this block (caller rule).
+
+### MODE `split` (`@git-reset`)
+
+1. **Reset confirm** — State branch **`$BRANCH`** and **`git reset --hard "$ALIGN_REF"`**. Remind that **tracked** files match **`$ALIGN_REF`** and uncommitted **tracked** edits are discarded (**§1** already handled consent when dirty). **Goal** + **AskQuestion** (**Abort** / **Proceed**).
+2. **Execute reset** — Only after Proceed: **`git reset --hard "$ALIGN_REF"`** (stay on **`$BRANCH`**).
+3. **Clean confirm** — Remind: **`git clean -fdx`** (or **`git clean -fd`**) matches **§3** dry-run. **Goal** + **AskQuestion** (**Abort** / **Proceed**).
+4. **Execute clean** — Only after Proceed: **`git clean -fdx`** or **`git clean -fd`**.
+
+---
+
+## 5. Optional — non-git / global caches
+
+**Only** if the user **explicitly** asked (**`@git-main`**) or per table (**`@git-reset`**). **Each** command: **own** **Goal** + **AskQuestion** (**Abort** / **Proceed**). Skip if not applicable.
+
+| Topic | When to offer | Example | Confirm |
+| --- | --- | --- | --- |
+| **Docker** | `Dockerfile` / compose present **or** user asked | `docker builder prune -f` | **Goal** + **AskQuestion** before run |
+| **Docker (aggressive)** | User explicitly asks | `docker system prune` / `-a` | **Goal** + **AskQuestion** (explicit **Proceed**) |
+| **Podman** | Containerfile / user asked | `podman builder prune`, `podman system prune` | Same as Docker |
+| **npm (global cache)** | User asked | `npm cache clean --force` | **Goal** + **AskQuestion** |
+| **Playwright** | User asked; Playwright in deps | User cache under **`$HOME`** | **Goal** + **AskQuestion** before delete |
+| **Rust / extra** | User asks | project script / third-party tool | **Goal** + **AskQuestion** per command |
+| **Other** | README, Makefile, user names a tool | project-specific | **Goal** + **AskQuestion** per command |
+
+---
+
+## Do not (library)
+
+- **`git stash`**
+- **`git push`**
+- Fetch or resolve **`$ALIGN_REF`** (caller’s responsibility)
+
+## See also
+
+- **[`internal-read-gh-repo-stream`](../../read/gh/repo-stream/SKILL.md)** — **`CANONICAL_MAIN_REF`**, **`$TARGET`** priority (**`@git-reset`** §4).
+- **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** — reset/clean triggers.

--- a/.agents/skills/internal-write-git/zip/SKILL.md
+++ b/.agents/skills/internal-write-git/zip/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: internal-write-git-zip
+description: >-
+  Normative local shell: default git archive (GitHub-style zip, tracked tree only, no .git); optional full-tree zip
+  including .git for rare full-clone portable backups. No gh / GitHub API. Caller runs Q&A first; this library holds
+  runnable command blocks. Consumed by @git-zip.
+---
+
+# Internal: git zip commands (`internal-write-git-zip`)
+
+**Library.** **Runnable** **`git archive`** (default). **Caller** ([`git-zip`](../../../git/zip/SKILL.md)) owns **structured Q&A** and **Proceed** before invoking these steps via **[`internal-write-plan-skill-safety`](../../../write/plan/skill-safety/SKILL.md)** and **[`internal-write-plan-structured-qa`](../../../write/plan/structured-qa/SKILL.md)**. **Tag** create/replace/push is owned by **[`@git-tag`](../../../git/tag/SKILL.md)** via **`internal-write-git-tag`**; **`@git-zip`** calls **`@git-tag`** when needed, then sets **`ARCH_REF=refs/tags/${TAG}`** and invokes this file for export only.
+**Master-confirm rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** do not bypass session-level confirm for out-of-repo archive writes or optional full-tree backup writes.
+
+**Default behavior:** **`git archive --format=zip`** — same class of artifact as GitHub **"Source code (zip)"** for a ref (**no** **`.git`**, **no** untracked files). Primary caller **`@git-zip`** sets **`ARCH_REF=refs/tags/${TAG}`** (default **`TAG=${DATE}`**) after **`@git-tag`** or after read-only tag verification. Other callers may set **`ARCH_REF`** themselves (including **`HEAD`**) only with their own Q&A and scope.
+
+## Preconditions (read-only)
+
+Resolve repo root and naming facts **before** the Q&A rounds in the public skill. **Do not** write archives until **Proceed** after path/tag confirmation.
+
+```bash
+TOP=$(git rev-parse --show-toplevel)
+PROJECT=$(basename "$TOP")
+DATE=$(date +%Y-%m-%d)
+```
+
+Export **`TOP`**, **`PROJECT`**, **`DATE`**. Choose **`DEST_DIR`** with the user (default: parent of **`TOP`**). **Caller** sets **`ARCH_REF`**:
+
+- **`refs/tags/${TAG}`** — snapshot of the **annotated tag** (**`@git-zip`** public paths always use this after **`@git-tag`** or existing-tag verification; default **`TAG=${DATE}`**).
+- **`HEAD`** — only for **non-`@git-zip`** callers that explicitly export the current commit with their own confirmation.
+
+## Variables
+
+Substitute **`TOP`**, **`DEST_DIR`**, **`DATE`**, **`PROJECT`**, **`ARCH_REF`**. Output basename: **`${PROJECT}-${DATE}.zip`**.
+
+## Plain archive (default — contents only)
+
+**Tracked files at `ARCH_REF` only** — **no** **`.git`**.
+
+```bash
+mkdir -p "$DEST_DIR"
+OUT="${DEST_DIR}/${PROJECT}-${DATE}.zip"
+git -C "$TOP" archive --format=zip --output "$OUT" "$ARCH_REF"
+```
+
+Optional **top-level folder inside the zip** (closer to GitHub's **`owner-repo-ref/`** layout):
+
+```bash
+git -C "$TOP" archive --format=zip --prefix="${PROJECT}/" --output "$OUT" "$ARCH_REF"
+```
+
+## Optional full-tree backup (includes `.git`)
+
+**Not** **`@git-zip`** default — portable **clone** of the working tree **including** **`.git`** (large). Only when the user explicitly asks for **full repository** backup, not GitHub-style.
+
+```bash
+cd "$TOP"
+mkdir -p "$DEST_DIR"
+OUT="${DEST_DIR}/${PROJECT}-${DATE}-full.zip"
+zip -qr "$OUT" . -x "*.zip"
+```
+
+## See also
+
+- [`@git-tag`](../../../git/tag/SKILL.md) — tag create/replace/push (**mutations**); run before **`@git-zip`** export when the tag is not already settled
+- [`internal-read-git-workflows`](../../../read/git/workflows/SKILL.md#git-zip-workflow) — naming + **GitHub vs full-tree**
+- [`@git-zip`](../../../git/zip/SKILL.md) — public orchestration: **`@git-tag`** (when needed), then **`git archive`** at **`refs/tags/${TAG}`**
+- [`internal-write-git-tag`](../tag/SKILL.md) — **Create** / **Replace** / **Push** (**`@git-tag`** only); read-only **Inspect** shapes for **`@git-zip`** verification on the existing-tag path

--- a/.agents/skills/internal-write-plan-skill-safety/SKILL.md
+++ b/.agents/skills/internal-write-plan-skill-safety/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: internal-write-plan-skill-safety
+description: >-
+  Read-only: which operations need summary → confirm → act (push, commit, deletes, reset/clean, bulk/structural
+  creates, writes outside repo root, system-wide toolchain changes when the agent would perform them); §1e triage for
+  writes vs lightweight reads. Does NOT replace parent skills—layers on structured-qa for prompt UX.
+---
+
+# Internal: Skill safety (irreversible and high-impact actions)
+
+**Read-only policy.** Skills that perform **irreversible** or **high-impact** work must **summarize impact**, then **obtain explicit user confirmation**, then **act**. Confirmation UX follows **[`internal-write-plan-structured-qa`](../structured-qa/SKILL.md)** **§1a**, **§1b**, **§1c**, **§1e**, **§2**, **§3–§3a**, **§5**, **§8** (compact summary / **plan preview** before Q&A, **Cursor** **AskQuestion** for finite choices, **one** freeform reminder when needed—**no** redundant **Other** + duplicate chat invite; default **abort** on ambiguity; failure triage uses safe-first ~3-option choices).
+
+**Does not** replace parent skill steps (e.g. **`@git-reset`** **Proceed** before **`git reset --hard`**)—this library defines **what** to confirm and **how** to frame it.
+
+**Global gate** — **Any online mutation** (anything that **changes** remote GitHub state: **`gh issue`/`gh pr`/`gh api`** writes, **`git push`**, and equivalent) and **any write to paths outside the current git workspace root** (or outside an explicit user allowlist) require **Goal + structured confirm** (**AskQuestion** or equivalent per **`internal-write-plan-structured-qa`**) **before** the agent runs them. **Read-only** inventory (**`internal-read-gh-issue-list`**, **`internal-read-gh-pr-list`**, **`internal-read-gh-repo-stream`**, **`internal-write-gh-issue-commands`** **View** section when used for single-issue read-only, …) does **not** replace that gate for follow-on writes—the **mutation skill** owns **Proceed**.
+**Master-confirm override rule** — **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** flags can suppress low-risk prompt repetition, but they **never** bypass the session-level master confirm for online mutations, destructive local operations, or writes outside repo root.
+
+- **Write triage shape** — **Online writes** and **writes outside the repo root** use **[`internal-write-plan-structured-qa`](../structured-qa/SKILL.md)** **§1e** (**Abort** / **Review** / **Proceed**) before the first mutating command when the user may need to refine targets without a binary **No**/**Yes** only.
+- **Reads stay lightweight** — **Read-only** online and outside-repo passes do **not** use that stacked triage; see **§1e** read carve-out.
+
+For reusable prompt shape and labels, use [`internal-write-plan-structured-qa`](../structured-qa/SKILL.md) §1a, §1c, and §3a.
+
+## Internal libraries: read vs write cadence
+
+- **Read-only internals** — Libraries whose **normative fences** are **only** non-mutating toward GitHub and **non-destructive** toward disk by default (**`internal-read-gh-issue-list`**, **`internal-read-gh-pr-list`**, **`internal-read-gh-repo-stream`**, **`internal-read-git-merge-conflicts`** playbook, **`internal-read-gh-issue-dedupe`** checklist logic, **`internal-read-git-discover-dependencies`** when the parent forbids install/evaluate, most **`internal-read-git-doc-*`**, **`internal-read-git-git-diff-summary`** as read-only diff input, …). **Parents** that are **read-only** (e.g. **`@gh-issue-list`**, **`@gh-pr-list`**, **`@gh-issue-review`** inventory) may use them **without** an extra confirmation **unless** the parent skill itself needs **AskQuestion** (ambiguous pick). **Never** treat a read-only pass as permission to **skip** **Proceed** on a later **`gh`** write, **`git push`**, **commit**, **reset/clean**, **outside-repo write**, or **destructive install**—those steps keep their **Triggers** rows below.
+- **Write / mutation internals** — Libraries that own **`gh`** **mutations**, **`gh api`** writes, **`git`** history or index **mutations** via invoked commands, or **destructive** installs (**`internal-write-gh-issue-commands`**, **`internal-write-gh-pr-commands`**, **`internal-write-git-tag`** (**`git tag`** / **`git push`** tag), **`internal-write-gh-install-dependencies`** when cleans apply, …). **Always** run behind a **public** skill that performs **Goal + structured confirm** before the first mutating fence. **Extra scrutiny** when the effect is **online** or **outside this repository folder**.
+
+## `internal/gh` naming vs `git` work
+
+- All pack internals live under **`skills/read/gh/`** with path-faithful `internal-read-gh-*` / `internal-write-gh-*` names. **Split by job**, not by the word “git” in a name:
+  - **GitHub / network** — **`gh`** and GitHub **HTTP/API** shapes for issues/PRs/templates/stream (**`internal-read-gh-issue-list`**, **`internal-read-gh-pr-list`**, **`internal-write-gh-issue-commands`**, **`internal-write-gh-pr-commands`**, **`internal-read-gh-repo-forms-json`**, **`internal-read-gh-repo-stream`**, **issue/PR description** libs, …).
+  - **Local `git` / workspace shell** — **`internal-write-git-zip`**, **`internal-write-git-tag`**, **`internal-read-git-git-diff-summary`**, **`internal-read-git-merge-conflicts`**, **`internal-write-git-working-tree-align`**: **local terminal** playbooks and **`git`** usage **without** substituting **`@gh-*`**. **Public** **`@git-*`** skills under **`skills/git/`** own user intent for push/pull/reset/zip/tag; they consume these locals plus **discover / install / configuration / evaluate** for **toolchain** work on disk.
+
+---
+
+## Pattern
+
+1. **Summarize** — In chat: counts, branch/remotes, `git status --short`, `git diff --stat` (or staged stat), representative paths (cap long lists with “+N more”), dry-run output when available—combined with a **Goal** line into one **brief but detailed** preamble per **[`internal-write-plan-structured-qa`](../structured-qa/SKILL.md)** **§1a**. When **§1c** applies (large change set, outside-repo writes, many new doc paths), the preamble must include an explicit **plan** (what will run, file count, top paths).
+2. **Goal + confirm** — Then **AskQuestion** (or equivalent) with **very short** labels (**No**/**Yes** or **Abort**/**Proceed**, etc.) per **§2**; **at most one** brief chat reminder after the buttons per **§5** when the flow is not using the **§1b** “omit reminder” carve-out. Do **not** treat free-form chat as the **only** confirmation when the choice set is finite. One confirm may cover **commit + push** when both happen in the same flow; **merge** **§1c** with **§3a** into **one** round when both apply.
+3. **Act** — Only after explicit **Yes** / **Proceed** (or equivalent) from that structured step, or after the user’s **alternative** instruction in **chat** (re-summarize if scope changed).
+
+---
+
+## Structured confirm (authoring)
+
+**Structured confirm** — Shorthand for child **`SKILL.md`** files: meet the relevant **Triggers** row (what the summary must include; confirm **Yes** where required) **and** apply **[`internal-write-plan-structured-qa`](../structured-qa/SKILL.md)** **§1c** (when bulk/large) + **§3a** / **§1e** (offline-outside-repo + online writes) for **Goal** + **AskQuestion** shape—**merge** into **one** round when both apply. Link **this file** at least once per skill or per major section; in the same section you may then write **structured confirm** instead of repeating both library names.
+
+---
+
+## Triggers (minimum)
+
+| Trigger | Summary must include | Confirm |
+| --- | --- | --- |
+| **`git push`** / first upstream publish / **`git push origin <tag>`** | Branch or **tag** name, **`origin`** URL when pushing tags, remote intent, stat for what will be committed if the tree is not clean | Yes, before **commit** (if any) and **push** |
+| **`git push --force-with-lease`** (or equivalent force-like push) | Branch, remote, why non-force push failed, explicit risk to remote history/teammates, and safer alternatives considered | Yes — separate explicit confirm from normal push confirm; default **Abort** on ambiguity |
+| **`gh issue delete`** (bulk closed cleanup) | Count + preview table of ids/titles; irreversible on GitHub | Yes, before **each** delete wave (**`@gh-issue-delete-closed`**) |
+| **`gh project delete`** (bulk closed cleanup) | Owner scope + preview table of numbers/titles; irreversible on GitHub | Yes, before **each** delete wave (**`@gh-project-delete-closed`**) |
+| **`git commit`** (when the skill runs it) | Same stat / one-line message intent | Yes (may share one confirm with push) |
+| **`gh pr create`** | Target repo, **base** / **head**, one-line intent (“open a new PR with this title/body”) | Yes, before **`gh pr create`** |
+| **`gh pr edit`** | PR number, summary of title/body replacement (“replace remote PR description”) | Yes, before **`gh pr edit`** |
+| **`gh pr close`** | PR number, repo (`--repo` when applicable), one-line intent (“close PR #*N*”) | Yes, before **`gh pr close`** |
+| **`gh label create`** | Label name(s), color, short description intent | Yes, before **`gh label create`** (may be **separate** from **`gh issue create`** confirm when risks would blur) |
+| **Delete** paths (tracked or untracked) | Count + representative paths | Yes |
+| **`git reset --hard`**, **`git clean`**, destructive install cleans | Dry-run or impact list where applicable | Yes |
+| **Bulk / structural file creation** (many new paths from a plan) | Count + top paths / move map | Yes |
+| **Many new `README.md` / doc hub pages in one change set** | Count + categories + top paths | Yes — **§1c** plan preview + **No**/**Yes**; fold `.gitkeep` into the same summary (no separate modal) |
+| **Writes outside git workspace root** (or outside an explicit user allowlist) | Paths named; **Goal** (“touch paths outside repo”) | Yes — **§1c** + **§1e** before any write (**Abort** / **Review** / **Proceed**) |
+| **Large change set** (see below) | **§1c** plan embedded in preamble: file count + `git diff --stat` excerpt + top paths | Yes — use **§1c**; **merge** with **commit/push** confirm into **one** **No**/**Yes** when both apply |
+
+**Online mutation rows** — Rows whose triggers change GitHub or **`origin`** (**`git push`**, **`gh pr create`/`edit`/`close`**, **`gh issue`** mutations, **`gh project delete`**, **`gh label create`**, …) use the same **§1e** triage shape when a **Review** beat is needed—not limited to binary **No**/**Yes** when the user must refine targets or copy before mutating.
+
+**Large change set (defaults)** — Treat as **large** when **either**: (a) **≥10 files** changed (staged + unstaged intended for the operation), or (b) **≥500 lines** net change from `git diff --stat`. Parent skills may tighten or relax with user consent.
+
+### Exception: **`@git-pull`** merge commits
+
+Merge commits from **`@git-pull`**—including **`git merge`** when it completes without conflict and **`git commit`** after conflict resolution—**do not** need a separate **AskQuestion** before each commit. The user already invoked **`@git-pull`** to bring **`@{u}`** and **`ROOT_BRANCH`** into the current branch; that intent covers finishing the merge.
+
+If **`git status`** shows **unexpected** state before merging (e.g. unrelated uncommitted changes the user did not imply), **stop** and clarify in **chat** per **[`internal-write-plan-structured-qa`](../structured-qa/SKILL.md)** **§4**; default **abort** on ambiguity. Publishing remains **`@git-push`** (with its own confirm).
+
+### Exception: ephemeral scratch paths in **`@git-push`**
+
+Removing **only** directories or files the agent **created in the same `@git-push` run** as throwaway output (e.g. a random temp path never staged) so they are **not** committed **does not** require a separate **AskQuestion**—outside the **Delete** row’s normal confirm. **Do not** use this for tracked paths, user-owned dirs, or anything beyond that narrow case.
+
+---
+
+## Scope for new files (“create”)
+
+- **No** extra confirm for routine **single-file** edits the user clearly asked for.
+- **Yes** confirm for **bulk** or **structural** adds—e.g. **many** new **`docs/`** or mirror **`README.md`** paths in one change set, **`@git-docs`** when touching **many** **existing** doc paths in one run (**§1c**), plan-driven edits that add **many** new paths or reshape trees.
+
+---
+
+## Cross-skill Q&A (quick map)
+
+| Situation | Skill / library |
+| --- | --- |
+| User-driven **many** new doc / mirror paths | **Large create** — **AskQuestion** + **No**/**Yes** before bulk writes (**`internal-write-plan-skill-safety`**) |
+| User-driven doc sync (many **existing** files) | **`@git-docs`** — **AskQuestion** for mode; **No**/**Yes** before bulk in-place writes (**§1c**) |
+| Verify + **§8a** doc polish | **`@git-review`** — runs **`internal-write-gh-documentation`** after green evaluate |
+| Commit + push | **`@git-push`** — structured confirm for large change sets (**§3a**) |
+| `gh pr create` / `gh pr edit` | **`@gh-pr`** §9 — confirm before mutation; **`internal-read-gh-pr-description`** for **multiple** PR templates **or** **material template reshape** (keep / blend / pack) — **separate** from that **§9** PR mutation confirm when risks would blur |
+| `gh issue create` / `gh issue edit` / `gh issue close` / `gh issue delete` | **`@gh-issues`**, **`@gh-issue-close`**, **`@gh-issue-delete-closed`** — confirm before mutation; **`internal-read-gh-issue-description`** for **multiple** issue templates **or** **material reshape** — **separate** from final **`gh`** confirm when needed |
+| `gh project delete` | **`@gh-project-delete-closed`** — confirm before mutation; preview owner scope + closed set before each delete wave |
+| **`gh label create`** (issue label decoration) | **`@gh-issues`** after **`internal-read-gh-issue-labels`** — confirm before **`gh label create`**; then include label flags in the chosen issue mutation path |
+| Delivery from issue anchor (`#n` / URL) with branch + PR delegation | **`@gh-issue-view`** then **`@git-start`** — read full issue extract via **`internal-write-gh-issue-commands`** view when needed, present TODO plan + checkpoints, then **Goal + AskQuestion + Proceed** before mutating downstream flows (**`@git-start`**, implementation writes, **`@gh-pr`**) |
+| **`gh pr close`** | **`@gh-pr-close`** — **Goal** + **AskQuestion** + **Proceed** before **`gh pr close`** |
+
+---
+
+## Do
+
+- Apply this policy whenever a trigger row applies; link **`internal-write-plan-structured-qa`** for how to ask.
+- Keep confirms **one phase per major risk**—do not merge unrelated risks into a single “yes” (see structured-qa §3).
+
+## Do not
+
+- Skip summary or confirmation for rows in the table above.
+- Treat ambiguous replies as consent—default **abort** unless the parent skill states otherwise.
+
+---
+
+## See also
+
+- **[`internal-write-plan-structured-qa`](../structured-qa/SKILL.md)** — Prompt UX (AskQuestion, ordering, escape hatches).
+
+### Optional cleanup for ephemeral `.cursor/gh` staging
+
+When a run created disposable staging paths under `.cursor/gh/issues/` or `.cursor/gh/pr/`, offer a final **AskQuestion** to keep or delete those paths. Default to **keep** on ambiguity.

--- a/.agents/skills/internal-write-plan-structured-qa/SKILL.md
+++ b/.agents/skills/internal-write-plan-structured-qa/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: internal-write-plan-structured-qa
+description: >-
+  Read-only: AskQuestion vs chat, short labels, ordering, one freeform outlet; §1e Abort/Review/Proceed for offline
+  outside-repo + online writes. Pairs with internal-write-plan-skill-safety (which ops need confirm). Does not replace
+  parent skill content.
+---
+
+# Internal: Structured Q&A
+
+**Read-only policy library.** Skills that **ask**, **confirm**, or offer **finite choices** in Cursor apply **§1–§8** here (**§1** includes **§1e** triage). **Write libraries** (`skills/write/<domain>/**`): the **caller** (usually a public **`@git-*` / `@gh-*`** skill) must **merge every planned mutation** into one **summary**, then run **AskQuestion** (or equivalent) with **Proceed** before any fence in a **`write/`** library—**never** “chat yes” alone.
+
+**Pairing:** **`internal-write-plan-skill-safety`** names **which** actions need summary → confirm; **this file** is **how** to prompt (**§3a** for those triggers; **§1e** for **Abort** / **Review** / **Proceed** on offline-outside-repo and online writes).
+**Master-confirm override rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** may skip repetitive low-risk prompts, but they never waive session-level master confirm for online mutations, destructive actions, or writes outside repo root.
+
+## Do not
+
+- Replace **`internal-write-plan-skill-safety`** wholesale.
+
+---
+
+## 1. Finite choices — structured UI first
+
+- Use **AskQuestion** (or equivalent) for small known outcome sets; **gather facts** (names, dry-run) **before** options.
+
+### 1a. Order: summary → question → options → one chat line
+
+1. **Summary** — Goal line + tight facts (`git status --short`, `git diff --stat`, counts, top paths, commit intent—whatever parent requires). **Detail lives here**; labels stay tiny.
+2. **Question** — one sentence (“Proceed with …?”).
+3. **Structured options** — real finite set only; no fake **Other…** if §5 chat line covers escape (**§5**).
+4. **One** trailing chat invite max (**§5**).
+
+### 1b. Minimal binary (low-risk doc apply)
+
+Short summary (~5 bullets) → one-line question → **No**/**Yes** (**No** first) → optional trailing line (omit when noisy; **keep** for §3a triggers).
+
+### 1c. Plan preview (bulk / non-trivial writes)
+
+Plan + file count + paths → “Proceed?” → **No**/**Yes** (**No** first). **Yes** = execute as summarized. **Large** commit+push: **one** combined **No**/**Yes** with **`internal-write-plan-skill-safety`**—do not stack duplicate modals for the same phase.
+
+### 1d. Pre-write and mutation prompts (brief question, summary above)
+
+For prompt gates that immediately decide a write path (for example, choose edit/create before drafting, or confirm a final GitHub mutation):
+
+1. Put the **full actionable summary** in the assistant message immediately before AskQuestion (goal, target, key facts, what happens on Proceed).
+2. Keep the **AskQuestion prompt text short** (one sentence; identifiers and action only). Do not paste full PR/issue bodies, long diffs, or large markdown blocks in the prompt itself.
+3. Use safe-first options: **Abort** first, then one or more **Proceed** options that map to exact actions.
+4. Offer exactly one refinement outlet per **§5** (either **`additionalSuggestion`** or one trailing chat line, not both).
+5. If multiple **Proceed** options exist, keep labels short and specific (for example, “Proceed — edit #n”, “Proceed — create new”).
+
+**`@gh-issues` multi-issue batch:** When several themes ship in one invocation, put a compact **table** in the pre-prompt summary (theme → **edit #n** or **create** → body file path if any). Offer **Abort** (safe-first), optional **Defer** / narrow options if the parent skill allows, then **Proceed — batch** whose summary already lists **every** `gh issue create` / `gh issue edit` in execution order. **One** Proceed confirms the **whole** batch. If the user prefers smaller steps, stop after partial execution and route remaining themes to a **follow-up `@gh-issues`** (new summary + Proceed).
+
+This pattern complements **§3a** and is commonly used in **`@gh-pr`** intent and mutation confirms.
+
+**`@gh-issues` pre-dedupe gate:** after each issue-draft refinement summary, use **Sharpen / Abort / Ship** (finite labels, **§5**) before inventory/dedupe; orchestration lives in **[`internal-read-gh-issue-preflight-qa`](../../read/gh/issue-preflight-qa/SKILL.md)**.
+
+### 1e. Pre-write triage — offline outside repo + online mutations
+
+When **`internal-write-plan-skill-safety`** applies to **writes outside the git workspace root** or **online mutations** (remote GitHub changes, **`git push`**, durable **`gh`** writes, tag push to **`origin`**, …):
+
+1. **Summary first** — **Goal** + targets + counts per **§1a**; use **§1c** when bulk/large or many paths.
+2. **AskQuestion** (safe-first order when labels are ordered): **Abort** / **Review** / **Proceed**.
+   - **Abort** — stop; no mutating fence.
+   - **Review** — pause to restate targets, paths, or intent in chat; adjust destination/repo/title/body **without** running **`gh`**, **`git push`**, **`git archive`**, or other mutating blocks yet. Then re-summarize and ask again.
+   - **Proceed** — execute **exactly** what was summarized.
+
+This tri-modal gate is for **writes only**. **Read-only** work (**`gh` list/view/search** when non-mutating, **`internal-read-gh-repo-stream`**, reading paths outside the workspace for **inspection**) stays **straightforward**: optional tight **§1a** preamble, then run the read **without** stacking **Abort / Review / Proceed**. Use **AskQuestion** on reads only for **finite disambiguation** (for example which issue id), not as mandatory safety triage.
+
+**Relation to §8:** **Review** overlaps **Change plan** in failure/plan-change triage—prefer the same short labels across flows.
+
+---
+
+## 2. Option design
+
+- **Very short labels** — **No**/**Yes**, **Abort**/**Proceed**, or verb+object; optional ~80-char template hint.
+- **~2–12** options; larger sets → narrow first.
+- **Never** paragraphs inside option text.
+
+---
+
+## 3. Destructive / binary flows
+
+- Opposing actions clear; **impact before confirm** (`git status`, dry-run, counts).
+- **Default-safe:** ambiguous → abort unless parent says otherwise.
+- **One confirm per major risk**—do not merge unrelated risks into one **Yes**.
+
+### 3a. Goal-first (safety triggers)
+
+For ops flagged in **`internal-write-plan-skill-safety`** (commit, push, reset/clean, destructive installs, **`gh`** PR/issue mutations, bulk deletes, writes outside repo, …):
+
+1. **Preamble** — **Goal** (one line) + compact facts (**§1a**).
+2. **Question** — one short sentence (e.g. “Proceed with commit and push?”).
+3. **AskQuestion** — **No**/**Yes** or **Abort**/**Proceed**; safe option first when order matters.
+4. **One** chat reminder after buttons (**§5**); skip if redundant with **`additionalSuggestion`**.
+
+The modal prompt may repeat only minimal identifiers (branch/tag/target), while the detailed summary remains in the message above.
+
+Remote irreversible (**push**, durable **`gh`** writes) and local destructive (**reset/clean**, wipes) share this pattern.
+
+---
+
+## 4. Open-ended
+
+Chat prompt; one question + inline examples; re-ask with constraint on validation failure (e.g. branch name).
+
+---
+
+## 5. Freeform — no duplicate outlets
+
+- **Safest option first** when UI order matters.
+- **Escape** = real negative options (**No**/**Abort**)—not **Other…** **and** “or type in chat” **and** **`additionalSuggestion`** same turn.
+- **One** freeform outlet: either **one** post-button chat line **or** JSON **`additionalSuggestion`**—not both as duplicate “type something else” paths.
+- **`allow_multiple: true`** only when truly needed (rare).
+
+---
+
+## 6. Tool naming
+
+Describe capability (“structured multiple-choice”) vs hard-coding a single IDE control name.
+
+---
+
+## 7. Consumers (index)
+
+**Any** skill with **AskQuestion** / destructive **Proceed**: **`@git-push`**, **`@git-main`**, **`@git-reset`**, **`@git-start`**, **`@git-review`** (install prepare), **`@git-docs`**, **`@git-zip`**, **`@gh-pr`**, **`@gh-pr-close`**, **`@gh-issues`**, **`@gh-issue-close`**, **`@gh-issue-delete-closed`**, **`@gh-project-delete-closed`**, **`@gh-issue-pick`**, **`@gh-issue-review`** (scope only), **`internal-read-gh-pr-description`** (multi-template / material reshape), **large** doc edits (**`internal-write-plan-skill-safety`** **confirm-first**).
+
+**Internal:** **`internal-write-plan-skill-safety`** — trigger list vs **§3a** / **§1e** here.
+
+---
+
+## 8. Failure / plan-change triage
+
+Use this pattern when a mutating step fails (for example **`git push`**, **`gh`** mutation), or when a new fact changes the plan (for example wrong branch, missing remote, protected/default-branch restrictions).
+
+1. Put full failure context in the assistant message above the prompt. Keep AskQuestion prompt brief and action-oriented (for example, “Push failed on branch `foo`; choose next step.”).
+2. Keep options to about **3** when possible, **safe-first**:
+   - **Abort** — stop without further writes.
+   - **Change plan** — switch approach (for example create/switch branch, choose a different target, or refine in chat per **§5**).
+   - **Proceed / Retry** — retry same path; if risky (for example force-like behavior), name the risk in the label/prompt.
+3. Do not hide risky actions behind generic “Proceed.” If an option can rewrite shared history or bypass protection, call that out explicitly and rely on **`internal-write-plan-skill-safety`** triggers.
+4. Keep one refinement outlet only (either **`additionalSuggestion`** or one trailing chat line), consistent with **§5**.

--- a/.agents/skills/internal-write-plan/SKILL.md
+++ b/.agents/skills/internal-write-plan/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: internal-write-plan
+description: >-
+  Cross-cutting safety and structured Q&A libraries used by planning, git, and GitHub workflows.
+---
+
+# `skills/write/plan/`
+
+Shared prompt-safety write libraries.
+
+- `structured-qa` defines confirmation and option-prompt UX.
+- `skill-safety` defines when confirmation is mandatory before mutating actions.
+
+These libraries are not public workflow entrypoints; they are consumed by public skills.
+
+- For plan-driven gh workflows, these libraries also govern final keep/delete prompts for temporary `.cursor/gh/issues/` and `.cursor/gh/pr/` artifacts.

--- a/.agents/skills/internal-write-plan/skill-safety/SKILL.md
+++ b/.agents/skills/internal-write-plan/skill-safety/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: internal-write-plan-skill-safety
+description: >-
+  Read-only: which operations need summary → confirm → act (push, commit, deletes, reset/clean, bulk/structural
+  creates, writes outside repo root, system-wide toolchain changes when the agent would perform them); §1e triage for
+  writes vs lightweight reads. Does NOT replace parent skills—layers on structured-qa for prompt UX.
+---
+
+# Internal: Skill safety (irreversible and high-impact actions)
+
+**Read-only policy.** Skills that perform **irreversible** or **high-impact** work must **summarize impact**, then **obtain explicit user confirmation**, then **act**. Confirmation UX follows **[`internal-write-plan-structured-qa`](../structured-qa/SKILL.md)** **§1a**, **§1b**, **§1c**, **§1e**, **§2**, **§3–§3a**, **§5**, **§8** (compact summary / **plan preview** before Q&A, **Cursor** **AskQuestion** for finite choices, **one** freeform reminder when needed—**no** redundant **Other** + duplicate chat invite; default **abort** on ambiguity; failure triage uses safe-first ~3-option choices).
+
+**Does not** replace parent skill steps (e.g. **`@git-reset`** **Proceed** before **`git reset --hard`**)—this library defines **what** to confirm and **how** to frame it.
+
+**Global gate** — **Any online mutation** (anything that **changes** remote GitHub state: **`gh issue`/`gh pr`/`gh api`** writes, **`git push`**, and equivalent) and **any write to paths outside the current git workspace root** (or outside an explicit user allowlist) require **Goal + structured confirm** (**AskQuestion** or equivalent per **`internal-write-plan-structured-qa`**) **before** the agent runs them. **Read-only** inventory (**`internal-read-gh-issue-list`**, **`internal-read-gh-pr-list`**, **`internal-read-gh-repo-stream`**, **`internal-write-gh-issue-commands`** **View** section when used for single-issue read-only, …) does **not** replace that gate for follow-on writes—the **mutation skill** owns **Proceed**.
+**Master-confirm override rule** — **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** flags can suppress low-risk prompt repetition, but they **never** bypass the session-level master confirm for online mutations, destructive local operations, or writes outside repo root.
+
+- **Write triage shape** — **Online writes** and **writes outside the repo root** use **[`internal-write-plan-structured-qa`](../structured-qa/SKILL.md)** **§1e** (**Abort** / **Review** / **Proceed**) before the first mutating command when the user may need to refine targets without a binary **No**/**Yes** only.
+- **Reads stay lightweight** — **Read-only** online and outside-repo passes do **not** use that stacked triage; see **§1e** read carve-out.
+
+For reusable prompt shape and labels, use [`internal-write-plan-structured-qa`](../structured-qa/SKILL.md) §1a, §1c, and §3a.
+
+## Internal libraries: read vs write cadence
+
+- **Read-only internals** — Libraries whose **normative fences** are **only** non-mutating toward GitHub and **non-destructive** toward disk by default (**`internal-read-gh-issue-list`**, **`internal-read-gh-pr-list`**, **`internal-read-gh-repo-stream`**, **`internal-read-git-merge-conflicts`** playbook, **`internal-read-gh-issue-dedupe`** checklist logic, **`internal-read-git-discover-dependencies`** when the parent forbids install/evaluate, most **`internal-read-git-doc-*`**, **`internal-read-git-git-diff-summary`** as read-only diff input, …). **Parents** that are **read-only** (e.g. **`@gh-issue-list`**, **`@gh-pr-list`**, **`@gh-issue-review`** inventory) may use them **without** an extra confirmation **unless** the parent skill itself needs **AskQuestion** (ambiguous pick). **Never** treat a read-only pass as permission to **skip** **Proceed** on a later **`gh`** write, **`git push`**, **commit**, **reset/clean**, **outside-repo write**, or **destructive install**—those steps keep their **Triggers** rows below.
+- **Write / mutation internals** — Libraries that own **`gh`** **mutations**, **`gh api`** writes, **`git`** history or index **mutations** via invoked commands, or **destructive** installs (**`internal-write-gh-issue-commands`**, **`internal-write-gh-pr-commands`**, **`internal-write-git-tag`** (**`git tag`** / **`git push`** tag), **`internal-write-gh-install-dependencies`** when cleans apply, …). **Always** run behind a **public** skill that performs **Goal + structured confirm** before the first mutating fence. **Extra scrutiny** when the effect is **online** or **outside this repository folder**.
+
+## `internal/gh` naming vs `git` work
+
+- All pack internals live under **`skills/read/gh/`** with path-faithful `internal-read-gh-*` / `internal-write-gh-*` names. **Split by job**, not by the word “git” in a name:
+  - **GitHub / network** — **`gh`** and GitHub **HTTP/API** shapes for issues/PRs/templates/stream (**`internal-read-gh-issue-list`**, **`internal-read-gh-pr-list`**, **`internal-write-gh-issue-commands`**, **`internal-write-gh-pr-commands`**, **`internal-read-gh-repo-forms-json`**, **`internal-read-gh-repo-stream`**, **issue/PR description** libs, …).
+  - **Local `git` / workspace shell** — **`internal-write-git-zip`**, **`internal-write-git-tag`**, **`internal-read-git-git-diff-summary`**, **`internal-read-git-merge-conflicts`**, **`internal-write-git-working-tree-align`**: **local terminal** playbooks and **`git`** usage **without** substituting **`@gh-*`**. **Public** **`@git-*`** skills under **`skills/git/`** own user intent for push/pull/reset/zip/tag; they consume these locals plus **discover / install / configuration / evaluate** for **toolchain** work on disk.
+
+---
+
+## Pattern
+
+1. **Summarize** — In chat: counts, branch/remotes, `git status --short`, `git diff --stat` (or staged stat), representative paths (cap long lists with “+N more”), dry-run output when available—combined with a **Goal** line into one **brief but detailed** preamble per **[`internal-write-plan-structured-qa`](../structured-qa/SKILL.md)** **§1a**. When **§1c** applies (large change set, outside-repo writes, many new doc paths), the preamble must include an explicit **plan** (what will run, file count, top paths).
+2. **Goal + confirm** — Then **AskQuestion** (or equivalent) with **very short** labels (**No**/**Yes** or **Abort**/**Proceed**, etc.) per **§2**; **at most one** brief chat reminder after the buttons per **§5** when the flow is not using the **§1b** “omit reminder” carve-out. Do **not** treat free-form chat as the **only** confirmation when the choice set is finite. One confirm may cover **commit + push** when both happen in the same flow; **merge** **§1c** with **§3a** into **one** round when both apply.
+3. **Act** — Only after explicit **Yes** / **Proceed** (or equivalent) from that structured step, or after the user’s **alternative** instruction in **chat** (re-summarize if scope changed).
+
+---
+
+## Structured confirm (authoring)
+
+**Structured confirm** — Shorthand for child **`SKILL.md`** files: meet the relevant **Triggers** row (what the summary must include; confirm **Yes** where required) **and** apply **[`internal-write-plan-structured-qa`](../structured-qa/SKILL.md)** **§1c** (when bulk/large) + **§3a** / **§1e** (offline-outside-repo + online writes) for **Goal** + **AskQuestion** shape—**merge** into **one** round when both apply. Link **this file** at least once per skill or per major section; in the same section you may then write **structured confirm** instead of repeating both library names.
+
+---
+
+## Triggers (minimum)
+
+| Trigger | Summary must include | Confirm |
+| --- | --- | --- |
+| **`git push`** / first upstream publish / **`git push origin <tag>`** | Branch or **tag** name, **`origin`** URL when pushing tags, remote intent, stat for what will be committed if the tree is not clean | Yes, before **commit** (if any) and **push** |
+| **`git push --force-with-lease`** (or equivalent force-like push) | Branch, remote, why non-force push failed, explicit risk to remote history/teammates, and safer alternatives considered | Yes — separate explicit confirm from normal push confirm; default **Abort** on ambiguity |
+| **`gh issue delete`** (bulk closed cleanup) | Count + preview table of ids/titles; irreversible on GitHub | Yes, before **each** delete wave (**`@gh-issue-delete-closed`**) |
+| **`gh project delete`** (bulk closed cleanup) | Owner scope + preview table of numbers/titles; irreversible on GitHub | Yes, before **each** delete wave (**`@gh-project-delete-closed`**) |
+| **`git commit`** (when the skill runs it) | Same stat / one-line message intent | Yes (may share one confirm with push) |
+| **`gh pr create`** | Target repo, **base** / **head**, one-line intent (“open a new PR with this title/body”) | Yes, before **`gh pr create`** |
+| **`gh pr edit`** | PR number, summary of title/body replacement (“replace remote PR description”) | Yes, before **`gh pr edit`** |
+| **`gh pr close`** | PR number, repo (`--repo` when applicable), one-line intent (“close PR #*N*”) | Yes, before **`gh pr close`** |
+| **`gh label create`** | Label name(s), color, short description intent | Yes, before **`gh label create`** (may be **separate** from **`gh issue create`** confirm when risks would blur) |
+| **Delete** paths (tracked or untracked) | Count + representative paths | Yes |
+| **`git reset --hard`**, **`git clean`**, destructive install cleans | Dry-run or impact list where applicable | Yes |
+| **Bulk / structural file creation** (many new paths from a plan) | Count + top paths / move map | Yes |
+| **Many new `README.md` / doc hub pages in one change set** | Count + categories + top paths | Yes — **§1c** plan preview + **No**/**Yes**; fold `.gitkeep` into the same summary (no separate modal) |
+| **Writes outside git workspace root** (or outside an explicit user allowlist) | Paths named; **Goal** (“touch paths outside repo”) | Yes — **§1c** + **§1e** before any write (**Abort** / **Review** / **Proceed**) |
+| **Large change set** (see below) | **§1c** plan embedded in preamble: file count + `git diff --stat` excerpt + top paths | Yes — use **§1c**; **merge** with **commit/push** confirm into **one** **No**/**Yes** when both apply |
+
+**Online mutation rows** — Rows whose triggers change GitHub or **`origin`** (**`git push`**, **`gh pr create`/`edit`/`close`**, **`gh issue`** mutations, **`gh project delete`**, **`gh label create`**, …) use the same **§1e** triage shape when a **Review** beat is needed—not limited to binary **No**/**Yes** when the user must refine targets or copy before mutating.
+
+**Large change set (defaults)** — Treat as **large** when **either**: (a) **≥10 files** changed (staged + unstaged intended for the operation), or (b) **≥500 lines** net change from `git diff --stat`. Parent skills may tighten or relax with user consent.
+
+### Exception: **`@git-pull`** merge commits
+
+Merge commits from **`@git-pull`**—including **`git merge`** when it completes without conflict and **`git commit`** after conflict resolution—**do not** need a separate **AskQuestion** before each commit. The user already invoked **`@git-pull`** to bring **`@{u}`** and **`ROOT_BRANCH`** into the current branch; that intent covers finishing the merge.
+
+If **`git status`** shows **unexpected** state before merging (e.g. unrelated uncommitted changes the user did not imply), **stop** and clarify in **chat** per **[`internal-write-plan-structured-qa`](../structured-qa/SKILL.md)** **§4**; default **abort** on ambiguity. Publishing remains **`@git-push`** (with its own confirm).
+
+### Exception: ephemeral scratch paths in **`@git-push`**
+
+Removing **only** directories or files the agent **created in the same `@git-push` run** as throwaway output (e.g. a random temp path never staged) so they are **not** committed **does not** require a separate **AskQuestion**—outside the **Delete** row’s normal confirm. **Do not** use this for tracked paths, user-owned dirs, or anything beyond that narrow case.
+
+---
+
+## Scope for new files (“create”)
+
+- **No** extra confirm for routine **single-file** edits the user clearly asked for.
+- **Yes** confirm for **bulk** or **structural** adds—e.g. **many** new **`docs/`** or mirror **`README.md`** paths in one change set, **`@git-docs`** when touching **many** **existing** doc paths in one run (**§1c**), plan-driven edits that add **many** new paths or reshape trees.
+
+---
+
+## Cross-skill Q&A (quick map)
+
+| Situation | Skill / library |
+| --- | --- |
+| User-driven **many** new doc / mirror paths | **Large create** — **AskQuestion** + **No**/**Yes** before bulk writes (**`internal-write-plan-skill-safety`**) |
+| User-driven doc sync (many **existing** files) | **`@git-docs`** — **AskQuestion** for mode; **No**/**Yes** before bulk in-place writes (**§1c**) |
+| Verify + **§8a** doc polish | **`@git-review`** — runs **`internal-write-gh-documentation`** after green evaluate |
+| Commit + push | **`@git-push`** — structured confirm for large change sets (**§3a**) |
+| `gh pr create` / `gh pr edit` | **`@gh-pr`** §9 — confirm before mutation; **`internal-read-gh-pr-description`** for **multiple** PR templates **or** **material template reshape** (keep / blend / pack) — **separate** from that **§9** PR mutation confirm when risks would blur |
+| `gh issue create` / `gh issue edit` / `gh issue close` / `gh issue delete` | **`@gh-issues`**, **`@gh-issue-close`**, **`@gh-issue-delete-closed`** — confirm before mutation; **`internal-read-gh-issue-description`** for **multiple** issue templates **or** **material reshape** — **separate** from final **`gh`** confirm when needed |
+| `gh project delete` | **`@gh-project-delete-closed`** — confirm before mutation; preview owner scope + closed set before each delete wave |
+| **`gh label create`** (issue label decoration) | **`@gh-issues`** after **`internal-read-gh-issue-labels`** — confirm before **`gh label create`**; then include label flags in the chosen issue mutation path |
+| Delivery from issue anchor (`#n` / URL) with branch + PR delegation | **`@gh-issue-view`** then **`@git-start`** — read full issue extract via **`internal-write-gh-issue-commands`** view when needed, present TODO plan + checkpoints, then **Goal + AskQuestion + Proceed** before mutating downstream flows (**`@git-start`**, implementation writes, **`@gh-pr`**) |
+| **`gh pr close`** | **`@gh-pr-close`** — **Goal** + **AskQuestion** + **Proceed** before **`gh pr close`** |
+
+---
+
+## Do
+
+- Apply this policy whenever a trigger row applies; link **`internal-write-plan-structured-qa`** for how to ask.
+- Keep confirms **one phase per major risk**—do not merge unrelated risks into a single “yes” (see structured-qa §3).
+
+## Do not
+
+- Skip summary or confirmation for rows in the table above.
+- Treat ambiguous replies as consent—default **abort** unless the parent skill states otherwise.
+
+---
+
+## See also
+
+- **[`internal-write-plan-structured-qa`](../structured-qa/SKILL.md)** — Prompt UX (AskQuestion, ordering, escape hatches).
+
+### Optional cleanup for ephemeral `.cursor/gh` staging
+
+When a run created disposable staging paths under `.cursor/gh/issues/` or `.cursor/gh/pr/`, offer a final **AskQuestion** to keep or delete those paths. Default to **keep** on ambiguity.

--- a/.agents/skills/internal-write-plan/structured-qa/SKILL.md
+++ b/.agents/skills/internal-write-plan/structured-qa/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: internal-write-plan-structured-qa
+description: >-
+  Read-only: AskQuestion vs chat, short labels, ordering, one freeform outlet; §1e Abort/Review/Proceed for offline
+  outside-repo + online writes. Pairs with internal-write-plan-skill-safety (which ops need confirm). Does not replace
+  parent skill content.
+---
+
+# Internal: Structured Q&A
+
+**Read-only policy library.** Skills that **ask**, **confirm**, or offer **finite choices** in Cursor apply **§1–§8** here (**§1** includes **§1e** triage). **Write libraries** (`skills/write/<domain>/**`): the **caller** (usually a public **`@git-*` / `@gh-*`** skill) must **merge every planned mutation** into one **summary**, then run **AskQuestion** (or equivalent) with **Proceed** before any fence in a **`write/`** library—**never** “chat yes” alone.
+
+**Pairing:** **`internal-write-plan-skill-safety`** names **which** actions need summary → confirm; **this file** is **how** to prompt (**§3a** for those triggers; **§1e** for **Abort** / **Review** / **Proceed** on offline-outside-repo and online writes).
+**Master-confirm override rule:** **`SKIP_QA_*`** and **`SKIP_QA_WRITE`** may skip repetitive low-risk prompts, but they never waive session-level master confirm for online mutations, destructive actions, or writes outside repo root.
+
+## Do not
+
+- Replace **`internal-write-plan-skill-safety`** wholesale.
+
+---
+
+## 1. Finite choices — structured UI first
+
+- Use **AskQuestion** (or equivalent) for small known outcome sets; **gather facts** (names, dry-run) **before** options.
+
+### 1a. Order: summary → question → options → one chat line
+
+1. **Summary** — Goal line + tight facts (`git status --short`, `git diff --stat`, counts, top paths, commit intent—whatever parent requires). **Detail lives here**; labels stay tiny.
+2. **Question** — one sentence (“Proceed with …?”).
+3. **Structured options** — real finite set only; no fake **Other…** if §5 chat line covers escape (**§5**).
+4. **One** trailing chat invite max (**§5**).
+
+### 1b. Minimal binary (low-risk doc apply)
+
+Short summary (~5 bullets) → one-line question → **No**/**Yes** (**No** first) → optional trailing line (omit when noisy; **keep** for §3a triggers).
+
+### 1c. Plan preview (bulk / non-trivial writes)
+
+Plan + file count + paths → “Proceed?” → **No**/**Yes** (**No** first). **Yes** = execute as summarized. **Large** commit+push: **one** combined **No**/**Yes** with **`internal-write-plan-skill-safety`**—do not stack duplicate modals for the same phase.
+
+### 1d. Pre-write and mutation prompts (brief question, summary above)
+
+For prompt gates that immediately decide a write path (for example, choose edit/create before drafting, or confirm a final GitHub mutation):
+
+1. Put the **full actionable summary** in the assistant message immediately before AskQuestion (goal, target, key facts, what happens on Proceed).
+2. Keep the **AskQuestion prompt text short** (one sentence; identifiers and action only). Do not paste full PR/issue bodies, long diffs, or large markdown blocks in the prompt itself.
+3. Use safe-first options: **Abort** first, then one or more **Proceed** options that map to exact actions.
+4. Offer exactly one refinement outlet per **§5** (either **`additionalSuggestion`** or one trailing chat line, not both).
+5. If multiple **Proceed** options exist, keep labels short and specific (for example, “Proceed — edit #n”, “Proceed — create new”).
+
+**`@gh-issues` multi-issue batch:** When several themes ship in one invocation, put a compact **table** in the pre-prompt summary (theme → **edit #n** or **create** → body file path if any). Offer **Abort** (safe-first), optional **Defer** / narrow options if the parent skill allows, then **Proceed — batch** whose summary already lists **every** `gh issue create` / `gh issue edit` in execution order. **One** Proceed confirms the **whole** batch. If the user prefers smaller steps, stop after partial execution and route remaining themes to a **follow-up `@gh-issues`** (new summary + Proceed).
+
+This pattern complements **§3a** and is commonly used in **`@gh-pr`** intent and mutation confirms.
+
+**`@gh-issues` pre-dedupe gate:** after each issue-draft refinement summary, use **Sharpen / Abort / Ship** (finite labels, **§5**) before inventory/dedupe; orchestration lives in **[`internal-read-gh-issue-preflight-qa`](../../read/gh/issue-preflight-qa/SKILL.md)**.
+
+### 1e. Pre-write triage — offline outside repo + online mutations
+
+When **`internal-write-plan-skill-safety`** applies to **writes outside the git workspace root** or **online mutations** (remote GitHub changes, **`git push`**, durable **`gh`** writes, tag push to **`origin`**, …):
+
+1. **Summary first** — **Goal** + targets + counts per **§1a**; use **§1c** when bulk/large or many paths.
+2. **AskQuestion** (safe-first order when labels are ordered): **Abort** / **Review** / **Proceed**.
+   - **Abort** — stop; no mutating fence.
+   - **Review** — pause to restate targets, paths, or intent in chat; adjust destination/repo/title/body **without** running **`gh`**, **`git push`**, **`git archive`**, or other mutating blocks yet. Then re-summarize and ask again.
+   - **Proceed** — execute **exactly** what was summarized.
+
+This tri-modal gate is for **writes only**. **Read-only** work (**`gh` list/view/search** when non-mutating, **`internal-read-gh-repo-stream`**, reading paths outside the workspace for **inspection**) stays **straightforward**: optional tight **§1a** preamble, then run the read **without** stacking **Abort / Review / Proceed**. Use **AskQuestion** on reads only for **finite disambiguation** (for example which issue id), not as mandatory safety triage.
+
+**Relation to §8:** **Review** overlaps **Change plan** in failure/plan-change triage—prefer the same short labels across flows.
+
+---
+
+## 2. Option design
+
+- **Very short labels** — **No**/**Yes**, **Abort**/**Proceed**, or verb+object; optional ~80-char template hint.
+- **~2–12** options; larger sets → narrow first.
+- **Never** paragraphs inside option text.
+
+---
+
+## 3. Destructive / binary flows
+
+- Opposing actions clear; **impact before confirm** (`git status`, dry-run, counts).
+- **Default-safe:** ambiguous → abort unless parent says otherwise.
+- **One confirm per major risk**—do not merge unrelated risks into one **Yes**.
+
+### 3a. Goal-first (safety triggers)
+
+For ops flagged in **`internal-write-plan-skill-safety`** (commit, push, reset/clean, destructive installs, **`gh`** PR/issue mutations, bulk deletes, writes outside repo, …):
+
+1. **Preamble** — **Goal** (one line) + compact facts (**§1a**).
+2. **Question** — one short sentence (e.g. “Proceed with commit and push?”).
+3. **AskQuestion** — **No**/**Yes** or **Abort**/**Proceed**; safe option first when order matters.
+4. **One** chat reminder after buttons (**§5**); skip if redundant with **`additionalSuggestion`**.
+
+The modal prompt may repeat only minimal identifiers (branch/tag/target), while the detailed summary remains in the message above.
+
+Remote irreversible (**push**, durable **`gh`** writes) and local destructive (**reset/clean**, wipes) share this pattern.
+
+---
+
+## 4. Open-ended
+
+Chat prompt; one question + inline examples; re-ask with constraint on validation failure (e.g. branch name).
+
+---
+
+## 5. Freeform — no duplicate outlets
+
+- **Safest option first** when UI order matters.
+- **Escape** = real negative options (**No**/**Abort**)—not **Other…** **and** “or type in chat” **and** **`additionalSuggestion`** same turn.
+- **One** freeform outlet: either **one** post-button chat line **or** JSON **`additionalSuggestion`**—not both as duplicate “type something else” paths.
+- **`allow_multiple: true`** only when truly needed (rare).
+
+---
+
+## 6. Tool naming
+
+Describe capability (“structured multiple-choice”) vs hard-coding a single IDE control name.
+
+---
+
+## 7. Consumers (index)
+
+**Any** skill with **AskQuestion** / destructive **Proceed**: **`@git-push`**, **`@git-main`**, **`@git-reset`**, **`@git-start`**, **`@git-review`** (install prepare), **`@git-docs`**, **`@git-zip`**, **`@gh-pr`**, **`@gh-pr-close`**, **`@gh-issues`**, **`@gh-issue-close`**, **`@gh-issue-delete-closed`**, **`@gh-project-delete-closed`**, **`@gh-issue-pick`**, **`@gh-issue-review`** (scope only), **`internal-read-gh-pr-description`** (multi-template / material reshape), **large** doc edits (**`internal-write-plan-skill-safety`** **confirm-first**).
+
+**Internal:** **`internal-write-plan-skill-safety`** — trigger list vs **§3a** / **§1e** here.
+
+---
+
+## 8. Failure / plan-change triage
+
+Use this pattern when a mutating step fails (for example **`git push`**, **`gh`** mutation), or when a new fact changes the plan (for example wrong branch, missing remote, protected/default-branch restrictions).
+
+1. Put full failure context in the assistant message above the prompt. Keep AskQuestion prompt brief and action-oriented (for example, “Push failed on branch `foo`; choose next step.”).
+2. Keep options to about **3** when possible, **safe-first**:
+   - **Abort** — stop without further writes.
+   - **Change plan** — switch approach (for example create/switch branch, choose a different target, or refine in chat per **§5**).
+   - **Proceed / Retry** — retry same path; if risky (for example force-like behavior), name the risk in the label/prompt.
+3. Do not hide risky actions behind generic “Proceed.” If an option can rewrite shared history or bypass protection, call that out explicitly and rely on **`internal-write-plan-skill-safety`** triggers.
+4. Keep one refinement outlet only (either **`additionalSuggestion`** or one trailing chat line), consistent with **§5**.

--- a/.agents/skills/m01-ownership/SKILL.md
+++ b/.agents/skills/m01-ownership/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: m01-ownership
+description: "CRITICAL: Use for ownership/borrow/lifetime issues. Triggers: E0382, E0597, E0506, E0507, E0515, E0716, E0106, value moved, borrowed value does not live long enough, cannot move out of, use of moved value, ownership, borrow, lifetime, 'a, 'static, move, clone, Copy, 所有权, 借用, 生命周期"
+user-invocable: false
+---
+
+# Ownership & Lifetimes
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**Who should own this data, and for how long?**
+
+Before fixing ownership errors, understand the data's role:
+- Is it shared or exclusive?
+- Is it short-lived or long-lived?
+- Is it transformed or just read?
+
+---
+
+## Error → Design Question
+
+| Error | Don't Just Say | Ask Instead |
+|-------|----------------|-------------|
+| E0382 | "Clone it" | Who should own this data? |
+| E0597 | "Extend lifetime" | Is the scope boundary correct? |
+| E0506 | "End borrow first" | Should mutation happen elsewhere? |
+| E0507 | "Clone before move" | Why are we moving from a reference? |
+| E0515 | "Return owned" | Should caller own the data? |
+| E0716 | "Bind to variable" | Why is this temporary? |
+| E0106 | "Add 'a" | What is the actual lifetime relationship? |
+
+---
+
+## Thinking Prompt
+
+Before fixing an ownership error, ask:
+
+1. **What is this data's domain role?**
+   - Entity (unique identity) → owned
+   - Value Object (interchangeable) → clone/copy OK
+   - Temporary (computation result) → maybe restructure
+
+2. **Is the ownership design intentional?**
+   - By design → work within constraints
+   - Accidental → consider redesign
+
+3. **Fix symptom or redesign?**
+   - If Strike 3 (3rd attempt) → escalate to Layer 2
+
+---
+
+## Trace Up ↑
+
+When errors persist, trace to design layer:
+
+```
+E0382 (moved value)
+    ↑ Ask: What design choice led to this ownership pattern?
+    ↑ Check: m09-domain (is this Entity or Value Object?)
+    ↑ Check: domain-* (what constraints apply?)
+```
+
+| Persistent Error | Trace To | Question |
+|-----------------|----------|----------|
+| E0382 repeated | m02-resource | Should use Arc/Rc for sharing? |
+| E0597 repeated | m09-domain | Is scope boundary at right place? |
+| E0506/E0507 | m03-mutability | Should use interior mutability? |
+
+---
+
+## Trace Down ↓
+
+From design decisions to implementation:
+
+```
+"Data needs to be shared immutably"
+    ↓ Use: Arc<T> (multi-thread) or Rc<T> (single-thread)
+
+"Data needs exclusive ownership"
+    ↓ Use: move semantics, take ownership
+
+"Data is read-only view"
+    ↓ Use: &T (immutable borrow)
+```
+
+---
+
+## Quick Reference
+
+| Pattern | Ownership | Cost | Use When |
+|---------|-----------|------|----------|
+| Move | Transfer | Zero | Caller doesn't need data |
+| `&T` | Borrow | Zero | Read-only access |
+| `&mut T` | Exclusive borrow | Zero | Need to modify |
+| `clone()` | Duplicate | Alloc + copy | Actually need a copy |
+| `Rc<T>` | Shared (single) | Ref count | Single-thread sharing |
+| `Arc<T>` | Shared (multi) | Atomic ref count | Multi-thread sharing |
+| `Cow<T>` | Clone-on-write | Alloc if mutated | Might modify |
+
+## Error Code Reference
+
+| Error | Cause | Quick Fix |
+|-------|-------|-----------|
+| E0382 | Value moved | Clone, reference, or redesign ownership |
+| E0597 | Reference outlives owner | Extend owner scope or restructure |
+| E0506 | Assign while borrowed | End borrow before mutation |
+| E0507 | Move out of borrowed | Clone or use reference |
+| E0515 | Return local reference | Return owned value |
+| E0716 | Temporary dropped | Bind to variable |
+| E0106 | Missing lifetime | Add `'a` annotation |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| `.clone()` everywhere | Hides design issues | Design ownership properly |
+| Fight borrow checker | Increases complexity | Work with the compiler |
+| `'static` for everything | Restricts flexibility | Use appropriate lifetimes |
+| Leak with `Box::leak` | Memory leak | Proper lifetime design |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Need smart pointers | m02-resource |
+| Need interior mutability | m03-mutability |
+| Data is domain entity | m09-domain |
+| Learning ownership concepts | m14-mental-model |

--- a/.agents/skills/m01-ownership/comparison.md
+++ b/.agents/skills/m01-ownership/comparison.md
@@ -1,0 +1,222 @@
+# Ownership: Comparison with Other Languages
+
+## Rust vs C++
+
+### Memory Management
+
+| Aspect | Rust | C++ |
+|--------|------|-----|
+| Default | Move semantics | Copy semantics (pre-C++11) |
+| Move | `let b = a;` (a invalidated) | `auto b = std::move(a);` (a valid but unspecified) |
+| Copy | `let b = a.clone();` | `auto b = a;` |
+| Safety | Compile-time enforcement | Runtime responsibility |
+
+### Rust Move vs C++ Move
+
+```rust
+// Rust: after move, 'a' is INVALID
+let a = String::from("hello");
+let b = a;  // a moved
+// println!("{}", a);  // COMPILE ERROR
+
+// Equivalent in C++:
+// std::string a = "hello";
+// std::string b = std::move(a);
+// std::cout << a;  // UNDEFINED (compiles but buggy)
+```
+
+### Smart Pointers
+
+| Rust | C++ | Purpose |
+|------|-----|---------|
+| `Box<T>` | `std::unique_ptr<T>` | Unique ownership |
+| `Rc<T>` | `std::shared_ptr<T>` | Shared ownership |
+| `Arc<T>` | `std::shared_ptr<T>` + atomic | Thread-safe shared |
+| `RefCell<T>` | (manual runtime checks) | Interior mutability |
+
+---
+
+## Rust vs Go
+
+### Memory Model
+
+| Aspect | Rust | Go |
+|--------|------|-----|
+| Memory | Stack + heap, explicit | GC manages all |
+| Ownership | Enforced at compile-time | None (GC handles) |
+| Null | `Option<T>` | `nil` for pointers |
+| Concurrency | `Send`/`Sync` traits | Channels (less strict) |
+
+### Sharing Data
+
+```rust
+// Rust: explicit about sharing
+use std::sync::Arc;
+let data = Arc::new(vec![1, 2, 3]);
+let data_clone = Arc::clone(&data);
+std::thread::spawn(move || {
+    println!("{:?}", data_clone);
+});
+
+// Go: implicit sharing
+// data := []int{1, 2, 3}
+// go func() {
+//     fmt.Println(data)  // potential race condition
+// }()
+```
+
+### Why No GC in Rust
+
+1. **Deterministic destruction**: Resources freed exactly when scope ends
+2. **Zero-cost**: No GC pauses or overhead
+3. **Embeddable**: Works in OS kernels, embedded systems
+4. **Predictable latency**: Critical for real-time systems
+
+---
+
+## Rust vs Java/C#
+
+### Reference Semantics
+
+| Aspect | Rust | Java/C# |
+|--------|------|---------|
+| Objects | Owned by default | Reference by default |
+| Null | `Option<T>` | `null` (nullable) |
+| Immutability | Default | Must use `final`/`readonly` |
+| Copy | Explicit `.clone()` | Reference copy (shallow) |
+
+### Comparison
+
+```rust
+// Rust: clear ownership
+fn process(data: Vec<i32>) {  // takes ownership
+    // data is ours, will be freed at end
+}
+
+let numbers = vec![1, 2, 3];
+process(numbers);
+// numbers is invalid here
+
+// Java: ambiguous ownership
+// void process(List<Integer> data) {
+//     // Who owns data? Caller? Callee? Both?
+//     // Can caller still use it?
+// }
+```
+
+---
+
+## Rust vs Python
+
+### Memory Model
+
+| Aspect | Rust | Python |
+|--------|------|--------|
+| Typing | Static, compile-time | Dynamic, runtime |
+| Memory | Ownership-based | Reference counting + GC |
+| Mutability | Default immutable | Default mutable |
+| Performance | Native, zero-cost | Interpreted, higher overhead |
+
+### Common Pattern Translation
+
+```rust
+// Rust: borrowing iteration
+let items = vec!["a", "b", "c"];
+for item in &items {
+    println!("{}", item);
+}
+// items still usable
+
+// Python: iteration doesn't consume
+// items = ["a", "b", "c"]
+// for item in items:
+//     print(item)
+// items still usable (different reason - ref counting)
+```
+
+---
+
+## Unique Rust Concepts
+
+### Concepts Other Languages Lack
+
+1. **Borrow Checker**: No other mainstream language has compile-time borrow checking
+2. **Lifetimes**: Explicit annotation of reference validity
+3. **Move by Default**: Values move, not copy
+4. **No Null**: `Option<T>` instead of null pointers
+5. **Affine Types**: Values can be used at most once
+
+### Learning Curve Areas
+
+| Concept | Coming From | Key Insight |
+|---------|-------------|-------------|
+| Ownership | GC languages | Think about who "owns" data |
+| Borrowing | C/C++ | Like references but checked |
+| Lifetimes | Any | Explicit scope of validity |
+| Move | C++ | Move is default, not copy |
+
+---
+
+## Mental Model Shifts
+
+### From GC Languages (Java, Go, Python)
+
+```
+Before: "Memory just works, GC handles it"
+After:  "I explicitly decide who owns data and when it's freed"
+```
+
+Key shifts:
+- Think about ownership at design time
+- Returning references requires lifetime thinking
+- No more `null` - use `Option<T>`
+
+### From C/C++
+
+```
+Before: "I manually manage memory and hope I get it right"
+After:  "Compiler enforces correctness, I fight the borrow checker"
+```
+
+Key shifts:
+- Trust the compiler's errors
+- Move is the default (unlike C++ copy)
+- Smart pointers are idiomatic, not overhead
+
+### From Functional Languages (Haskell, ML)
+
+```
+Before: "Everything is immutable, copying is fine"
+After:  "Mutability is explicit, ownership prevents aliasing"
+```
+
+Key shifts:
+- Mutability is safe because of ownership rules
+- No persistent data structures needed (usually)
+- Performance characteristics are explicit
+
+---
+
+## Performance Trade-offs
+
+| Language | Memory Overhead | Latency | Throughput |
+|----------|-----------------|---------|------------|
+| Rust | Minimal (no GC) | Predictable | Excellent |
+| C++ | Minimal | Predictable | Excellent |
+| Go | GC overhead | GC pauses | Good |
+| Java | GC overhead | GC pauses | Good |
+| Python | High (ref counting + GC) | Variable | Lower |
+
+### When Rust Ownership Wins
+
+1. **Real-time systems**: No GC pauses
+2. **Embedded**: No runtime overhead
+3. **High-performance**: Zero-cost abstractions
+4. **Concurrent**: Data races prevented at compile time
+
+### When GC Might Be Preferable
+
+1. **Rapid prototyping**: Less mental overhead
+2. **Complex object graphs**: Cycles are tricky in Rust
+3. **GUI applications**: Object lifetimes are dynamic
+4. **Small programs**: Overhead doesn't matter

--- a/.agents/skills/m01-ownership/examples/best-practices.md
+++ b/.agents/skills/m01-ownership/examples/best-practices.md
@@ -1,0 +1,339 @@
+# Ownership Best Practices
+
+## API Design Patterns
+
+### 1. Prefer Borrowing Over Ownership
+
+```rust
+// BAD: takes ownership unnecessarily
+fn print_name(name: String) {
+    println!("Name: {}", name);
+}
+
+// GOOD: borrows instead
+fn print_name(name: &str) {
+    println!("Name: {}", name);
+}
+
+// Caller benefits:
+let name = String::from("Alice");
+print_name(&name);  // can reuse name
+print_name(&name);  // still valid
+```
+
+### 2. Return Owned Values from Constructors
+
+```rust
+// GOOD: return owned value
+impl User {
+    fn new(name: &str) -> Self {
+        User {
+            name: name.to_string(),
+        }
+    }
+}
+
+// GOOD: accept Into<String> for flexibility
+impl User {
+    fn new(name: impl Into<String>) -> Self {
+        User {
+            name: name.into(),
+        }
+    }
+}
+
+// Usage:
+let u1 = User::new("Alice");        // &str
+let u2 = User::new(String::from("Bob"));  // String
+```
+
+### 3. Use AsRef for Generic Borrowing
+
+```rust
+// GOOD: accepts both &str and String
+fn process<S: AsRef<str>>(input: S) {
+    let s = input.as_ref();
+    println!("{}", s);
+}
+
+process("literal");           // &str
+process(String::from("owned")); // String
+process(&String::from("ref")); // &String
+```
+
+### 4. Cow for Clone-on-Write
+
+```rust
+use std::borrow::Cow;
+
+// Return borrowed when possible, owned when needed
+fn maybe_modify(s: &str, uppercase: bool) -> Cow<'_, str> {
+    if uppercase {
+        Cow::Owned(s.to_uppercase())  // allocates
+    } else {
+        Cow::Borrowed(s)  // zero-cost
+    }
+}
+
+let input = "hello";
+let result = maybe_modify(input, false);
+// result is borrowed, no allocation
+```
+
+---
+
+## Struct Design Patterns
+
+### 1. Owned Fields vs References
+
+```rust
+// Use owned fields for most cases
+struct User {
+    name: String,
+    email: String,
+}
+
+// Use references only when lifetime is clear
+struct UserView<'a> {
+    name: &'a str,
+    email: &'a str,
+}
+
+// Pattern: owned data + view for efficiency
+impl User {
+    fn view(&self) -> UserView<'_> {
+        UserView {
+            name: &self.name,
+            email: &self.email,
+        }
+    }
+}
+```
+
+### 2. Builder Pattern with Ownership
+
+```rust
+#[derive(Default)]
+struct RequestBuilder {
+    url: Option<String>,
+    method: Option<String>,
+    body: Option<Vec<u8>>,
+}
+
+impl RequestBuilder {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    // Take self by value for chaining
+    fn url(mut self, url: impl Into<String>) -> Self {
+        self.url = Some(url.into());
+        self
+    }
+
+    fn method(mut self, method: impl Into<String>) -> Self {
+        self.method = Some(method.into());
+        self
+    }
+
+    fn build(self) -> Result<Request, Error> {
+        Ok(Request {
+            url: self.url.ok_or(Error::MissingUrl)?,
+            method: self.method.unwrap_or_else(|| "GET".to_string()),
+            body: self.body.unwrap_or_default(),
+        })
+    }
+}
+
+// Usage:
+let req = RequestBuilder::new()
+    .url("https://example.com")
+    .method("POST")
+    .build()?;
+```
+
+### 3. Interior Mutability When Needed
+
+```rust
+use std::cell::RefCell;
+use std::rc::Rc;
+
+// Shared mutable state in single-threaded context
+struct Counter {
+    value: Rc<RefCell<u32>>,
+}
+
+impl Counter {
+    fn new() -> Self {
+        Counter {
+            value: Rc::new(RefCell::new(0)),
+        }
+    }
+
+    fn increment(&self) {
+        *self.value.borrow_mut() += 1;
+    }
+
+    fn get(&self) -> u32 {
+        *self.value.borrow()
+    }
+
+    fn clone_handle(&self) -> Self {
+        Counter {
+            value: Rc::clone(&self.value),
+        }
+    }
+}
+```
+
+---
+
+## Collection Patterns
+
+### 1. Efficient Iteration
+
+```rust
+let items = vec![1, 2, 3, 4, 5];
+
+// Iterate by reference (no move)
+for item in &items {
+    println!("{}", item);
+}
+
+// Iterate by mutable reference
+for item in &mut items.clone() {
+    *item *= 2;
+}
+
+// Consume with into_iter when done
+let sum: i32 = items.into_iter().sum();
+```
+
+### 2. Collecting Results
+
+```rust
+// Collect into owned collection
+let strings: Vec<String> = (0..5)
+    .map(|i| format!("item_{}", i))
+    .collect();
+
+// Collect references
+let refs: Vec<&str> = strings.iter().map(|s| s.as_str()).collect();
+
+// Collect with transformation
+let result: Result<Vec<i32>, _> = ["1", "2", "3"]
+    .iter()
+    .map(|s| s.parse::<i32>())
+    .collect();
+```
+
+### 3. Entry API for Maps
+
+```rust
+use std::collections::HashMap;
+
+let mut map: HashMap<String, Vec<i32>> = HashMap::new();
+
+// Efficient: don't search twice
+map.entry("key".to_string())
+   .or_insert_with(Vec::new)
+   .push(42);
+
+// With entry modification
+map.entry("key".to_string())
+   .and_modify(|v| v.push(43))
+   .or_insert_with(|| vec![43]);
+```
+
+---
+
+## Error Handling with Ownership
+
+### 1. Preserve Context in Errors
+
+```rust
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+struct ParseError {
+    input: String,  // owns the problematic input
+    message: String,
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Failed to parse '{}': {}", self.input, self.message)
+    }
+}
+
+fn parse(input: &str) -> Result<i32, ParseError> {
+    input.parse().map_err(|_| ParseError {
+        input: input.to_string(),  // clone for error context
+        message: "not a valid integer".to_string(),
+    })
+}
+```
+
+### 2. Ownership in Result Chains
+
+```rust
+fn process_data(path: &str) -> Result<ProcessedData, Error> {
+    let content = std::fs::read_to_string(path)?;  // owned String
+    let parsed = parse_content(&content)?;          // borrow
+    let processed = transform(parsed)?;             // ownership moves
+    Ok(processed)                                   // return owned
+}
+```
+
+---
+
+## Performance Considerations
+
+### 1. Avoid Unnecessary Clones
+
+```rust
+// BAD: cloning just to compare
+fn contains_item(items: &[String], target: &str) -> bool {
+    items.iter().any(|s| s.clone() == target)  // unnecessary clone
+}
+
+// GOOD: compare references
+fn contains_item(items: &[String], target: &str) -> bool {
+    items.iter().any(|s| s == target)  // String implements PartialEq<str>
+}
+```
+
+### 2. Use Slices for Flexibility
+
+```rust
+// BAD: requires Vec
+fn sum(numbers: &Vec<i32>) -> i32 {
+    numbers.iter().sum()
+}
+
+// GOOD: accepts any slice
+fn sum(numbers: &[i32]) -> i32 {
+    numbers.iter().sum()
+}
+
+// Now works with:
+sum(&vec![1, 2, 3]);     // Vec
+sum(&[1, 2, 3]);         // array
+sum(&array[1..3]);       // slice
+```
+
+### 3. In-Place Mutation
+
+```rust
+// BAD: allocates new String
+fn make_uppercase(s: &str) -> String {
+    s.to_uppercase()
+}
+
+// GOOD when you own the data: mutate in place
+fn make_uppercase(mut s: String) -> String {
+    s.make_ascii_uppercase();  // in-place for ASCII
+    s
+}
+```

--- a/.agents/skills/m01-ownership/patterns/common-errors.md
+++ b/.agents/skills/m01-ownership/patterns/common-errors.md
@@ -1,0 +1,265 @@
+# Common Ownership Errors & Fixes
+
+## E0382: Use of Moved Value
+
+### Error Pattern
+```rust
+let s = String::from("hello");
+let s2 = s;          // s moved here
+println!("{}", s);   // ERROR: value borrowed after move
+```
+
+### Fix Options
+
+**Option 1: Clone (if ownership not needed)**
+```rust
+let s = String::from("hello");
+let s2 = s.clone();  // s is cloned
+println!("{}", s);   // OK: s still valid
+```
+
+**Option 2: Borrow (if modification not needed)**
+```rust
+let s = String::from("hello");
+let s2 = &s;         // borrow, not move
+println!("{}", s);   // OK
+println!("{}", s2);  // OK
+```
+
+**Option 3: Use Rc/Arc (for shared ownership)**
+```rust
+use std::rc::Rc;
+let s = Rc::new(String::from("hello"));
+let s2 = Rc::clone(&s);  // shared ownership
+println!("{}", s);       // OK
+println!("{}", s2);      // OK
+```
+
+---
+
+## E0597: Borrowed Value Does Not Live Long Enough
+
+### Error Pattern
+```rust
+fn get_str() -> &str {
+    let s = String::from("hello");
+    &s  // ERROR: s dropped here, but reference returned
+}
+```
+
+### Fix Options
+
+**Option 1: Return owned value**
+```rust
+fn get_str() -> String {
+    String::from("hello")  // return owned value
+}
+```
+
+**Option 2: Use 'static lifetime**
+```rust
+fn get_str() -> &'static str {
+    "hello"  // string literal has 'static lifetime
+}
+```
+
+**Option 3: Accept reference parameter**
+```rust
+fn get_str<'a>(s: &'a str) -> &'a str {
+    s  // return reference with same lifetime as input
+}
+```
+
+---
+
+## E0499: Cannot Borrow as Mutable More Than Once
+
+### Error Pattern
+```rust
+let mut s = String::from("hello");
+let r1 = &mut s;
+let r2 = &mut s;  // ERROR: second mutable borrow
+println!("{}, {}", r1, r2);
+```
+
+### Fix Options
+
+**Option 1: Sequential borrows**
+```rust
+let mut s = String::from("hello");
+{
+    let r1 = &mut s;
+    r1.push_str(" world");
+}  // r1 goes out of scope
+let r2 = &mut s;  // OK: r1 no longer exists
+```
+
+**Option 2: Use RefCell for interior mutability**
+```rust
+use std::cell::RefCell;
+let s = RefCell::new(String::from("hello"));
+let mut r1 = s.borrow_mut();
+// drop r1 before borrowing again
+drop(r1);
+let mut r2 = s.borrow_mut();
+```
+
+---
+
+## E0502: Cannot Borrow as Mutable While Immutable Borrow Exists
+
+### Error Pattern
+```rust
+let mut v = vec![1, 2, 3];
+let first = &v[0];      // immutable borrow
+v.push(4);              // ERROR: mutable borrow while immutable exists
+println!("{}", first);
+```
+
+### Fix Options
+
+**Option 1: Finish using immutable borrow first**
+```rust
+let mut v = vec![1, 2, 3];
+let first = v[0];       // copy value, not borrow
+v.push(4);              // OK
+println!("{}", first);  // OK: using copied value
+```
+
+**Option 2: Clone before mutating**
+```rust
+let mut v = vec![1, 2, 3];
+let first = v[0].clone();  // if T: Clone
+v.push(4);
+println!("{}", first);
+```
+
+---
+
+## E0507: Cannot Move Out of Borrowed Content
+
+### Error Pattern
+```rust
+fn take_string(s: &String) {
+    let moved = *s;  // ERROR: cannot move out of borrowed content
+}
+```
+
+### Fix Options
+
+**Option 1: Clone**
+```rust
+fn take_string(s: &String) {
+    let cloned = s.clone();
+}
+```
+
+**Option 2: Take ownership in function signature**
+```rust
+fn take_string(s: String) {  // take ownership
+    let moved = s;
+}
+```
+
+**Option 3: Use mem::take for Option/Default types**
+```rust
+fn take_from_option(opt: &mut Option<String>) -> Option<String> {
+    std::mem::take(opt)  // replaces with None, returns owned value
+}
+```
+
+---
+
+## E0515: Return Local Reference
+
+### Error Pattern
+```rust
+fn create_string() -> &String {
+    let s = String::from("hello");
+    &s  // ERROR: cannot return reference to local variable
+}
+```
+
+### Fix Options
+
+**Option 1: Return owned value**
+```rust
+fn create_string() -> String {
+    String::from("hello")
+}
+```
+
+**Option 2: Use static/const**
+```rust
+fn get_static_str() -> &'static str {
+    "hello"
+}
+```
+
+---
+
+## E0716: Temporary Value Dropped While Borrowed
+
+### Error Pattern
+```rust
+let r: &str = &String::from("hello");  // ERROR: temporary dropped
+println!("{}", r);
+```
+
+### Fix Options
+
+**Option 1: Bind to variable first**
+```rust
+let s = String::from("hello");
+let r: &str = &s;
+println!("{}", r);
+```
+
+**Option 2: Use let binding with reference**
+```rust
+let r: &str = {
+    let s = String::from("hello");
+    // s.as_str()  // ERROR: still temporary
+    Box::leak(s.into_boxed_str())  // extreme: leak for 'static
+};
+```
+
+---
+
+## Pattern: Loop Ownership Issues
+
+### Error Pattern
+```rust
+let strings = vec![String::from("a"), String::from("b")];
+for s in strings {
+    println!("{}", s);
+}
+// ERROR: strings moved into loop
+println!("{:?}", strings);
+```
+
+### Fix Options
+
+**Option 1: Iterate by reference**
+```rust
+let strings = vec![String::from("a"), String::from("b")];
+for s in &strings {
+    println!("{}", s);
+}
+println!("{:?}", strings);  // OK
+```
+
+**Option 2: Use iter()**
+```rust
+for s in strings.iter() {
+    println!("{}", s);
+}
+```
+
+**Option 3: Clone if needed**
+```rust
+for s in strings.clone() {
+    // consumes cloned vec
+}
+println!("{:?}", strings);  // original still available
+```

--- a/.agents/skills/m01-ownership/patterns/lifetime-patterns.md
+++ b/.agents/skills/m01-ownership/patterns/lifetime-patterns.md
@@ -1,0 +1,229 @@
+# Lifetime Patterns
+
+## Basic Lifetime Annotation
+
+### When Required
+```rust
+// ERROR: missing lifetime specifier
+fn longest(x: &str, y: &str) -> &str {
+    if x.len() > y.len() { x } else { y }
+}
+
+// FIX: explicit lifetime
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
+    if x.len() > y.len() { x } else { y }
+}
+```
+
+### Lifetime Elision Rules
+1. Each input reference gets its own lifetime
+2. If one input lifetime, output uses same
+3. If `&self` or `&mut self`, output uses self's lifetime
+
+```rust
+// These are equivalent (elision applies):
+fn first_word(s: &str) -> &str { ... }
+fn first_word<'a>(s: &'a str) -> &'a str { ... }
+
+// Method with self (elision applies):
+impl MyStruct {
+    fn get_ref(&self) -> &str { ... }
+    // Equivalent to:
+    fn get_ref<'a>(&'a self) -> &'a str { ... }
+}
+```
+
+---
+
+## Struct Lifetimes
+
+### Struct Holding References
+```rust
+// Struct must declare lifetime for references
+struct Excerpt<'a> {
+    part: &'a str,
+}
+
+impl<'a> Excerpt<'a> {
+    fn level(&self) -> i32 { 3 }
+
+    // Return reference tied to self's lifetime
+    fn get_part(&self) -> &str {
+        self.part
+    }
+}
+```
+
+### Multiple Lifetimes in Struct
+```rust
+struct Multi<'a, 'b> {
+    x: &'a str,
+    y: &'b str,
+}
+
+// Use when references may have different lifetimes
+fn make_multi<'a, 'b>(x: &'a str, y: &'b str) -> Multi<'a, 'b> {
+    Multi { x, y }
+}
+```
+
+---
+
+## 'static Lifetime
+
+### When to Use
+```rust
+// String literals are 'static
+let s: &'static str = "hello";
+
+// Owned data can be leaked to 'static
+let leaked: &'static str = Box::leak(String::from("hello").into_boxed_str());
+
+// Thread spawn requires 'static or move
+std::thread::spawn(move || {
+    // closure owns data, satisfies 'static
+});
+```
+
+### Avoid Overusing 'static
+```rust
+// BAD: requires 'static unnecessarily
+fn process(s: &'static str) { ... }
+
+// GOOD: use generic lifetime
+fn process<'a>(s: &'a str) { ... }
+// or
+fn process(s: &str) { ... }  // lifetime elision
+```
+
+---
+
+## Higher-Ranked Trait Bounds (HRTB)
+
+### for<'a> Syntax
+```rust
+// Function that works with any lifetime
+fn apply_to_ref<F>(f: F)
+where
+    F: for<'a> Fn(&'a str) -> &'a str,
+{
+    let s = String::from("hello");
+    let result = f(&s);
+    println!("{}", result);
+}
+```
+
+### Common Use: Closure Bounds
+```rust
+// Closure that borrows any lifetime
+fn filter_refs<F>(items: &[&str], pred: F) -> Vec<&str>
+where
+    F: for<'a> Fn(&'a str) -> bool,
+{
+    items.iter().copied().filter(|s| pred(s)).collect()
+}
+```
+
+---
+
+## Lifetime Bounds
+
+### 'a: 'b (Outlives)
+```rust
+// 'a must live at least as long as 'b
+fn coerce<'a, 'b>(x: &'a str) -> &'b str
+where
+    'a: 'b,
+{
+    x
+}
+```
+
+### T: 'a (Type Outlives Lifetime)
+```rust
+// T must live at least as long as 'a
+struct Wrapper<'a, T: 'a> {
+    value: &'a T,
+}
+
+// Common pattern with trait objects
+fn use_trait<'a, T: MyTrait + 'a>(t: &'a T) { ... }
+```
+
+---
+
+## Common Lifetime Mistakes
+
+### Mistake 1: Returning Reference to Local
+```rust
+// WRONG
+fn dangle() -> &String {
+    let s = String::from("hello");
+    &s  // s dropped, reference invalid
+}
+
+// RIGHT
+fn no_dangle() -> String {
+    String::from("hello")
+}
+```
+
+### Mistake 2: Conflicting Lifetimes
+```rust
+// WRONG: might return reference to y which has shorter lifetime
+fn wrong<'a, 'b>(x: &'a str, y: &'b str) -> &'a str {
+    y  // ERROR: 'b might not live as long as 'a
+}
+
+// RIGHT: use same lifetime or add bound
+fn right<'a>(x: &'a str, y: &'a str) -> &'a str {
+    y  // OK: both have lifetime 'a
+}
+```
+
+### Mistake 3: Struct Outlives Reference
+```rust
+// WRONG: s might outlive the string it references
+let r;
+{
+    let s = String::from("hello");
+    r = Excerpt { part: &s };  // ERROR
+}
+println!("{}", r.part);  // s already dropped
+
+// RIGHT: ensure source outlives struct
+let s = String::from("hello");
+let r = Excerpt { part: &s };
+println!("{}", r.part);  // OK: s still in scope
+```
+
+---
+
+## Subtyping and Variance
+
+### Covariance
+```rust
+// &'a T is covariant in 'a
+// Can use &'long where &'short expected
+fn example<'short, 'long: 'short>(long_ref: &'long str) {
+    let short_ref: &'short str = long_ref;  // OK: covariance
+}
+```
+
+### Invariance
+```rust
+// &'a mut T is invariant in 'a
+fn example<'a, 'b>(x: &'a mut &'b str, y: &'b str) {
+    *x = y;  // ERROR if 'a and 'b are different
+}
+```
+
+### Practical Impact
+```rust
+// This works due to covariance
+fn accept_any<'a>(s: &'a str) { ... }
+
+let s = String::from("hello");
+let long_lived: &str = &s;
+accept_any(long_lived);  // 'long coerces to 'short
+```

--- a/.agents/skills/m06-error-handling/SKILL.md
+++ b/.agents/skills/m06-error-handling/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: m06-error-handling
+description: "CRITICAL: Use for error handling. Triggers: Result, Option, Error, ?, unwrap, expect, panic, anyhow, thiserror, when to panic vs return Result, custom error, error propagation, 错误处理, Result 用法, 什么时候用 panic"
+user-invocable: false
+---
+
+# Error Handling
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**Is this failure expected or a bug?**
+
+Before choosing error handling strategy:
+- Can this fail in normal operation?
+- Who should handle this failure?
+- What context does the caller need?
+
+---
+
+## Error → Design Question
+
+| Pattern | Don't Just Say | Ask Instead |
+|---------|----------------|-------------|
+| unwrap panics | "Use ?" | Is None/Err actually possible here? |
+| Type mismatch on ? | "Use anyhow" | Are error types designed correctly? |
+| Lost error context | "Add .context()" | What does the caller need to know? |
+| Too many error variants | "Use Box<dyn Error>" | Is error granularity right? |
+
+---
+
+## Thinking Prompt
+
+Before handling an error:
+
+1. **What kind of failure is this?**
+   - Expected → Result<T, E>
+   - Absence normal → Option<T>
+   - Bug/invariant → panic!
+   - Unrecoverable → panic!
+
+2. **Who handles this?**
+   - Caller → propagate with ?
+   - Current function → match/if-let
+   - User → friendly error message
+   - Programmer → panic with message
+
+3. **What context is needed?**
+   - Type of error → thiserror variants
+   - Call chain → anyhow::Context
+   - Debug info → anyhow or tracing
+
+---
+
+## Trace Up ↑
+
+When error strategy is unclear:
+
+```
+"Should I return Result or Option?"
+    ↑ Ask: Is absence/failure normal or exceptional?
+    ↑ Check: m09-domain (what does domain say?)
+    ↑ Check: domain-* (error handling requirements)
+```
+
+| Situation | Trace To | Question |
+|-----------|----------|----------|
+| Too many unwraps | m09-domain | Is the data model right? |
+| Error context design | m13-domain-error | What recovery is needed? |
+| Library vs app errors | m11-ecosystem | Who are the consumers? |
+
+---
+
+## Trace Down ↓
+
+From design to implementation:
+
+```
+"Expected failure, library code"
+    ↓ Use: thiserror for typed errors
+
+"Expected failure, application code"
+    ↓ Use: anyhow for ergonomic errors
+
+"Absence is normal (find, get, lookup)"
+    ↓ Use: Option<T>
+
+"Bug or invariant violation"
+    ↓ Use: panic!, assert!, unreachable!
+
+"Need to propagate with context"
+    ↓ Use: .context("what was happening")
+```
+
+---
+
+## Quick Reference
+
+| Pattern | When | Example |
+|---------|------|---------|
+| `Result<T, E>` | Recoverable error | `fn read() -> Result<String, io::Error>` |
+| `Option<T>` | Absence is normal | `fn find() -> Option<&Item>` |
+| `?` | Propagate error | `let data = file.read()?;` |
+| `unwrap()` | Dev/test only | `config.get("key").unwrap()` |
+| `expect()` | Invariant holds | `env.get("HOME").expect("HOME set")` |
+| `panic!` | Unrecoverable | `panic!("critical failure")` |
+
+## Library vs Application
+
+| Context | Error Crate | Why |
+|---------|-------------|-----|
+| Library | `thiserror` | Typed errors for consumers |
+| Application | `anyhow` | Ergonomic error handling |
+| Mixed | Both | thiserror at boundaries, anyhow internally |
+
+## Decision Flowchart
+
+```
+Is failure expected?
+├─ Yes → Is absence the only "failure"?
+│        ├─ Yes → Option<T>
+│        └─ No → Result<T, E>
+│                 ├─ Library → thiserror
+│                 └─ Application → anyhow
+└─ No → Is it a bug?
+        ├─ Yes → panic!, assert!
+        └─ No → Consider if really unrecoverable
+
+Use ? → Need context?
+├─ Yes → .context("message")
+└─ No → Plain ?
+```
+
+---
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `unwrap()` panic | Unhandled None/Err | Use `?` or match |
+| Type mismatch | Different error types | Use `anyhow` or `From` |
+| Lost context | `?` without context | Add `.context()` |
+| `cannot use ?` | Missing Result return | Return `Result<(), E>` |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| `.unwrap()` everywhere | Panics in production | `.expect("reason")` or `?` |
+| Ignore errors silently | Bugs hidden | Handle or propagate |
+| `panic!` for expected errors | Bad UX, no recovery | Result |
+| Box<dyn Error> everywhere | Lost type info | thiserror |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Domain error strategy | m13-domain-error |
+| Crate boundaries | m11-ecosystem |
+| Type-safe errors | m05-type-driven |
+| Mental models | m14-mental-model |

--- a/.agents/skills/m06-error-handling/examples/library-vs-app.md
+++ b/.agents/skills/m06-error-handling/examples/library-vs-app.md
@@ -1,0 +1,332 @@
+# Error Handling: Library vs Application
+
+## Library Error Design
+
+### Principles
+1. **Define specific error types** - Don't use `anyhow` in libraries
+2. **Implement std::error::Error** - For compatibility
+3. **Provide error variants** - Let users match on errors
+4. **Include source errors** - Enable error chains
+5. **Be `Send + Sync`** - For async compatibility
+
+### Example: Library Error Type
+```rust
+// lib.rs
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DatabaseError {
+    #[error("connection failed: {host}:{port}")]
+    ConnectionFailed {
+        host: String,
+        port: u16,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("query failed: {query}")]
+    QueryFailed {
+        query: String,
+        #[source]
+        source: SqlError,
+    },
+
+    #[error("record not found: {table}.{id}")]
+    NotFound { table: String, id: String },
+
+    #[error("constraint violation: {0}")]
+    ConstraintViolation(String),
+}
+
+// Public Result alias
+pub type Result<T> = std::result::Result<T, DatabaseError>;
+
+// Library functions
+pub fn connect(host: &str, port: u16) -> Result<Connection> {
+    // ...
+}
+
+pub fn query(conn: &Connection, sql: &str) -> Result<Rows> {
+    // ...
+}
+```
+
+### Library Usage of Errors
+```rust
+impl Database {
+    pub fn get_user(&self, id: &str) -> Result<User> {
+        let rows = self.query(&format!("SELECT * FROM users WHERE id = '{}'", id))?;
+
+        rows.first()
+            .cloned()
+            .ok_or_else(|| DatabaseError::NotFound {
+                table: "users".to_string(),
+                id: id.to_string(),
+            })
+    }
+}
+```
+
+---
+
+## Application Error Design
+
+### Principles
+1. **Use anyhow for convenience** - Or custom unified error
+2. **Add context liberally** - Help debugging
+3. **Log at boundaries** - Don't log in libraries
+4. **Convert to user-friendly messages** - For display
+
+### Example: Application Error Handling
+```rust
+// main.rs
+use anyhow::{Context, Result};
+use tracing::{error, info};
+
+async fn run_server() -> Result<()> {
+    let config = load_config()
+        .context("failed to load configuration")?;
+
+    let db = Database::connect(&config.db_url)
+        .await
+        .context("failed to connect to database")?;
+
+    let server = Server::new(config.port)
+        .context("failed to create server")?;
+
+    info!("Server starting on port {}", config.port);
+
+    server.run(db).await
+        .context("server error")?;
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::init();
+
+    if let Err(e) = run_server().await {
+        error!("Application error: {:#}", e);
+        std::process::exit(1);
+    }
+}
+```
+
+### Converting Library Errors
+```rust
+use mylib::DatabaseError;
+
+async fn get_user_handler(id: &str) -> Result<Response> {
+    match db.get_user(id).await {
+        Ok(user) => Ok(Response::json(user)),
+
+        Err(DatabaseError::NotFound { .. }) => {
+            Ok(Response::not_found("User not found"))
+        }
+
+        Err(DatabaseError::ConnectionFailed { .. }) => {
+            error!("Database connection failed");
+            Ok(Response::internal_error("Service unavailable"))
+        }
+
+        Err(e) => {
+            error!("Database error: {}", e);
+            Err(e.into())  // Convert to anyhow::Error
+        }
+    }
+}
+```
+
+---
+
+## Error Handling Layers
+
+```
+┌─────────────────────────────────────┐
+│           Application Layer          │
+│  - Use anyhow or unified error       │
+│  - Add context at boundaries         │
+│  - Log errors                        │
+│  - Convert to user messages          │
+└─────────────────────────────────────┘
+                 │
+                 │ calls
+                 ▼
+┌─────────────────────────────────────┐
+│           Service Layer              │
+│  - Map between error types           │
+│  - Add business context              │
+│  - Handle recoverable errors         │
+└─────────────────────────────────────┘
+                 │
+                 │ calls
+                 ▼
+┌─────────────────────────────────────┐
+│           Library Layer              │
+│  - Define specific error types       │
+│  - Use thiserror                     │
+│  - Include source errors             │
+│  - No logging                        │
+└─────────────────────────────────────┘
+```
+
+---
+
+## Practical Examples
+
+### HTTP API Error Response
+```rust
+use axum::{response::IntoResponse, http::StatusCode};
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+    code: String,
+}
+
+enum AppError {
+    NotFound(String),
+    BadRequest(String),
+    Internal(anyhow::Error),
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        let (status, error, code) = match self {
+            AppError::NotFound(msg) => {
+                (StatusCode::NOT_FOUND, msg, "NOT_FOUND")
+            }
+            AppError::BadRequest(msg) => {
+                (StatusCode::BAD_REQUEST, msg, "BAD_REQUEST")
+            }
+            AppError::Internal(e) => {
+                tracing::error!("Internal error: {:#}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal server error".to_string(),
+                    "INTERNAL_ERROR",
+                )
+            }
+        };
+
+        let body = ErrorResponse {
+            error,
+            code: code.to_string(),
+        };
+
+        (status, axum::Json(body)).into_response()
+    }
+}
+```
+
+### CLI Error Handling
+```rust
+use anyhow::{Context, Result};
+use clap::Parser;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(short, long)]
+    config: String,
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {:#}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let args = Args::parse();
+
+    let config = std::fs::read_to_string(&args.config)
+        .context(format!("Failed to read config file: {}", args.config))?;
+
+    let parsed: Config = toml::from_str(&config)
+        .context("Failed to parse config file")?;
+
+    process(parsed)?;
+
+    println!("Done!");
+    Ok(())
+}
+```
+
+---
+
+## Testing Error Handling
+
+### Testing Error Cases
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_not_found_error() {
+        let result = db.get_user("nonexistent");
+
+        assert!(matches!(
+            result,
+            Err(DatabaseError::NotFound { table, id })
+            if table == "users" && id == "nonexistent"
+        ));
+    }
+
+    #[test]
+    fn test_error_message() {
+        let err = DatabaseError::NotFound {
+            table: "users".to_string(),
+            id: "123".to_string(),
+        };
+
+        assert_eq!(err.to_string(), "record not found: users.123");
+    }
+
+    #[test]
+    fn test_error_chain() {
+        let io_err = std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "connection refused"
+        );
+
+        let err = DatabaseError::ConnectionFailed {
+            host: "localhost".to_string(),
+            port: 5432,
+            source: io_err,
+        };
+
+        // Check source is preserved
+        assert!(err.source().is_some());
+    }
+}
+```
+
+### Testing with anyhow
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_with_context() -> anyhow::Result<()> {
+        let result = process("valid input")?;
+        assert_eq!(result, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_error_context() {
+        let err = process("invalid")
+            .context("processing failed")
+            .unwrap_err();
+
+        // Check error chain contains expected text
+        let chain = format!("{:#}", err);
+        assert!(chain.contains("processing failed"));
+    }
+}
+```

--- a/.agents/skills/m06-error-handling/patterns/error-patterns.md
+++ b/.agents/skills/m06-error-handling/patterns/error-patterns.md
@@ -1,0 +1,404 @@
+# Error Handling Patterns
+
+## The ? Operator
+
+### Basic Usage
+```rust
+fn read_config() -> Result<Config, io::Error> {
+    let content = std::fs::read_to_string("config.toml")?;
+    let config: Config = toml::from_str(&content)?;  // needs From impl
+    Ok(config)
+}
+```
+
+### With Different Error Types
+```rust
+use std::error::Error;
+
+// Box<dyn Error> for quick prototyping
+fn process() -> Result<(), Box<dyn Error>> {
+    let file = std::fs::read_to_string("data.txt")?;
+    let num: i32 = file.trim().parse()?;  // different error type
+    Ok(())
+}
+```
+
+### Custom Conversion with From
+```rust
+#[derive(Debug)]
+enum MyError {
+    Io(std::io::Error),
+    Parse(std::num::ParseIntError),
+}
+
+impl From<std::io::Error> for MyError {
+    fn from(err: std::io::Error) -> Self {
+        MyError::Io(err)
+    }
+}
+
+impl From<std::num::ParseIntError> for MyError {
+    fn from(err: std::num::ParseIntError) -> Self {
+        MyError::Parse(err)
+    }
+}
+
+fn process() -> Result<i32, MyError> {
+    let content = std::fs::read_to_string("num.txt")?;  // auto-converts
+    let num: i32 = content.trim().parse()?;  // auto-converts
+    Ok(num)
+}
+```
+
+---
+
+## Error Type Design
+
+### Simple Enum Error
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConfigError {
+    NotFound,
+    InvalidFormat,
+    MissingField(String),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigError::NotFound => write!(f, "configuration file not found"),
+            ConfigError::InvalidFormat => write!(f, "invalid configuration format"),
+            ConfigError::MissingField(field) => write!(f, "missing field: {}", field),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+```
+
+### Error with Source (Wrapping)
+```rust
+#[derive(Debug)]
+pub struct AppError {
+    kind: AppErrorKind,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum AppErrorKind {
+    Config,
+    Database,
+    Network,
+}
+
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            AppErrorKind::Config => write!(f, "configuration error"),
+            AppErrorKind::Database => write!(f, "database error"),
+            AppErrorKind::Network => write!(f, "network error"),
+        }
+    }
+}
+
+impl std::error::Error for AppError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_ref().map(|e| e.as_ref() as _)
+    }
+}
+```
+
+---
+
+## Using thiserror
+
+### Basic Usage
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DataError {
+    #[error("file not found: {path}")]
+    NotFound { path: String },
+
+    #[error("invalid data format")]
+    InvalidFormat,
+
+    #[error("IO error")]
+    Io(#[from] std::io::Error),
+
+    #[error("parse error: {0}")]
+    Parse(#[from] std::num::ParseIntError),
+}
+
+// Usage
+fn load_data(path: &str) -> Result<Data, DataError> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|_| DataError::NotFound { path: path.to_string() })?;
+    let num: i32 = content.trim().parse()?;  // auto-converts with #[from]
+    Ok(Data { value: num })
+}
+```
+
+### Transparent Wrapper
+```rust
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub struct MyError(#[from] InnerError);
+
+// Useful for newtype error wrappers
+```
+
+---
+
+## Using anyhow
+
+### For Applications
+```rust
+use anyhow::{Context, Result, bail, ensure};
+
+fn process_file(path: &str) -> Result<Data> {
+    let content = std::fs::read_to_string(path)
+        .context("failed to read config file")?;
+
+    ensure!(!content.is_empty(), "config file is empty");
+
+    let data: Data = serde_json::from_str(&content)
+        .context("failed to parse JSON")?;
+
+    if data.version < 1 {
+        bail!("unsupported config version: {}", data.version);
+    }
+
+    Ok(data)
+}
+
+fn main() -> Result<()> {
+    let data = process_file("config.json")
+        .context("failed to load configuration")?;
+    Ok(())
+}
+```
+
+### Error Chain
+```rust
+use anyhow::{Context, Result};
+
+fn deep_function() -> Result<()> {
+    std::fs::read_to_string("missing.txt")
+        .context("failed to read file")?;
+    Ok(())
+}
+
+fn middle_function() -> Result<()> {
+    deep_function()
+        .context("failed in deep function")?;
+    Ok(())
+}
+
+fn top_function() -> Result<()> {
+    middle_function()
+        .context("failed in middle function")?;
+    Ok(())
+}
+
+// Error output shows full chain:
+// Error: failed in middle function
+// Caused by:
+//     0: failed in deep function
+//     1: failed to read file
+//     2: No such file or directory (os error 2)
+```
+
+---
+
+## Option Handling
+
+### Converting Option to Result
+```rust
+fn find_user(id: u32) -> Option<User> { ... }
+
+// Using ok_or for static error
+fn get_user(id: u32) -> Result<User, &'static str> {
+    find_user(id).ok_or("user not found")
+}
+
+// Using ok_or_else for dynamic error
+fn get_user(id: u32) -> Result<User, String> {
+    find_user(id).ok_or_else(|| format!("user {} not found", id))
+}
+```
+
+### Chaining Options
+```rust
+fn get_nested_value(data: &Data) -> Option<&str> {
+    data.config
+        .as_ref()?
+        .nested
+        .as_ref()?
+        .value
+        .as_deref()
+}
+
+// Equivalent with and_then
+fn get_nested_value(data: &Data) -> Option<&str> {
+    data.config
+        .as_ref()
+        .and_then(|c| c.nested.as_ref())
+        .and_then(|n| n.value.as_deref())
+}
+```
+
+---
+
+## Pattern: Result Combinators
+
+### map and map_err
+```rust
+fn parse_port(s: &str) -> Result<u16, ParseError> {
+    s.parse::<u16>()
+        .map_err(|e| ParseError::InvalidPort(e))
+}
+
+fn get_url(config: &Config) -> Result<String, Error> {
+    config.url()
+        .map(|u| format!("https://{}", u))
+}
+```
+
+### and_then (flatMap)
+```rust
+fn validate_and_save(input: &str) -> Result<(), Error> {
+    validate(input)
+        .and_then(|valid| save(valid))
+        .and_then(|saved| notify(saved))
+}
+```
+
+### unwrap_or and unwrap_or_else
+```rust
+// Default value
+let port = config.port().unwrap_or(8080);
+
+// Computed default
+let port = config.port().unwrap_or_else(|| find_free_port());
+
+// Default for Result
+let data = load_data().unwrap_or_default();
+```
+
+---
+
+## Pattern: Early Return vs Combinators
+
+### Early Return Style
+```rust
+fn process(input: &str) -> Result<Output, Error> {
+    let step1 = validate(input)?;
+    if !step1.is_valid {
+        return Err(Error::Invalid);
+    }
+
+    let step2 = transform(step1)?;
+    let step3 = save(step2)?;
+
+    Ok(step3)
+}
+```
+
+### Combinator Style
+```rust
+fn process(input: &str) -> Result<Output, Error> {
+    validate(input)
+        .and_then(|s| {
+            if s.is_valid {
+                Ok(s)
+            } else {
+                Err(Error::Invalid)
+            }
+        })
+        .and_then(transform)
+        .and_then(save)
+}
+```
+
+### When to Use Which
+
+| Style | Best For |
+|-------|----------|
+| Early return (`?`) | Most cases, clearer flow |
+| Combinators | Functional pipelines, one-liners |
+| Match | Complex branching on errors |
+
+---
+
+## Panic vs Result
+
+### When to Panic
+```rust
+// 1. Unrecoverable programmer error
+fn get_config() -> &'static Config {
+    CONFIG.get().expect("config must be initialized")
+}
+
+// 2. In tests
+#[test]
+fn test_parsing() {
+    let result = parse("valid").unwrap();  // OK in tests
+    assert_eq!(result, expected);
+}
+
+// 3. Prototype/examples
+fn main() {
+    let data = load().unwrap();  // OK for quick examples
+}
+```
+
+### When to Return Result
+```rust
+// 1. Any I/O operation
+fn read_file(path: &str) -> Result<String, io::Error>
+
+// 2. User input validation
+fn parse_port(s: &str) -> Result<u16, ParseError>
+
+// 3. Network operations
+async fn fetch(url: &str) -> Result<Response, Error>
+
+// 4. Anything that can fail at runtime
+fn connect(addr: &str) -> Result<Connection, Error>
+```
+
+---
+
+## Error Context Best Practices
+
+### Add Context at Boundaries
+```rust
+fn load_user_config(user_id: u64) -> Result<Config, Error> {
+    let path = format!("/home/{}/config.toml", user_id);
+
+    std::fs::read_to_string(&path)
+        .context(format!("failed to read config for user {}", user_id))?
+        // NOT: .context("failed to read file")  // too generic
+
+    // ...
+}
+```
+
+### Include Relevant Data
+```rust
+// Good: includes the problematic value
+fn parse_age(s: &str) -> Result<u8, Error> {
+    s.parse()
+        .context(format!("invalid age value: '{}'", s))
+}
+
+// Bad: no context about what failed
+fn parse_age(s: &str) -> Result<u8, Error> {
+    s.parse()
+        .context("parse error")
+}
+```

--- a/.agents/skills/m07-concurrency/SKILL.md
+++ b/.agents/skills/m07-concurrency/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: m07-concurrency
+description: "CRITICAL: Use for concurrency/async. Triggers: E0277 Send Sync, cannot be sent between threads, thread, spawn, channel, mpsc, Mutex, RwLock, Atomic, async, await, Future, tokio, deadlock, race condition, 并发, 线程, 异步, 死锁"
+user-invocable: false
+---
+
+# Concurrency
+
+> **Layer 1: Language Mechanics**
+
+## Core Question
+
+**Is this CPU-bound or I/O-bound, and what's the sharing model?**
+
+Before choosing concurrency primitives:
+- What's the workload type?
+- What data needs to be shared?
+- What's the thread safety requirement?
+
+---
+
+## Error → Design Question
+
+| Error | Don't Just Say | Ask Instead |
+|-------|----------------|-------------|
+| E0277 Send | "Add Send bound" | Should this type cross threads? |
+| E0277 Sync | "Wrap in Mutex" | Is shared access really needed? |
+| Future not Send | "Use spawn_local" | Is async the right choice? |
+| Deadlock | "Reorder locks" | Is the locking design correct? |
+
+---
+
+## Thinking Prompt
+
+Before adding concurrency:
+
+1. **What's the workload?**
+   - CPU-bound → threads (std::thread, rayon)
+   - I/O-bound → async (tokio, async-std)
+   - Mixed → hybrid approach
+
+2. **What's the sharing model?**
+   - No sharing → message passing (channels)
+   - Immutable sharing → Arc<T>
+   - Mutable sharing → Arc<Mutex<T>> or Arc<RwLock<T>>
+
+3. **What are the Send/Sync requirements?**
+   - Cross-thread ownership → Send
+   - Cross-thread references → Sync
+   - Single-thread async → spawn_local
+
+---
+
+## Trace Up ↑ (MANDATORY)
+
+**CRITICAL**: Don't just fix the error. Trace UP to find domain constraints.
+
+### Domain Detection Table
+
+| Context Keywords | Load Domain Skill | Key Constraint |
+|-----------------|-------------------|----------------|
+| Web API, HTTP, axum, actix, handler | **domain-web** | Handlers run on any thread |
+| 交易, 支付, trading, payment | **domain-fintech** | Audit + thread safety |
+| gRPC, kubernetes, microservice | **domain-cloud-native** | Distributed tracing |
+| CLI, terminal, clap | **domain-cli** | Usually single-thread OK |
+
+### Example: Web API + Rc Error
+
+```
+"Rc cannot be sent between threads" in Web API context
+    ↑ DETECT: "Web API" → Load domain-web
+    ↑ FIND: domain-web says "Shared state must be thread-safe"
+    ↑ FIND: domain-web says "Rc in state" is Common Mistake
+    ↓ DESIGN: Use Arc<T> with State extractor
+    ↓ IMPL: axum::extract::State<Arc<AppConfig>>
+```
+
+### Generic Trace
+
+```
+"Send not satisfied for my type"
+    ↑ Ask: What domain is this? Load domain-* skill
+    ↑ Ask: Does this type need to cross thread boundaries?
+    ↑ Check: m09-domain (is the data model correct?)
+```
+
+| Situation | Trace To | Question |
+|-----------|----------|----------|
+| Send/Sync in Web | **domain-web** | What's the state management pattern? |
+| Send/Sync in CLI | **domain-cli** | Is multi-thread really needed? |
+| Mutex vs channels | m09-domain | Shared state or message passing? |
+| Async vs threads | m10-performance | What's the workload profile? |
+
+---
+
+## Trace Down ↓
+
+From design to implementation:
+
+```
+"Need parallelism for CPU work"
+    ↓ Use: std::thread or rayon
+
+"Need concurrency for I/O"
+    ↓ Use: async/await with tokio
+
+"Need to share immutable data across threads"
+    ↓ Use: Arc<T>
+
+"Need to share mutable data across threads"
+    ↓ Use: Arc<Mutex<T>> or Arc<RwLock<T>>
+    ↓ Or: channels for message passing
+
+"Need simple atomic operations"
+    ↓ Use: AtomicBool, AtomicUsize, etc.
+```
+
+---
+
+## Send/Sync Markers
+
+| Marker | Meaning | Example |
+|--------|---------|---------|
+| `Send` | Can transfer ownership between threads | Most types |
+| `Sync` | Can share references between threads | `Arc<T>` |
+| `!Send` | Must stay on one thread | `Rc<T>` |
+| `!Sync` | No shared refs across threads | `RefCell<T>` |
+
+## Quick Reference
+
+| Pattern | Thread-Safe | Blocking | Use When |
+|---------|-------------|----------|----------|
+| `std::thread` | Yes | Yes | CPU-bound parallelism |
+| `async/await` | Yes | No | I/O-bound concurrency |
+| `Mutex<T>` | Yes | Yes | Shared mutable state |
+| `RwLock<T>` | Yes | Yes | Read-heavy shared state |
+| `mpsc::channel` | Yes | Optional | Message passing |
+| `Arc<Mutex<T>>` | Yes | Yes | Shared mutable across threads |
+
+## Decision Flowchart
+
+```
+What type of work?
+├─ CPU-bound → std::thread or rayon
+├─ I/O-bound → async/await
+└─ Mixed → hybrid (spawn_blocking)
+
+Need to share data?
+├─ No → message passing (channels)
+├─ Immutable → Arc<T>
+└─ Mutable →
+   ├─ Read-heavy → Arc<RwLock<T>>
+   └─ Write-heavy → Arc<Mutex<T>>
+   └─ Simple counter → AtomicUsize
+
+Async context?
+├─ Type is Send → tokio::spawn
+├─ Type is !Send → spawn_local
+└─ Blocking code → spawn_blocking
+```
+
+---
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| E0277 `Send` not satisfied | Non-Send in async | Use Arc or spawn_local |
+| E0277 `Sync` not satisfied | Non-Sync shared | Wrap with Mutex |
+| Deadlock | Lock ordering | Consistent lock order |
+| `future is not Send` | Non-Send across await | Drop before await |
+| `MutexGuard` across await | Guard held during suspend | Scope guard properly |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| Arc<Mutex<T>> everywhere | Contention, complexity | Message passing |
+| thread::sleep in async | Blocks executor | tokio::time::sleep |
+| Holding locks across await | Blocks other tasks | Scope locks tightly |
+| Ignoring deadlock risk | Hard to debug | Lock ordering, try_lock |
+
+---
+
+## Async-Specific Patterns
+
+### Avoid MutexGuard Across Await
+
+```rust
+// Bad: guard held across await
+let guard = mutex.lock().await;
+do_async().await;  // guard still held!
+
+// Good: scope the lock
+{
+    let guard = mutex.lock().await;
+    // use guard
+}  // guard dropped
+do_async().await;
+```
+
+### Non-Send Types in Async
+
+```rust
+// Rc is !Send, can't cross await in spawned task
+// Option 1: use Arc instead
+// Option 2: use spawn_local (single-thread runtime)
+// Option 3: ensure Rc is dropped before .await
+```
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Smart pointer choice | m02-resource |
+| Interior mutability | m03-mutability |
+| Performance tuning | m10-performance |
+| Domain concurrency needs | domain-* |

--- a/.agents/skills/m07-concurrency/comparison.md
+++ b/.agents/skills/m07-concurrency/comparison.md
@@ -1,0 +1,312 @@
+# Concurrency: Comparison with Other Languages
+
+## Rust vs Go
+
+### Concurrency Model
+
+| Aspect | Rust | Go |
+|--------|------|-----|
+| Model | Ownership + Send/Sync | CSP (Communicating Sequential Processes) |
+| Primitives | Arc, Mutex, channels | goroutines, channels |
+| Safety | Compile-time | Runtime (race detector) |
+| Async | async/await + runtime | Built-in scheduler |
+
+### Goroutines vs Rust Tasks
+
+```rust
+// Rust: explicit about thread safety
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+let data = Arc::new(Mutex::new(vec![]));
+let data_clone = Arc::clone(&data);
+
+tokio::spawn(async move {
+    let mut guard = data_clone.lock().await;
+    guard.push(1);  // Safe: Mutex protects access
+});
+
+// Go: implicit sharing (potential race)
+// data := []int{}
+// go func() {
+//     data = append(data, 1)  // RACE CONDITION!
+// }()
+```
+
+### Channel Comparison
+
+```rust
+// Rust: typed channels with ownership
+use tokio::sync::mpsc;
+
+let (tx, mut rx) = mpsc::channel::<String>(100);
+
+tokio::spawn(async move {
+    tx.send("hello".to_string()).await.unwrap();
+    // tx is moved, can't be used elsewhere
+});
+
+// Go: channels are more flexible but less safe
+// ch := make(chan string, 100)
+// go func() {
+//     ch <- "hello"
+//     // ch can still be used anywhere
+// }()
+```
+
+---
+
+## Rust vs Java
+
+### Thread Safety Model
+
+| Aspect | Rust | Java |
+|--------|------|------|
+| Safety | Compile-time (Send/Sync) | Runtime (synchronized, volatile) |
+| Null | No null (Option) | NullPointerException risk |
+| Locks | RAII (drop releases) | try-finally or try-with-resources |
+| Memory | No GC | GC with stop-the-world |
+
+### Synchronization Comparison
+
+```rust
+// Rust: lock is tied to data
+use std::sync::Mutex;
+
+let data = Mutex::new(vec![1, 2, 3]);
+{
+    let mut guard = data.lock().unwrap();
+    guard.push(4);
+}  // lock released automatically
+
+// Java: lock and data are separate
+// List<Integer> data = new ArrayList<>();
+// synchronized(data) {
+//     data.add(4);
+// }  // easy to forget synchronization elsewhere
+```
+
+### Thread Pool Comparison
+
+```rust
+// Rust: rayon for data parallelism
+use rayon::prelude::*;
+
+let sum: i32 = (0..1000)
+    .into_par_iter()
+    .map(|x| x * x)
+    .sum();
+
+// Java: Stream API
+// int sum = IntStream.range(0, 1000)
+//     .parallel()
+//     .map(x -> x * x)
+//     .sum();
+```
+
+---
+
+## Rust vs C++
+
+### Safety Guarantees
+
+| Aspect | Rust | C++ |
+|--------|------|-----|
+| Data races | Prevented at compile-time | Undefined behavior |
+| Deadlocks | Not prevented (same as C++) | Not prevented |
+| Thread safety | Send/Sync traits | Convention only |
+| Memory ordering | Explicit Ordering enum | memory_order enum |
+
+### Atomic Comparison
+
+```rust
+// Rust: clear memory ordering
+use std::sync::atomic::{AtomicI32, Ordering};
+
+let counter = AtomicI32::new(0);
+counter.fetch_add(1, Ordering::SeqCst);
+let value = counter.load(Ordering::Acquire);
+
+// C++: similar but without safety
+// std::atomic<int> counter{0};
+// counter.fetch_add(1, std::memory_order_seq_cst);
+// int value = counter.load(std::memory_order_acquire);
+```
+
+### Mutex Comparison
+
+```rust
+// Rust: data protected by Mutex
+use std::sync::Mutex;
+
+struct SafeCounter {
+    count: Mutex<i32>,  // Mutex contains the data
+}
+
+impl SafeCounter {
+    fn increment(&self) {
+        *self.count.lock().unwrap() += 1;
+    }
+}
+
+// C++: mutex separate from data (error-prone)
+// class Counter {
+//     std::mutex mtx;
+//     int count;  // NOT protected by type system
+// public:
+//     void increment() {
+//         std::lock_guard<std::mutex> lock(mtx);
+//         count++;
+//     }
+//     void unsafe_increment() {
+//         count++;  // Compiles! But wrong.
+//     }
+// };
+```
+
+---
+
+## Async Models Comparison
+
+| Language | Model | Runtime |
+|----------|-------|---------|
+| Rust | async/await, zero-cost | tokio, async-std (bring your own) |
+| Go | goroutines | Built-in scheduler |
+| JavaScript | async/await, Promises | Event loop (single-threaded) |
+| Python | async/await | asyncio (single-threaded) |
+| Java | CompletableFuture, Virtual Threads | ForkJoinPool, Loom |
+
+### Rust vs JavaScript Async
+
+```rust
+// Rust: async requires explicit runtime, can use multiple threads
+#[tokio::main]
+async fn main() {
+    let results = tokio::join!(
+        fetch("url1"),  // runs concurrently
+        fetch("url2"),
+    );
+}
+
+// JavaScript: single-threaded event loop
+// async function main() {
+//     const results = await Promise.all([
+//         fetch("url1"),
+//         fetch("url2"),
+//     ]);
+// }
+```
+
+### Rust vs Python Async
+
+```rust
+// Rust: true parallelism possible
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    let handles: Vec<_> = urls
+        .into_iter()
+        .map(|url| tokio::spawn(fetch(url)))  // spawns on thread pool
+        .collect();
+
+    for handle in handles {
+        let _ = handle.await;
+    }
+}
+
+// Python: asyncio is single-threaded (use ProcessPoolExecutor for CPU)
+# async def main():
+#     tasks = [asyncio.create_task(fetch(url)) for url in urls]
+#     await asyncio.gather(*tasks)  # all on same thread
+```
+
+---
+
+## Send and Sync: Rust's Unique Feature
+
+No other mainstream language has compile-time thread safety markers:
+
+| Trait | Meaning | Auto-impl |
+|-------|---------|-----------|
+| `Send` | Safe to transfer between threads | Most types |
+| `Sync` | Safe to share `&T` between threads | Types with thread-safe `&` |
+| `!Send` | Must stay on one thread | Rc, raw pointers |
+| `!Sync` | References can't be shared | RefCell, Cell |
+
+### Why This Matters
+
+```rust
+// Rust PREVENTS this at compile time:
+use std::rc::Rc;
+
+let rc = Rc::new(42);
+std::thread::spawn(move || {
+    println!("{}", rc);  // ERROR: Rc is not Send
+});
+
+// In other languages, this would be a runtime bug:
+// - Go: race detector might catch it
+// - Java: undefined behavior
+// - Python: GIL usually saves you
+// - C++: undefined behavior
+```
+
+---
+
+## Performance Characteristics
+
+| Aspect | Rust | Go | Java | C++ |
+|--------|------|-----|------|-----|
+| Thread overhead | System threads or M:N | M:N (goroutines) | System or virtual | System threads |
+| Context switch | OS-level or cooperative | Cheap (goroutines) | OS-level | OS-level |
+| Memory | Predictable (no GC) | GC pauses | GC pauses | Predictable |
+| Async overhead | Zero-cost futures | Runtime overhead | Boxing overhead | Depends |
+
+### When to Use What
+
+| Scenario | Best Choice |
+|----------|-------------|
+| CPU-bound parallelism | Rust (rayon), C++ |
+| I/O-bound concurrency | Rust (tokio), Go, Node.js |
+| Low latency required | Rust, C++ |
+| Rapid development | Go, Python |
+| Complex concurrent state | Rust (compile-time safety) |
+
+---
+
+## Mental Model Shifts
+
+### From Go
+
+```
+Before: "Just use goroutines and channels"
+After:  "Explicitly declare what can be shared and how"
+```
+
+Key shifts:
+- `Arc<Mutex<T>>` instead of implicit sharing
+- Compiler enforces thread safety
+- Async needs explicit runtime
+
+### From Java
+
+```
+Before: "synchronized everywhere, hope for the best"
+After:  "Types encode thread safety, compiler enforces"
+```
+
+Key shifts:
+- No need for synchronized keyword
+- Mutex contains data, not separate
+- No GC pauses in critical sections
+
+### From C++
+
+```
+Before: "Be careful, read the docs, use sanitizers"
+After:  "Compiler catches data races, trust the type system"
+```
+
+Key shifts:
+- Send/Sync replace convention
+- RAII locks are mandatory, not optional
+- Much harder to write incorrect concurrent code

--- a/.agents/skills/m07-concurrency/examples/thread-patterns.md
+++ b/.agents/skills/m07-concurrency/examples/thread-patterns.md
@@ -1,0 +1,396 @@
+# Thread-Based Concurrency Patterns
+
+## Thread Spawning Best Practices
+
+### Basic Thread Spawn
+```rust
+use std::thread;
+
+fn main() {
+    let handle = thread::spawn(|| {
+        println!("Hello from thread!");
+        42  // return value
+    });
+
+    let result = handle.join().unwrap();
+    println!("Thread returned: {}", result);
+}
+```
+
+### Named Threads for Debugging
+```rust
+use std::thread;
+
+let builder = thread::Builder::new()
+    .name("worker-1".to_string())
+    .stack_size(32 * 1024);  // 32KB stack
+
+let handle = builder.spawn(|| {
+    println!("Thread name: {:?}", thread::current().name());
+}).unwrap();
+```
+
+### Scoped Threads (No 'static Required)
+```rust
+use std::thread;
+
+fn process_data(data: &[u32]) -> Vec<u32> {
+    thread::scope(|s| {
+        let handles: Vec<_> = data
+            .chunks(2)
+            .map(|chunk| {
+                s.spawn(|| {
+                    chunk.iter().map(|x| x * 2).collect::<Vec<_>>()
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .flat_map(|h| h.join().unwrap())
+            .collect()
+    })
+}
+
+fn main() {
+    let data = vec![1, 2, 3, 4, 5, 6];
+    let result = process_data(&data);  // No 'static needed!
+    println!("{:?}", result);
+}
+```
+
+---
+
+## Shared State Patterns
+
+### Arc + Mutex (Read-Write)
+```rust
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+fn shared_counter() {
+    let counter = Arc::new(Mutex::new(0));
+    let mut handles = vec![];
+
+    for _ in 0..10 {
+        let counter = Arc::clone(&counter);
+        let handle = thread::spawn(move || {
+            let mut num = counter.lock().unwrap();
+            *num += 1;
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    println!("Result: {}", *counter.lock().unwrap());
+}
+```
+
+### Arc + RwLock (Read-Heavy)
+```rust
+use std::sync::{Arc, RwLock};
+use std::thread;
+
+fn read_heavy_cache() {
+    let cache = Arc::new(RwLock::new(vec![1, 2, 3]));
+
+    // Many readers
+    for i in 0..5 {
+        let cache = Arc::clone(&cache);
+        thread::spawn(move || {
+            let data = cache.read().unwrap();
+            println!("Reader {}: {:?}", i, *data);
+        });
+    }
+
+    // Occasional writer
+    {
+        let cache = Arc::clone(&cache);
+        thread::spawn(move || {
+            let mut data = cache.write().unwrap();
+            data.push(4);
+            println!("Writer: added element");
+        });
+    }
+}
+```
+
+### Atomic for Simple Types
+```rust
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+
+fn atomic_counter() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let mut handles = vec![];
+
+    for _ in 0..10 {
+        let counter = Arc::clone(&counter);
+        handles.push(thread::spawn(move || {
+            for _ in 0..1000 {
+                counter.fetch_add(1, Ordering::SeqCst);
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    println!("Result: {}", counter.load(Ordering::SeqCst));
+}
+```
+
+---
+
+## Channel Patterns
+
+### MPSC Channel
+```rust
+use std::sync::mpsc;
+use std::thread;
+
+fn producer_consumer() {
+    let (tx, rx) = mpsc::channel();
+
+    // Multiple producers
+    for i in 0..3 {
+        let tx = tx.clone();
+        thread::spawn(move || {
+            for j in 0..5 {
+                tx.send(format!("msg {}-{}", i, j)).unwrap();
+            }
+        });
+    }
+    drop(tx);  // Drop original sender
+
+    // Single consumer
+    for received in rx {
+        println!("Got: {}", received);
+    }
+}
+```
+
+### Sync Channel (Bounded)
+```rust
+use std::sync::mpsc;
+use std::thread;
+
+fn bounded_channel() {
+    let (tx, rx) = mpsc::sync_channel(2);  // buffer size 2
+
+    thread::spawn(move || {
+        for i in 0..5 {
+            println!("Sending {}", i);
+            tx.send(i).unwrap();  // blocks if buffer full
+            println!("Sent {}", i);
+        }
+    });
+
+    thread::sleep(std::time::Duration::from_millis(500));
+    for received in rx {
+        println!("Received: {}", received);
+        thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+```
+
+---
+
+## Thread Pool Patterns
+
+### Using rayon for Parallel Iteration
+```rust
+use rayon::prelude::*;
+
+fn parallel_map() {
+    let numbers: Vec<i32> = (0..1000).collect();
+
+    let squares: Vec<i32> = numbers
+        .par_iter()  // parallel iterator
+        .map(|x| x * x)
+        .collect();
+
+    println!("Processed {} items", squares.len());
+}
+
+fn parallel_filter_map() {
+    let data: Vec<String> = get_data();
+
+    let results: Vec<_> = data
+        .par_iter()
+        .filter(|s| !s.is_empty())
+        .map(|s| expensive_process(s))
+        .collect();
+}
+```
+
+### Custom Thread Pool with crossbeam
+```rust
+use crossbeam::channel;
+use std::thread;
+
+fn custom_pool(num_workers: usize) {
+    let (tx, rx) = channel::bounded::<Box<dyn FnOnce() + Send>>(100);
+
+    // Spawn workers
+    let workers: Vec<_> = (0..num_workers)
+        .map(|_| {
+            let rx = rx.clone();
+            thread::spawn(move || {
+                while let Ok(task) = rx.recv() {
+                    task();
+                }
+            })
+        })
+        .collect();
+
+    // Submit tasks
+    for i in 0..100 {
+        tx.send(Box::new(move || {
+            println!("Processing task {}", i);
+        })).unwrap();
+    }
+
+    drop(tx);  // Close channel
+
+    for worker in workers {
+        worker.join().unwrap();
+    }
+}
+```
+
+---
+
+## Synchronization Primitives
+
+### Barrier (Wait for All)
+```rust
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+fn barrier_example() {
+    let barrier = Arc::new(Barrier::new(3));
+    let mut handles = vec![];
+
+    for i in 0..3 {
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            println!("Thread {} starting", i);
+            thread::sleep(std::time::Duration::from_millis(i as u64 * 100));
+
+            barrier.wait();  // All threads wait here
+
+            println!("Thread {} after barrier", i);
+        }));
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+```
+
+### Condvar (Condition Variable)
+```rust
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+
+fn condvar_example() {
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let pair_clone = Arc::clone(&pair);
+
+    // Waiter thread
+    let waiter = thread::spawn(move || {
+        let (lock, cvar) = &*pair_clone;
+        let mut started = lock.lock().unwrap();
+        while !*started {
+            started = cvar.wait(started).unwrap();
+        }
+        println!("Waiter: condition met!");
+    });
+
+    // Notifier
+    thread::sleep(std::time::Duration::from_millis(100));
+    let (lock, cvar) = &*pair;
+    {
+        let mut started = lock.lock().unwrap();
+        *started = true;
+    }
+    cvar.notify_one();
+
+    waiter.join().unwrap();
+}
+```
+
+### Once (One-Time Initialization)
+```rust
+use std::sync::Once;
+
+static INIT: Once = Once::new();
+static mut CONFIG: Option<Config> = None;
+
+fn get_config() -> &'static Config {
+    INIT.call_once(|| {
+        unsafe {
+            CONFIG = Some(load_config());
+        }
+    });
+    unsafe { CONFIG.as_ref().unwrap() }
+}
+
+// Better: use once_cell or lazy_static
+use once_cell::sync::Lazy;
+
+static CONFIG: Lazy<Config> = Lazy::new(|| {
+    load_config()
+});
+```
+
+---
+
+## Error Handling in Threads
+
+### Handling Panics
+```rust
+use std::thread;
+
+fn handle_panic() {
+    let handle = thread::spawn(|| {
+        panic!("Thread panicked!");
+    });
+
+    match handle.join() {
+        Ok(_) => println!("Thread completed successfully"),
+        Err(e) => {
+            if let Some(s) = e.downcast_ref::<&str>() {
+                println!("Thread panicked with: {}", s);
+            } else if let Some(s) = e.downcast_ref::<String>() {
+                println!("Thread panicked with: {}", s);
+            } else {
+                println!("Thread panicked with unknown error");
+            }
+        }
+    }
+}
+```
+
+### Catching Panics
+```rust
+use std::panic;
+
+fn catch_panic() {
+    let result = panic::catch_unwind(|| {
+        risky_operation()
+    });
+
+    match result {
+        Ok(value) => println!("Success: {:?}", value),
+        Err(_) => println!("Operation panicked, continuing..."),
+    }
+}
+```

--- a/.agents/skills/m07-concurrency/patterns/async-patterns.md
+++ b/.agents/skills/m07-concurrency/patterns/async-patterns.md
@@ -1,0 +1,409 @@
+# Async Patterns in Rust
+
+## Task Spawning
+
+### Basic Spawn
+```rust
+use tokio::task;
+
+#[tokio::main]
+async fn main() {
+    // Spawn a task that runs concurrently
+    let handle = task::spawn(async {
+        expensive_computation().await
+    });
+
+    // Do other work while task runs
+    other_work().await;
+
+    // Wait for result
+    let result = handle.await.unwrap();
+}
+```
+
+### Spawn with Shared State
+```rust
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+async fn process_with_state() {
+    let state = Arc::new(Mutex::new(vec![]));
+
+    let handles: Vec<_> = (0..10)
+        .map(|i| {
+            let state = Arc::clone(&state);
+            tokio::spawn(async move {
+                let mut guard = state.lock().await;
+                guard.push(i);
+            })
+        })
+        .collect();
+
+    // Wait for all tasks
+    for handle in handles {
+        handle.await.unwrap();
+    }
+}
+```
+
+---
+
+## Select Pattern
+
+### Racing Multiple Futures
+```rust
+use tokio::select;
+use tokio::time::{sleep, Duration};
+
+async fn first_response() {
+    select! {
+        result = fetch_from_server_a() => {
+            println!("A responded first: {:?}", result);
+        }
+        result = fetch_from_server_b() => {
+            println!("B responded first: {:?}", result);
+        }
+    }
+}
+```
+
+### Select with Timeout
+```rust
+use tokio::time::timeout;
+
+async fn with_timeout() -> Result<Data, Error> {
+    select! {
+        result = fetch_data() => result,
+        _ = sleep(Duration::from_secs(5)) => {
+            Err(Error::Timeout)
+        }
+    }
+}
+
+// Or use timeout directly
+async fn with_timeout2() -> Result<Data, Error> {
+    timeout(Duration::from_secs(5), fetch_data())
+        .await
+        .map_err(|_| Error::Timeout)?
+}
+```
+
+### Select with Channel
+```rust
+use tokio::sync::mpsc;
+
+async fn process_messages(mut rx: mpsc::Receiver<Message>) {
+    loop {
+        select! {
+            Some(msg) = rx.recv() => {
+                handle_message(msg).await;
+            }
+            _ = tokio::signal::ctrl_c() => {
+                println!("Shutting down...");
+                break;
+            }
+        }
+    }
+}
+```
+
+---
+
+## Channel Patterns
+
+### MPSC (Multi-Producer, Single-Consumer)
+```rust
+use tokio::sync::mpsc;
+
+async fn producer_consumer() {
+    let (tx, mut rx) = mpsc::channel(100);
+
+    // Spawn producers
+    for i in 0..3 {
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            tx.send(format!("Message from {}", i)).await.unwrap();
+        });
+    }
+
+    // Drop original sender so channel closes
+    drop(tx);
+
+    // Consume
+    while let Some(msg) = rx.recv().await {
+        println!("Received: {}", msg);
+    }
+}
+```
+
+### Oneshot (Single-Shot Response)
+```rust
+use tokio::sync::oneshot;
+
+async fn request_response() {
+    let (tx, rx) = oneshot::channel();
+
+    tokio::spawn(async move {
+        let result = compute_something().await;
+        tx.send(result).unwrap();
+    });
+
+    // Wait for response
+    let response = rx.await.unwrap();
+}
+```
+
+### Broadcast (Multi-Consumer)
+```rust
+use tokio::sync::broadcast;
+
+async fn pub_sub() {
+    let (tx, _) = broadcast::channel(16);
+
+    // Subscribe multiple consumers
+    let mut rx1 = tx.subscribe();
+    let mut rx2 = tx.subscribe();
+
+    tokio::spawn(async move {
+        while let Ok(msg) = rx1.recv().await {
+            println!("Consumer 1: {}", msg);
+        }
+    });
+
+    tokio::spawn(async move {
+        while let Ok(msg) = rx2.recv().await {
+            println!("Consumer 2: {}", msg);
+        }
+    });
+
+    // Publish
+    tx.send("Hello").unwrap();
+}
+```
+
+### Watch (Single Latest Value)
+```rust
+use tokio::sync::watch;
+
+async fn config_updates() {
+    let (tx, mut rx) = watch::channel(Config::default());
+
+    // Consumer watches for changes
+    tokio::spawn(async move {
+        while rx.changed().await.is_ok() {
+            let config = rx.borrow();
+            apply_config(&config);
+        }
+    });
+
+    // Update config
+    tx.send(Config::new()).unwrap();
+}
+```
+
+---
+
+## Structured Concurrency
+
+### JoinSet for Task Groups
+```rust
+use tokio::task::JoinSet;
+
+async fn parallel_fetch(urls: Vec<String>) -> Vec<Result<Response, Error>> {
+    let mut set = JoinSet::new();
+
+    for url in urls {
+        set.spawn(async move {
+            fetch(&url).await
+        });
+    }
+
+    let mut results = vec![];
+    while let Some(res) = set.join_next().await {
+        results.push(res.unwrap());
+    }
+    results
+}
+```
+
+### Scoped Tasks (no 'static)
+```rust
+// Using tokio-scoped or async-scoped crate
+use async_scoped::TokioScope;
+
+async fn scoped_example(data: &[u32]) {
+    let results = TokioScope::scope_and_block(|scope| {
+        for item in data {
+            scope.spawn(async move {
+                process(item).await
+            });
+        }
+    });
+}
+```
+
+---
+
+## Cancellation Patterns
+
+### Using CancellationToken
+```rust
+use tokio_util::sync::CancellationToken;
+
+async fn cancellable_task(token: CancellationToken) {
+    loop {
+        select! {
+            _ = token.cancelled() => {
+                println!("Task cancelled");
+                break;
+            }
+            _ = do_work() => {
+                // Continue working
+            }
+        }
+    }
+}
+
+async fn main_with_cancellation() {
+    let token = CancellationToken::new();
+    let task_token = token.clone();
+
+    let handle = tokio::spawn(cancellable_task(task_token));
+
+    // Cancel after some condition
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    token.cancel();
+
+    handle.await.unwrap();
+}
+```
+
+### Graceful Shutdown
+```rust
+async fn serve_with_shutdown(shutdown: impl Future) {
+    let server = TcpListener::bind("0.0.0.0:8080").await.unwrap();
+
+    loop {
+        select! {
+            Ok((socket, _)) = server.accept() => {
+                tokio::spawn(handle_connection(socket));
+            }
+            _ = &mut shutdown => {
+                println!("Shutting down...");
+                break;
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c().await.unwrap();
+    };
+
+    serve_with_shutdown(ctrl_c).await;
+}
+```
+
+---
+
+## Backpressure Patterns
+
+### Bounded Channels
+```rust
+use tokio::sync::mpsc;
+
+async fn with_backpressure() {
+    // Buffer of 10 - producers will wait if full
+    let (tx, mut rx) = mpsc::channel(10);
+
+    let producer = tokio::spawn(async move {
+        for i in 0..1000 {
+            // This will wait if channel is full
+            tx.send(i).await.unwrap();
+        }
+    });
+
+    let consumer = tokio::spawn(async move {
+        while let Some(item) = rx.recv().await {
+            // Slow consumer
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            process(item);
+        }
+    });
+
+    let _ = tokio::join!(producer, consumer);
+}
+```
+
+### Semaphore for Rate Limiting
+```rust
+use tokio::sync::Semaphore;
+use std::sync::Arc;
+
+async fn rate_limited_requests(urls: Vec<String>) {
+    let semaphore = Arc::new(Semaphore::new(10));  // max 10 concurrent
+
+    let handles: Vec<_> = urls
+        .into_iter()
+        .map(|url| {
+            let sem = Arc::clone(&semaphore);
+            tokio::spawn(async move {
+                let _permit = sem.acquire().await.unwrap();
+                fetch(&url).await
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+}
+```
+
+---
+
+## Error Handling in Async
+
+### Propagating Errors
+```rust
+async fn fetch_and_parse(url: &str) -> Result<Data, Error> {
+    let response = fetch(url).await?;
+    let data = parse(response).await?;
+    Ok(data)
+}
+```
+
+### Handling Task Panics
+```rust
+async fn robust_spawn() {
+    let handle = tokio::spawn(async {
+        risky_operation().await
+    });
+
+    match handle.await {
+        Ok(result) => println!("Success: {:?}", result),
+        Err(e) if e.is_panic() => {
+            println!("Task panicked: {:?}", e);
+        }
+        Err(e) => {
+            println!("Task cancelled: {:?}", e);
+        }
+    }
+}
+```
+
+### Try-Join for Multiple Results
+```rust
+use tokio::try_join;
+
+async fn fetch_all() -> Result<(A, B, C), Error> {
+    // All must succeed, or first error returned
+    try_join!(
+        fetch_a(),
+        fetch_b(),
+        fetch_c(),
+    )
+}
+```

--- a/.agents/skills/m07-concurrency/patterns/common-errors.md
+++ b/.agents/skills/m07-concurrency/patterns/common-errors.md
@@ -1,0 +1,331 @@
+# Common Concurrency Errors & Fixes
+
+## E0277: Cannot Send Between Threads
+
+### Error Pattern
+```rust
+use std::rc::Rc;
+
+let data = Rc::new(42);
+std::thread::spawn(move || {
+    println!("{}", data);  // ERROR: Rc<i32> cannot be sent between threads
+});
+```
+
+### Fix Options
+
+**Option 1: Use Arc instead**
+```rust
+use std::sync::Arc;
+
+let data = Arc::new(42);
+let data_clone = Arc::clone(&data);
+std::thread::spawn(move || {
+    println!("{}", data_clone);  // OK: Arc is Send
+});
+```
+
+**Option 2: Move owned data**
+```rust
+let data = 42;  // i32 is Copy and Send
+std::thread::spawn(move || {
+    println!("{}", data);  // OK
+});
+```
+
+---
+
+## E0277: Cannot Share Between Threads (Not Sync)
+
+### Error Pattern
+```rust
+use std::cell::RefCell;
+use std::sync::Arc;
+
+let data = Arc::new(RefCell::new(42));
+// ERROR: RefCell is not Sync
+```
+
+### Fix Options
+
+**Option 1: Use Mutex for thread-safe interior mutability**
+```rust
+use std::sync::{Arc, Mutex};
+
+let data = Arc::new(Mutex::new(42));
+let data_clone = Arc::clone(&data);
+std::thread::spawn(move || {
+    let mut guard = data_clone.lock().unwrap();
+    *guard += 1;
+});
+```
+
+**Option 2: Use RwLock for read-heavy workloads**
+```rust
+use std::sync::{Arc, RwLock};
+
+let data = Arc::new(RwLock::new(42));
+let data_clone = Arc::clone(&data);
+std::thread::spawn(move || {
+    let guard = data_clone.read().unwrap();
+    println!("{}", *guard);
+});
+```
+
+---
+
+## Deadlock Patterns
+
+### Pattern 1: Lock Ordering Deadlock
+```rust
+// DANGER: potential deadlock
+use std::sync::{Arc, Mutex};
+
+let a = Arc::new(Mutex::new(1));
+let b = Arc::new(Mutex::new(2));
+
+// Thread 1: locks a then b
+let a1 = Arc::clone(&a);
+let b1 = Arc::clone(&b);
+std::thread::spawn(move || {
+    let _a = a1.lock().unwrap();
+    let _b = b1.lock().unwrap();  // waits for b
+});
+
+// Thread 2: locks b then a (opposite order!)
+let a2 = Arc::clone(&a);
+let b2 = Arc::clone(&b);
+std::thread::spawn(move || {
+    let _b = b2.lock().unwrap();
+    let _a = a2.lock().unwrap();  // waits for a - DEADLOCK
+});
+```
+
+### Fix: Consistent Lock Ordering
+```rust
+// SAFE: always lock in same order (a before b)
+std::thread::spawn(move || {
+    let _a = a1.lock().unwrap();
+    let _b = b1.lock().unwrap();
+});
+
+std::thread::spawn(move || {
+    let _a = a2.lock().unwrap();  // same order
+    let _b = b2.lock().unwrap();
+});
+```
+
+### Pattern 2: Self-Deadlock
+```rust
+// DANGER: locking same mutex twice
+let m = Mutex::new(42);
+let _g1 = m.lock().unwrap();
+let _g2 = m.lock().unwrap();  // DEADLOCK on std::Mutex
+
+// FIX: use parking_lot::ReentrantMutex if needed
+// or restructure code to avoid double locking
+```
+
+---
+
+## Mutex Guard Across Await
+
+### Error Pattern
+```rust
+use std::sync::Mutex;
+use tokio::time::sleep;
+
+async fn bad_async() {
+    let m = Mutex::new(42);
+    let guard = m.lock().unwrap();
+    sleep(Duration::from_secs(1)).await;  // WARNING: guard held across await
+    println!("{}", *guard);
+}
+```
+
+### Fix Options
+
+**Option 1: Scope the lock**
+```rust
+async fn good_async() {
+    let m = Mutex::new(42);
+    let value = {
+        let guard = m.lock().unwrap();
+        *guard  // copy value
+    };  // guard dropped here
+    sleep(Duration::from_secs(1)).await;
+    println!("{}", value);
+}
+```
+
+**Option 2: Use tokio::sync::Mutex**
+```rust
+use tokio::sync::Mutex;
+
+async fn good_async() {
+    let m = Mutex::new(42);
+    let guard = m.lock().await;  // async lock
+    sleep(Duration::from_secs(1)).await;  // OK with tokio::Mutex
+    println!("{}", *guard);
+}
+```
+
+---
+
+## Data Race Prevention
+
+### Pattern: Missing Synchronization
+```rust
+// This WON'T compile - Rust prevents data races
+use std::sync::Arc;
+
+let data = Arc::new(0);
+let d1 = Arc::clone(&data);
+let d2 = Arc::clone(&data);
+
+std::thread::spawn(move || {
+    // *d1 += 1;  // ERROR: cannot mutate through Arc
+});
+
+std::thread::spawn(move || {
+    // *d2 += 1;  // ERROR: cannot mutate through Arc
+});
+```
+
+### Fix: Add Synchronization
+```rust
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicI32, Ordering};
+
+// Option 1: Mutex
+let data = Arc::new(Mutex::new(0));
+let d1 = Arc::clone(&data);
+std::thread::spawn(move || {
+    *d1.lock().unwrap() += 1;
+});
+
+// Option 2: Atomic (for simple types)
+let data = Arc::new(AtomicI32::new(0));
+let d1 = Arc::clone(&data);
+std::thread::spawn(move || {
+    d1.fetch_add(1, Ordering::SeqCst);
+});
+```
+
+---
+
+## Channel Errors
+
+### Disconnected Channel
+```rust
+use std::sync::mpsc;
+
+let (tx, rx) = mpsc::channel();
+drop(tx);  // sender dropped
+match rx.recv() {
+    Ok(v) => println!("{}", v),
+    Err(_) => println!("channel disconnected"),  // this happens
+}
+```
+
+### Fix: Handle Disconnection
+```rust
+// Use try_recv for non-blocking
+loop {
+    match rx.try_recv() {
+        Ok(msg) => handle(msg),
+        Err(TryRecvError::Empty) => continue,
+        Err(TryRecvError::Disconnected) => break,
+    }
+}
+
+// Or iterate (stops on disconnect)
+for msg in rx {
+    handle(msg);
+}
+```
+
+---
+
+## Async Common Errors
+
+### Forgetting to Spawn
+```rust
+// WRONG: future not polled
+async fn fetch_data() -> Result<Data, Error> { ... }
+
+fn process() {
+    fetch_data();  // does nothing! returns Future that's dropped
+}
+
+// RIGHT: await or spawn
+async fn process() {
+    let data = fetch_data().await;  // awaited
+}
+
+fn process_sync() {
+    tokio::spawn(fetch_data());  // spawned
+}
+```
+
+### Blocking in Async Context
+```rust
+// WRONG: blocks the executor
+async fn bad() {
+    std::thread::sleep(Duration::from_secs(1));  // blocks!
+    std::fs::read_to_string("file.txt").unwrap();  // blocks!
+}
+
+// RIGHT: use async versions
+async fn good() {
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::fs::read_to_string("file.txt").await.unwrap();
+}
+
+// Or spawn_blocking for CPU-bound work
+async fn compute() {
+    let result = tokio::task::spawn_blocking(|| {
+        heavy_computation()  // OK to block here
+    }).await.unwrap();
+}
+```
+
+---
+
+## Thread Panic Handling
+
+### Unhandled Panic
+```rust
+let handle = std::thread::spawn(|| {
+    panic!("oops");
+});
+
+// Main thread continues, might miss the error
+handle.join().unwrap();  // panics here
+```
+
+### Proper Error Handling
+```rust
+let handle = std::thread::spawn(|| {
+    panic!("oops");
+});
+
+match handle.join() {
+    Ok(result) => println!("Success: {:?}", result),
+    Err(e) => println!("Thread panicked: {:?}", e),
+}
+
+// For async: use catch_unwind
+use std::panic;
+
+async fn safe_task() {
+    let result = panic::catch_unwind(|| {
+        risky_operation()
+    });
+
+    match result {
+        Ok(v) => use_value(v),
+        Err(_) => log_error("task panicked"),
+    }
+}
+```

--- a/.agents/skills/m10-performance/SKILL.md
+++ b/.agents/skills/m10-performance/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: m10-performance
+description: "CRITICAL: Use for performance optimization. Triggers: performance, optimization, benchmark, profiling, flamegraph, criterion, slow, fast, allocation, cache, SIMD, make it faster, 性能优化, 基准测试"
+user-invocable: false
+---
+
+# Performance Optimization
+
+> **Layer 2: Design Choices**
+
+## Core Question
+
+**What's the bottleneck, and is optimization worth it?**
+
+Before optimizing:
+- Have you measured? (Don't guess)
+- What's the acceptable performance?
+- Will optimization add complexity?
+
+---
+
+## Performance Decision → Implementation
+
+| Goal | Design Choice | Implementation |
+|------|---------------|----------------|
+| Reduce allocations | Pre-allocate, reuse | `with_capacity`, object pools |
+| Improve cache | Contiguous data | `Vec`, `SmallVec` |
+| Parallelize | Data parallelism | `rayon`, threads |
+| Avoid copies | Zero-copy | References, `Cow<T>` |
+| Reduce indirection | Inline data | `smallvec`, arrays |
+
+---
+
+## Thinking Prompt
+
+Before optimizing:
+
+1. **Have you measured?**
+   - Profile first → flamegraph, perf
+   - Benchmark → criterion, cargo bench
+   - Identify actual hotspots
+
+2. **What's the priority?**
+   - Algorithm (10x-1000x improvement)
+   - Data structure (2x-10x)
+   - Allocation (2x-5x)
+   - Cache (1.5x-3x)
+
+3. **What's the trade-off?**
+   - Complexity vs speed
+   - Memory vs CPU
+   - Latency vs throughput
+
+---
+
+## Trace Up ↑
+
+To domain constraints (Layer 3):
+
+```
+"How fast does this need to be?"
+    ↑ Ask: What's the performance SLA?
+    ↑ Check: domain-* (latency requirements)
+    ↑ Check: Business requirements (acceptable response time)
+```
+
+| Question | Trace To | Ask |
+|----------|----------|-----|
+| Latency requirements | domain-* | What's acceptable response time? |
+| Throughput needs | domain-* | How many requests per second? |
+| Memory constraints | domain-* | What's the memory budget? |
+
+---
+
+## Trace Down ↓
+
+To implementation (Layer 1):
+
+```
+"Need to reduce allocations"
+    ↓ m01-ownership: Use references, avoid clone
+    ↓ m02-resource: Pre-allocate with_capacity
+
+"Need to parallelize"
+    ↓ m07-concurrency: Choose rayon or threads
+    ↓ m07-concurrency: Consider async for I/O-bound
+
+"Need cache efficiency"
+    ↓ Data layout: Prefer Vec over HashMap when possible
+    ↓ Access patterns: Sequential over random access
+```
+
+---
+
+## Quick Reference
+
+| Tool | Purpose |
+|------|---------|
+| `cargo bench` | Micro-benchmarks |
+| `criterion` | Statistical benchmarks |
+| `perf` / `flamegraph` | CPU profiling |
+| `heaptrack` | Allocation tracking |
+| `valgrind` / `cachegrind` | Cache analysis |
+
+## Optimization Priority
+
+```
+1. Algorithm choice     (10x - 1000x)
+2. Data structure       (2x - 10x)
+3. Allocation reduction (2x - 5x)
+4. Cache optimization   (1.5x - 3x)
+5. SIMD/Parallelism     (2x - 8x)
+```
+
+## Common Techniques
+
+| Technique | When | How |
+|-----------|------|-----|
+| Pre-allocation | Known size | `Vec::with_capacity(n)` |
+| Avoid cloning | Hot paths | Use references or `Cow<T>` |
+| Batch operations | Many small ops | Collect then process |
+| SmallVec | Usually small | `smallvec::SmallVec<[T; N]>` |
+| Inline buffers | Fixed-size data | Arrays over Vec |
+
+---
+
+## Common Mistakes
+
+| Mistake | Why Wrong | Better |
+|---------|-----------|--------|
+| Optimize without profiling | Wrong target | Profile first |
+| Benchmark in debug mode | Meaningless | Always `--release` |
+| Use LinkedList | Cache unfriendly | `Vec` or `VecDeque` |
+| Hidden `.clone()` | Unnecessary allocs | Use references |
+| Premature optimization | Wasted effort | Make it work first |
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Bad | Better |
+|--------------|---------|--------|
+| Clone to avoid lifetimes | Performance cost | Proper ownership |
+| Box everything | Indirection cost | Stack when possible |
+| HashMap for small sets | Overhead | Vec with linear search |
+| String concat in loop | O(n^2) | `String::with_capacity` or `format!` |
+
+---
+
+## Related Skills
+
+| When | See |
+|------|-----|
+| Reducing clones | m01-ownership |
+| Concurrency options | m07-concurrency |
+| Smart pointer choice | m02-resource |
+| Domain requirements | domain-* |

--- a/.agents/skills/m10-performance/patterns/optimization-guide.md
+++ b/.agents/skills/m10-performance/patterns/optimization-guide.md
@@ -1,0 +1,365 @@
+# Rust Performance Optimization Guide
+
+## Profiling First
+
+### Tools
+```bash
+# CPU profiling
+cargo install flamegraph
+cargo flamegraph --bin myapp
+
+# Memory profiling
+cargo install cargo-instruments  # macOS
+heaptrack ./target/release/myapp  # Linux
+
+# Benchmarking
+cargo bench  # with criterion
+
+# Cache analysis
+valgrind --tool=cachegrind ./target/release/myapp
+```
+
+### Criterion Benchmarks
+```rust
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn benchmark_parse(c: &mut Criterion) {
+    let input = "test data".repeat(1000);
+
+    c.bench_function("parse_v1", |b| {
+        b.iter(|| parse_v1(&input))
+    });
+
+    c.bench_function("parse_v2", |b| {
+        b.iter(|| parse_v2(&input))
+    });
+}
+
+criterion_group!(benches, benchmark_parse);
+criterion_main!(benches);
+```
+
+---
+
+## Common Optimizations
+
+### 1. Avoid Unnecessary Allocations
+
+```rust
+// BAD: allocates on every call
+fn to_uppercase(s: &str) -> String {
+    s.to_uppercase()
+}
+
+// GOOD: return Cow, allocate only if needed
+use std::borrow::Cow;
+
+fn to_uppercase(s: &str) -> Cow<'_, str> {
+    if s.chars().all(|c| c.is_uppercase()) {
+        Cow::Borrowed(s)
+    } else {
+        Cow::Owned(s.to_uppercase())
+    }
+}
+```
+
+### 2. Reuse Allocations
+
+```rust
+// BAD: creates new Vec each iteration
+for item in items {
+    let mut buffer = Vec::new();
+    process(&mut buffer, item);
+}
+
+// GOOD: reuse buffer
+let mut buffer = Vec::new();
+for item in items {
+    buffer.clear();
+    process(&mut buffer, item);
+}
+```
+
+### 3. Use Appropriate Collections
+
+| Need | Collection | Notes |
+|------|------------|-------|
+| Sequential access | `Vec<T>` | Best cache locality |
+| Random access by key | `HashMap<K, V>` | O(1) lookup |
+| Ordered keys | `BTreeMap<K, V>` | O(log n) lookup |
+| Small sets (<20) | `Vec<T>` + linear search | Lower overhead |
+| FIFO queue | `VecDeque<T>` | O(1) push/pop both ends |
+
+### 4. Pre-allocate Capacity
+
+```rust
+// BAD: many reallocations
+let mut v = Vec::new();
+for i in 0..10000 {
+    v.push(i);
+}
+
+// GOOD: single allocation
+let mut v = Vec::with_capacity(10000);
+for i in 0..10000 {
+    v.push(i);
+}
+```
+
+---
+
+## String Optimization
+
+### Avoid String Concatenation in Loops
+
+```rust
+// BAD: O(n²) allocations
+let mut result = String::new();
+for s in strings {
+    result = result + &s;
+}
+
+// GOOD: O(n) with push_str
+let mut result = String::new();
+for s in strings {
+    result.push_str(&s);
+}
+
+// BETTER: pre-calculate capacity
+let total_len: usize = strings.iter().map(|s| s.len()).sum();
+let mut result = String::with_capacity(total_len);
+for s in strings {
+    result.push_str(&s);
+}
+
+// BEST: use join for simple cases
+let result = strings.join("");
+```
+
+### Use &str When Possible
+
+```rust
+// BAD: requires allocation
+fn greet(name: String) {
+    println!("Hello, {}", name);
+}
+
+// GOOD: borrows, no allocation
+fn greet(name: &str) {
+    println!("Hello, {}", name);
+}
+
+// Works with both:
+greet("world");                    // &str
+greet(&String::from("world"));     // &String coerces to &str
+```
+
+---
+
+## Iterator Optimization
+
+### Use Iterators Over Indexing
+
+```rust
+// BAD: bounds checking on each access
+let mut sum = 0;
+for i in 0..vec.len() {
+    sum += vec[i];
+}
+
+// GOOD: no bounds checking
+let sum: i32 = vec.iter().sum();
+
+// GOOD: when index needed
+for (i, item) in vec.iter().enumerate() {
+    // ...
+}
+```
+
+### Lazy Evaluation
+
+```rust
+// Iterators are lazy - computation happens at collect
+let result: Vec<_> = data
+    .iter()
+    .filter(|x| x.is_valid())
+    .map(|x| x.process())
+    .take(10)  // stop after 10 items
+    .collect();
+```
+
+### Avoid Collecting When Not Needed
+
+```rust
+// BAD: unnecessary intermediate allocation
+let filtered: Vec<_> = items.iter().filter(|x| x.valid).collect();
+let count = filtered.len();
+
+// GOOD: no allocation
+let count = items.iter().filter(|x| x.valid).count();
+```
+
+---
+
+## Parallelism with Rayon
+
+```rust
+use rayon::prelude::*;
+
+// Sequential
+let sum: i32 = (0..1_000_000).map(|x| x * x).sum();
+
+// Parallel (automatic work stealing)
+let sum: i32 = (0..1_000_000).into_par_iter().map(|x| x * x).sum();
+
+// Parallel with custom chunk size
+let results: Vec<_> = data
+    .par_chunks(1000)
+    .map(|chunk| process_chunk(chunk))
+    .collect();
+```
+
+---
+
+## Memory Layout
+
+### Use Appropriate Integer Sizes
+
+```rust
+// If values are small, use smaller types
+struct Item {
+    count: u8,      // 0-255, not u64
+    flags: u8,      // small enum
+    id: u32,        // if 4 billion is enough
+}
+```
+
+### Pack Structs Efficiently
+
+```rust
+// BAD: 24 bytes due to padding
+struct Bad {
+    a: u8,   // 1 byte + 7 padding
+    b: u64,  // 8 bytes
+    c: u8,   // 1 byte + 7 padding
+}
+
+// GOOD: 16 bytes (or use #[repr(packed)])
+struct Good {
+    b: u64,  // 8 bytes
+    a: u8,   // 1 byte
+    c: u8,   // 1 byte + 6 padding
+}
+```
+
+### Box Large Values
+
+```rust
+// Large enum variants waste space
+enum Message {
+    Quit,
+    Data([u8; 10000]),  // all variants are 10000+ bytes
+}
+
+// Better: box the large variant
+enum Message {
+    Quit,
+    Data(Box<[u8; 10000]>),  // variants are pointer-sized
+}
+```
+
+---
+
+## Async Performance
+
+### Avoid Blocking in Async
+
+```rust
+// BAD: blocks the executor
+async fn bad() {
+    std::thread::sleep(Duration::from_secs(1));  // blocking!
+    std::fs::read_to_string("file.txt").unwrap();  // blocking!
+}
+
+// GOOD: use async versions
+async fn good() {
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::fs::read_to_string("file.txt").await.unwrap();
+}
+
+// For CPU work: spawn_blocking
+async fn compute() -> i32 {
+    tokio::task::spawn_blocking(|| {
+        heavy_computation()
+    }).await.unwrap()
+}
+```
+
+### Buffer Async I/O
+
+```rust
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+// BAD: many small reads
+async fn bad(file: File) {
+    let mut byte = [0u8];
+    while file.read(&mut byte).await.unwrap() > 0 {
+        process(byte[0]);
+    }
+}
+
+// GOOD: buffered reading
+async fn good(file: File) {
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines();
+    while let Some(line) = lines.next_line().await.unwrap() {
+        process(&line);
+    }
+}
+```
+
+---
+
+## Release Build Optimization
+
+### Cargo.toml Settings
+
+```toml
+[profile.release]
+lto = true           # Link-time optimization
+codegen-units = 1    # Single codegen unit (slower compile, faster code)
+panic = "abort"      # Smaller binary, no unwinding
+strip = true         # Strip symbols
+
+[profile.release-fast]
+inherits = "release"
+opt-level = 3        # Maximum optimization
+
+[profile.release-small]
+inherits = "release"
+opt-level = "s"      # Optimize for size
+```
+
+### Compile-Time Assertions
+
+```rust
+// Zero runtime cost
+const _: () = assert!(std::mem::size_of::<MyStruct>() <= 64);
+```
+
+---
+
+## Checklist
+
+Before optimizing:
+- [ ] Profile to find actual bottlenecks
+- [ ] Have benchmarks to measure improvement
+- [ ] Consider if optimization is worth complexity
+
+Common wins:
+- [ ] Reduce allocations (Cow, reuse buffers)
+- [ ] Use appropriate collections
+- [ ] Pre-allocate with_capacity
+- [ ] Use iterators instead of indexing
+- [ ] Enable LTO for release builds
+- [ ] Use rayon for parallel workloads

--- a/.agents/skills/mermaid-diagrams/README.md
+++ b/.agents/skills/mermaid-diagrams/README.md
@@ -1,0 +1,244 @@
+# Mermaid Diagrams Skill
+
+A comprehensive guide for creating professional software diagrams using Mermaid's text-based syntax. This skill enables you to visualize system architecture, document code structure, model databases, and communicate technical concepts through diagrams.
+
+## Purpose
+
+Transform complex technical concepts into clear, maintainable diagrams that can be version-controlled alongside your code. Mermaid diagrams are rendered from simple text definitions, making them easy to update, review in pull requests, and maintain over time.
+
+## When to Use This Skill
+
+Use this skill when you need to:
+
+- **Document architecture** - Visualize system context, containers, components, and deployment
+- **Model domains** - Create domain models with entities, relationships, and behaviors
+- **Explain flows** - Show API interactions, user journeys, authentication sequences
+- **Design databases** - Document table relationships, keys, and schema structure
+- **Plan processes** - Map workflows, decision trees, algorithms, and pipelines
+- **Communicate designs** - Align stakeholders on technical decisions before coding
+
+### Trigger Phrases
+
+The skill activates when you mention:
+- "diagram", "visualize", "model", "map out", "show the flow"
+- "architecture diagram", "class diagram", "sequence diagram", "flowchart"
+- "database schema", "ERD", "entity relationship"
+- "system design", "data model", "domain model"
+
+## How It Works
+
+1. **Choose the right diagram type** based on what you want to communicate
+2. **Start with core elements** - entities, actors, or components
+3. **Add relationships** - connections, flows, interactions
+4. **Refine incrementally** - add details, styling, notes
+5. **Export or embed** - use in documentation, PRs, wikis
+
+Mermaid syntax is intuitive and follows a consistent pattern across all diagram types:
+
+```mermaid
+diagramType
+  definition content
+```
+
+## Key Features
+
+### 9 Diagram Types Supported
+
+1. **Class Diagrams** - Domain models, OOP design, entity relationships
+2. **Sequence Diagrams** - API flows, user interactions, temporal sequences
+3. **Flowcharts** - User journeys, processes, decision logic, pipelines
+4. **Entity Relationship Diagrams** - Database schemas, table relationships
+5. **C4 Architecture Diagrams** - System context, containers, components
+6. **State Diagrams** - State machines, lifecycle states
+7. **Git Graphs** - Branching strategies, version control flows
+8. **Gantt Charts** - Project timelines, scheduling
+9. **Pie/Bar Charts** - Data visualization, metrics
+
+### Advanced Capabilities
+
+- **Themes and styling** - Default, forest, dark, neutral, base themes
+- **Custom theming** - Configure colors, fonts, and layout
+- **Layout options** - Dagre (balanced) or ELK (advanced)
+- **Look options** - Classic or hand-drawn sketch style
+- **Subgraphs** - Group related elements for clarity
+- **Notes and comments** - Add context and explanations
+- **Alt/loop/opt blocks** - Complex flow control in sequences
+
+### Integration Support
+
+- **GitHub/GitLab** - Automatic rendering in Markdown files
+- **VS Code** - Preview with Markdown Mermaid extension
+- **Notion, Obsidian, Confluence** - Built-in support
+- **Export** - PNG, SVG, PDF via Mermaid Live or CLI
+
+## Usage Examples
+
+### Example 1: Document a Domain Model
+
+**When:** You're designing a video streaming platform and need to model core entities.
+
+```mermaid
+classDiagram
+    Title -- Genre
+    Title *-- Season
+    Title *-- Review
+    User --> Review : creates
+
+    class Title {
+        +string name
+        +int releaseYear
+        +play()
+    }
+
+    class Genre {
+        +string name
+        +getTopTitles()
+    }
+```
+
+### Example 2: Explain an API Authentication Flow
+
+**When:** You need to document how login works for frontend developers.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant API
+    participant Database
+
+    User->>API: POST /login
+    API->>Database: Query credentials
+    Database-->>API: Return user data
+    alt Valid credentials
+        API-->>User: 200 OK + JWT token
+    else Invalid credentials
+        API-->>User: 401 Unauthorized
+    end
+```
+
+### Example 3: Map a User Journey
+
+**When:** You're planning a feature and need to visualize the user flow.
+
+```mermaid
+flowchart TD
+    Start([User visits site]) --> Auth{Authenticated?}
+    Auth -->|No| Login[Show login page]
+    Auth -->|Yes| Dashboard[Show dashboard]
+    Login --> Creds[Enter credentials]
+    Creds --> Validate{Valid?}
+    Validate -->|Yes| Dashboard
+    Validate -->|No| Error[Show error]
+    Error --> Login
+```
+
+### Example 4: Design a Database Schema
+
+**When:** You're planning table relationships for a new feature.
+
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : includes
+
+    USER {
+        int id PK
+        string email UK
+        string name
+        datetime created_at
+    }
+
+    ORDER {
+        int id PK
+        int user_id FK
+        decimal total
+        datetime created_at
+    }
+```
+
+### Example 5: Visualize System Architecture (C4)
+
+**When:** You need to show how systems and external services interact.
+
+```mermaid
+C4Context
+    title System Context Diagram for E-commerce Platform
+
+    Person(customer, "Customer", "A user browsing and purchasing products")
+    System(webApp, "Web Application", "Provides product catalog and checkout")
+    System_Ext(payment, "Payment Gateway", "Processes payments")
+    System_Ext(email, "Email Service", "Sends order confirmations")
+
+    Rel(customer, webApp, "Browses products, places orders")
+    Rel(webApp, payment, "Processes payments", "HTTPS")
+    Rel(webApp, email, "Sends notifications", "SMTP")
+```
+
+## Getting Started
+
+1. **Identify what you need to communicate** - Architecture? Flow? Data model?
+2. **Choose the appropriate diagram type** - See "Diagram Type Selection Guide" in SKILL.md
+3. **Start simple** - Add core entities/components first
+4. **Add relationships** - Connect elements with appropriate connectors
+5. **Refine and style** - Add details, notes, and custom theming
+6. **Validate** - Test in [Mermaid Live Editor](https://mermaid.live)
+7. **Embed or export** - Use in Markdown, export as image, or integrate
+
+## Detailed References
+
+For comprehensive syntax and advanced features, see:
+
+- **[SKILL.md](SKILL.md)** - Quick start guide and diagram selection
+- **[references/class-diagrams.md](references/class-diagrams.md)** - Relationships, multiplicity, methods
+- **[references/sequence-diagrams.md](references/sequence-diagrams.md)** - Messages, activations, loops, alt blocks
+- **[references/flowcharts.md](references/flowcharts.md)** - Node shapes, decision logic, subgraphs
+- **[references/erd-diagrams.md](references/erd-diagrams.md)** - Cardinality, keys, attributes
+- **[references/c4-diagrams.md](references/c4-diagrams.md)** - Context, container, component levels
+- **[references/architecture-diagrams.md](references/architecture-diagrams.md)** - Cloud services, infrastructure, CI/CD deployments
+- **[references/advanced-features.md](references/advanced-features.md)** - Themes, styling, configuration
+
+## Best Practices
+
+1. **Start simple, iterate** - Begin with core elements, add complexity gradually
+2. **One diagram, one concept** - Keep diagrams focused and split large views
+3. **Use meaningful names** - Clear labels make diagrams self-documenting
+4. **Comment liberally** - Use `%%` to explain non-obvious relationships
+5. **Version control** - Store `.mmd` files with code, update as system evolves
+6. **Add context** - Include titles and notes explaining diagram purpose
+7. **Validate syntax** - Test in Mermaid Live before committing
+8. **Keep it readable** - Don't overcrowd; split into multiple diagrams if needed
+
+## Common Use Cases
+
+- **Onboarding** - Help new team members understand system structure
+- **Design reviews** - Visualize proposals before implementation
+- **Documentation** - Create living docs that evolve with code
+- **Architecture decisions** - Align stakeholders on technical choices
+- **Refactoring** - Plan restructuring with before/after diagrams
+- **API handoffs** - Document flows for frontend/backend coordination
+- **Database migrations** - Visualize schema changes
+
+## Tips for Success
+
+- **Test incrementally** - Validate syntax as you build to catch errors early
+- **Use consistent naming** - Match diagram names to code/database names
+- **Leverage GitHub rendering** - Diagrams appear automatically in `.md` files
+- **Export for presentations** - Use Mermaid Live or CLI for high-res exports
+- **Collaborate** - Diagrams are great for PR discussions and design docs
+- **Keep updated** - Update diagrams when code changes to prevent drift
+
+## Tools and Resources
+
+- **[Mermaid Live Editor](https://mermaid.live)** - Interactive editor with instant preview and export
+- **[Official Documentation](https://mermaid.js.org)** - Comprehensive syntax reference
+- **Mermaid CLI** - `npm install -g @mermaid-js/mermaid-cli` for batch exports
+- **VS Code Extension** - "Markdown Preview Mermaid Support" for live preview
+- **GitHub** - Native rendering in all `.md` files
+
+## Support
+
+For questions, syntax help, or advanced features, refer to:
+- SKILL.md for quick reference
+- Reference files in `references/` for detailed syntax
+- [Mermaid official docs](https://mermaid.js.org) for latest features

--- a/.agents/skills/mermaid-diagrams/SKILL.md
+++ b/.agents/skills/mermaid-diagrams/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: mermaid-diagrams
+description: Comprehensive guide for creating software diagrams using Mermaid syntax. Use when users need to create, visualize, or document software through diagrams including class diagrams (domain modeling, object-oriented design), sequence diagrams (application flows, API interactions, code execution), flowcharts (processes, algorithms, user journeys), entity relationship diagrams (database schemas), C4 architecture diagrams (system context, containers, components), state diagrams, git graphs, pie charts, gantt charts, or any other diagram type. Triggers include requests to "diagram", "visualize", "model", "map out", "show the flow", or when explaining system architecture, database design, code structure, or user/application flows.
+---
+
+# Mermaid Diagramming
+
+Create professional software diagrams using Mermaid's text-based syntax. Mermaid renders diagrams from simple text definitions, making diagrams version-controllable, easy to update, and maintainable alongside code.
+
+## Core Syntax Structure
+
+All Mermaid diagrams follow this pattern:
+
+```mermaid
+diagramType
+  definition content
+```
+
+**Key principles:**
+- First line declares diagram type (e.g., `classDiagram`, `sequenceDiagram`, `flowchart`)
+- Use `%%` for comments
+- Line breaks and indentation improve readability but aren't required
+- Unknown words break diagrams; parameters fail silently
+
+## Diagram Type Selection Guide
+
+**Choose the right diagram type:**
+
+1. **Class Diagrams** - Domain modeling, OOP design, entity relationships
+   - Domain-driven design documentation
+   - Object-oriented class structures
+   - Entity relationships and dependencies
+
+2. **Sequence Diagrams** - Temporal interactions, message flows
+   - API request/response flows
+   - User authentication flows
+   - System component interactions
+   - Method call sequences
+
+3. **Flowcharts** - Processes, algorithms, decision trees
+   - User journeys and workflows
+   - Business processes
+   - Algorithm logic
+   - Deployment pipelines
+
+4. **Entity Relationship Diagrams (ERD)** - Database schemas
+   - Table relationships
+   - Data modeling
+   - Schema design
+
+5. **C4 Diagrams** - Software architecture at multiple levels
+   - System Context (systems and users)
+   - Container (applications, databases, services)
+   - Component (internal structure)
+   - Code (class/interface level)
+
+6. **State Diagrams** - State machines, lifecycle states
+7. **Git Graphs** - Version control branching strategies
+8. **Gantt Charts** - Project timelines, scheduling
+9. **Pie/Bar Charts** - Data visualization
+
+## Quick Start Examples
+
+### Class Diagram (Domain Model)
+```mermaid
+classDiagram
+    Title -- Genre
+    Title *-- Season
+    Title *-- Review
+    User --> Review : creates
+
+    class Title {
+        +string name
+        +int releaseYear
+        +play()
+    }
+
+    class Genre {
+        +string name
+        +getTopTitles()
+    }
+```
+
+### Sequence Diagram (API Flow)
+```mermaid
+sequenceDiagram
+    participant User
+    participant API
+    participant Database
+
+    User->>API: POST /login
+    API->>Database: Query credentials
+    Database-->>API: Return user data
+    alt Valid credentials
+        API-->>User: 200 OK + JWT token
+    else Invalid credentials
+        API-->>User: 401 Unauthorized
+    end
+```
+
+### Flowchart (User Journey)
+```mermaid
+flowchart TD
+    Start([User visits site]) --> Auth{Authenticated?}
+    Auth -->|No| Login[Show login page]
+    Auth -->|Yes| Dashboard[Show dashboard]
+    Login --> Creds[Enter credentials]
+    Creds --> Validate{Valid?}
+    Validate -->|Yes| Dashboard
+    Validate -->|No| Error[Show error]
+    Error --> Login
+```
+
+### ERD (Database Schema)
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : includes
+
+    USER {
+        int id PK
+        string email UK
+        string name
+        datetime created_at
+    }
+
+    ORDER {
+        int id PK
+        int user_id FK
+        decimal total
+        datetime created_at
+    }
+```
+
+## Detailed References
+
+For in-depth guidance on specific diagram types, see:
+
+- **[references/class-diagrams.md](references/class-diagrams.md)** - Domain modeling, relationships (association, composition, aggregation, inheritance), multiplicity, methods/properties
+- **[references/sequence-diagrams.md](references/sequence-diagrams.md)** - Actors, participants, messages (sync/async), activations, loops, alt/opt/par blocks, notes
+- **[references/flowcharts.md](references/flowcharts.md)** - Node shapes, connections, decision logic, subgraphs, styling
+- **[references/erd-diagrams.md](references/erd-diagrams.md)** - Entities, relationships, cardinality, keys, attributes
+- **[references/c4-diagrams.md](references/c4-diagrams.md)** - System context, container, component diagrams, boundaries
+- **[references/architecture-diagrams.md](references/architecture-diagrams.md)** - Cloud services, infrastructure, CI/CD deployments
+- **[references/advanced-features.md](references/advanced-features.md)** - Themes, styling, configuration, layout options
+
+## Best Practices
+
+1. **Start Simple** - Begin with core entities/components, add details incrementally
+2. **Use Meaningful Names** - Clear labels make diagrams self-documenting
+3. **Comment Extensively** - Use `%%` comments to explain complex relationships
+4. **Keep Focused** - One diagram per concept; split large diagrams into multiple focused views
+5. **Version Control** - Store `.mmd` files alongside code for easy updates
+6. **Add Context** - Include titles and notes to explain diagram purpose
+7. **Iterate** - Refine diagrams as understanding evolves
+
+## Configuration and Theming
+
+Configure diagrams using frontmatter:
+
+```mermaid
+---
+config:
+  theme: base
+  themeVariables:
+    primaryColor: "#ff6b6b"
+---
+flowchart LR
+    A --> B
+```
+
+**Available themes:** default, forest, dark, neutral, base
+
+**Layout options:**
+- `layout: dagre` (default) - Classic balanced layout
+- `layout: elk` - Advanced layout for complex diagrams (requires integration)
+
+**Look options:**
+- `look: classic` - Traditional Mermaid style
+- `look: handDrawn` - Sketch-like appearance
+
+## Exporting and Rendering
+
+**Native support in:**
+- GitHub/GitLab - Automatically renders in Markdown
+- VS Code - With Markdown Mermaid extension
+- Notion, Obsidian, Confluence - Built-in support
+
+**Export options:**
+- [Mermaid Live Editor](https://mermaid.live) - Online editor with PNG/SVG export
+- Mermaid CLI - `npm install -g @mermaid-js/mermaid-cli` then `mmdc -i input.mmd -o output.png`
+- Docker - `docker run --rm -v $(pwd):/data minlag/mermaid-cli -i /data/input.mmd -o /data/output.png`
+
+## Common Pitfalls
+
+- **Breaking characters** - Avoid `{}` in comments, use proper escape sequences for special characters
+- **Syntax errors** - Misspellings break diagrams; validate syntax in Mermaid Live
+- **Overcomplexity** - Split complex diagrams into multiple focused views
+- **Missing relationships** - Document all important connections between entities
+
+## When to Create Diagrams
+
+**Always diagram when:**
+- Starting new projects or features
+- Documenting complex systems
+- Explaining architecture decisions
+- Designing database schemas
+- Planning refactoring efforts
+- Onboarding new team members
+
+**Use diagrams to:**
+- Align stakeholders on technical decisions
+- Document domain models collaboratively
+- Visualize data flows and system interactions
+- Plan before coding
+- Create living documentation that evolves with code

--- a/.agents/skills/mermaid-diagrams/references/advanced-features.md
+++ b/.agents/skills/mermaid-diagrams/references/advanced-features.md
@@ -1,0 +1,556 @@
+# Advanced Mermaid Features
+
+Advanced configuration, styling, theming, and other powerful features for creating professional diagrams.
+
+## Frontmatter Configuration
+
+Add YAML configuration at the top of diagrams:
+
+```mermaid
+---
+config:
+  theme: dark
+  themeVariables:
+    primaryColor: "#ff6b6b"
+    primaryTextColor: "#fff"
+    primaryBorderColor: "#333"
+    lineColor: "#666"
+    secondaryColor: "#4ecdc4"
+    tertiaryColor: "#ffe66d"
+---
+flowchart TD
+    A --> B
+```
+
+## Themes
+
+### Built-in Themes
+
+```mermaid
+---
+config:
+  theme: default
+---
+```
+
+**Available themes:**
+- `default` - Standard blue theme
+- `forest` - Green earth tones
+- `dark` - Dark mode friendly
+- `neutral` - Grayscale professional
+- `base` - Minimal base theme for customization
+
+### Theme Examples
+
+**Default Theme:**
+```mermaid
+---
+config:
+  theme: default
+---
+flowchart LR
+    A[Start] --> B[Process]
+    B --> C{Decision}
+    C -->|Yes| D[Action 1]
+    C -->|No| E[Action 2]
+```
+
+**Dark Theme:**
+```mermaid
+---
+config:
+  theme: dark
+---
+flowchart LR
+    A[Start] --> B[Process]
+    B --> C{Decision}
+```
+
+**Forest Theme:**
+```mermaid
+---
+config:
+  theme: forest
+---
+flowchart LR
+    A[Start] --> B[Process]
+```
+
+## Custom Theme Variables
+
+Override specific colors:
+
+```mermaid
+---
+config:
+  theme: base
+  themeVariables:
+    primaryColor: "#ff6b6b"
+    primaryTextColor: "#fff"
+    primaryBorderColor: "#d63031"
+    lineColor: "#74b9ff"
+    secondaryColor: "#00b894"
+    tertiaryColor: "#fdcb6e"
+    background: "#f0f0f0"
+    mainBkg: "#ffffff"
+    textColor: "#333333"
+    nodeBorder: "#333333"
+    clusterBkg: "#f9f9f9"
+    clusterBorder: "#666666"
+---
+flowchart TD
+    A --> B --> C
+```
+
+## Layout Options
+
+### Dagre Layout (Default)
+
+```mermaid
+---
+config:
+  layout: dagre
+---
+flowchart TD
+    A --> B
+```
+
+### ELK Layout (Advanced)
+
+For complex diagrams with better automatic layout:
+
+```mermaid
+---
+config:
+  layout: elk
+  elk:
+    mergeEdges: true
+    nodePlacementStrategy: BRANDES_KOEPF
+---
+flowchart TD
+    A --> B
+```
+
+**ELK node placement strategies:**
+- `SIMPLE` - Basic placement
+- `NETWORK_SIMPLEX` - Network optimization
+- `LINEAR_SEGMENTS` - Linear arrangement
+- `BRANDES_KOEPF` - Balanced (default)
+
+## Look Options
+
+### Classic Look
+
+Traditional Mermaid appearance:
+
+```mermaid
+---
+config:
+  look: classic
+---
+flowchart LR
+    A --> B --> C
+```
+
+### Hand-Drawn Look
+
+Sketch-like, informal style:
+
+```mermaid
+---
+config:
+  look: handDrawn
+---
+flowchart LR
+    A --> B --> C
+```
+
+## Complete Configuration Example
+
+```mermaid
+---
+config:
+  theme: base
+  look: handDrawn
+  layout: dagre
+  themeVariables:
+    primaryColor: "#ff6b6b"
+    primaryTextColor: "#fff"
+    primaryBorderColor: "#d63031"
+    lineColor: "#74b9ff"
+    secondaryColor: "#00b894"
+    tertiaryColor: "#fdcb6e"
+---
+flowchart TD
+    Start([Begin Process]) --> Input[Gather Data]
+    Input --> Process{Valid?}
+    Process -->|Yes| Store[(Save to DB)]
+    Process -->|No| Error[Show Error]
+    Store --> Notify[Send Notification]
+    Error --> Input
+    Notify --> End([Complete])
+```
+
+## Diagram-Specific Styling
+
+### Flowchart Styling
+
+**Class-based styling:**
+```mermaid
+flowchart TD
+    A[Normal]:::success
+    B[Warning]:::warning
+    C[Error]:::error
+    
+    classDef success fill:#00b894,stroke:#00a383,color:#fff
+    classDef warning fill:#fdcb6e,stroke:#e8b923,color:#333
+    classDef error fill:#ff6b6b,stroke:#ee5253,color:#fff
+    
+    A --> B --> C
+```
+
+**Node-specific styling:**
+```mermaid
+flowchart LR
+    A[Node A]
+    B[Node B]
+    C[Node C]
+    
+    style A fill:#ff6b6b,stroke:#333,stroke-width:4px
+    style B fill:#4ecdc4,stroke:#333,stroke-width:2px
+    style C fill:#ffe66d,stroke:#333,stroke-width:2px
+    
+    A --> B --> C
+```
+
+**Link styling:**
+```mermaid
+flowchart LR
+    A --> B
+    B --> C
+    C --> D
+    
+    linkStyle 0 stroke:#ff6b6b,stroke-width:4px
+    linkStyle 1 stroke:#4ecdc4,stroke-width:2px
+    linkStyle 2 stroke:#ffe66d,stroke-width:2px
+```
+
+### Sequence Diagram Styling
+
+```mermaid
+sequenceDiagram
+    participant A
+    participant B
+    participant C
+    
+    A->>B: Message 1
+    B->>C: Message 2
+    
+    Note over A,C: Styled note
+    
+    %%{init: {'theme':'forest'}}%%
+```
+
+### Class Diagram Styling
+
+```mermaid
+classDiagram
+    class User {
+        +String name
+        +login()
+    }
+    
+    class Admin {
+        +manageUsers()
+    }
+    
+    User <|-- Admin
+    
+    %%{init: {'theme':'dark'}}%%
+```
+
+## Directional Hints
+
+Control layout direction for specific nodes:
+
+```mermaid
+flowchart TB
+    A --> B
+    B --> C
+    B --> D
+    C --> E
+    D --> E
+    
+    %% This is a comment - helps organize complex diagrams
+```
+
+## Click Events and Links
+
+Add interactive elements:
+
+```mermaid
+flowchart LR
+    A[GitHub]
+    B[Documentation]
+    C[Live Demo]
+    
+    click A "https://github.com" "Go to GitHub"
+    click B "https://mermaid.js.org" "View Docs"
+    click C "https://mermaid.live" "Try Live Editor"
+    
+    A --> B --> C
+```
+
+## Tooltips
+
+Add hover information:
+
+```mermaid
+flowchart LR
+    A[Service A]
+    B[Service B]
+    
+    A -.->|REST API| B
+    
+    %% Tooltips are defined with links
+    link A: API Documentation @ https://api.example.com
+    link B: Service Dashboard @ https://dashboard.example.com
+```
+
+## Subgraph Styling
+
+```mermaid
+flowchart TB
+    subgraph Frontend
+        A[Web App]
+        B[Mobile App]
+    end
+    
+    subgraph Backend
+        C[API]
+        D[Database]
+    end
+    
+    A & B --> C
+    C --> D
+    
+    style Frontend fill:#e3f2fd,stroke:#2196f3,stroke-width:2px
+    style Backend fill:#fff3e0,stroke:#ff9800,stroke-width:2px
+```
+
+## Comments and Documentation
+
+```mermaid
+flowchart TD
+    %% This is a single-line comment
+    
+    %% Multi-line comments can be created
+    %% by using multiple comment lines
+    
+    A[Start]
+    B[Process]
+    C[End]
+    
+    %% Define relationships
+    A --> B
+    B --> C
+    
+    %% Add styling
+    style A fill:#90EE90
+    style C fill:#FFB6C1
+```
+
+## Complex Styling Example
+
+```mermaid
+flowchart TB
+    subgraph production[Production Environment]
+        direction LR
+        lb[Load Balancer]
+        
+        subgraph servers[Application Servers]
+            app1[Server 1]
+            app2[Server 2]
+            app3[Server 3]
+        end
+        
+        cache[(Redis Cache)]
+        db[(PostgreSQL)]
+    end
+    
+    subgraph monitoring[Monitoring]
+        logs[Log Aggregator]
+        metrics[Metrics Dashboard]
+    end
+    
+    users[Users] --> lb
+    lb --> app1 & app2 & app3
+    app1 & app2 & app3 --> cache
+    app1 & app2 & app3 --> db
+    app1 & app2 & app3 --> logs
+    logs --> metrics
+    
+    style production fill:#e8f5e9,stroke:#4caf50,stroke-width:3px
+    style servers fill:#fff3e0,stroke:#ff9800,stroke-width:2px
+    style monitoring fill:#e3f2fd,stroke:#2196f3,stroke-width:2px
+    
+    style lb fill:#ffeb3b,stroke:#fbc02d,stroke-width:2px
+    style cache fill:#ce93d8,stroke:#ab47bc,stroke-width:2px
+    style db fill:#ce93d8,stroke:#ab47bc,stroke-width:2px
+    
+    classDef serverClass fill:#81c784,stroke:#4caf50,stroke-width:2px,color:#000
+    class app1,app2,app3 serverClass
+    
+    linkStyle 0,1,2,3 stroke:#4caf50,stroke-width:2px
+    linkStyle 4,5,6,7,8,9 stroke:#ff9800,stroke-width:1px
+```
+
+## Responsive Sizing
+
+Use CSS to make diagrams responsive:
+
+```html
+<div style="max-width: 100%; overflow: auto;">
+    <pre class="mermaid">
+        flowchart LR
+            A --> B --> C
+    </pre>
+</div>
+```
+
+## SVG Export Options
+
+When exporting to SVG:
+
+```bash
+# Export with custom dimensions
+mmdc -i diagram.mmd -o output.svg -w 1920 -H 1080
+
+# Export with background color
+mmdc -i diagram.mmd -o output.svg -b "#ffffff"
+
+# Export with transparent background
+mmdc -i diagram.mmd -o output.svg -b "transparent"
+```
+
+## Best Practices for Advanced Features
+
+1. **Use themes consistently** - Pick one theme for related diagrams
+2. **Don't over-style** - Too many colors can reduce clarity
+3. **Test hand-drawn look** - Some diagrams work better with classic look
+4. **Use ELK for complex layouts** - When dagre creates crossed lines
+5. **Comment complex configurations** - Explain non-obvious styling choices
+6. **Keep it accessible** - Ensure sufficient color contrast
+7. **Test exports** - Verify diagrams render correctly in target format
+8. **Version control configs** - Track theme changes in your repository
+
+## Accessibility Considerations
+
+```mermaid
+---
+config:
+  theme: base
+  themeVariables:
+    primaryColor: "#0066cc"
+    primaryTextColor: "#ffffff"
+    primaryBorderColor: "#003d7a"
+    lineColor: "#333333"
+    background: "#ffffff"
+    mainBkg: "#f0f0f0"
+---
+flowchart TD
+    A[High Contrast Text] --> B[Clear Labels]
+    B --> C[Meaningful Colors]
+```
+
+**Accessibility tips:**
+- Use high contrast color combinations
+- Don't rely solely on color to convey meaning
+- Include descriptive text labels
+- Test with color blindness simulators
+- Consider dark mode alternatives
+
+## Performance Considerations
+
+For large diagrams:
+
+```mermaid
+---
+config:
+  layout: elk
+  elk:
+    mergeEdges: true
+---
+flowchart TD
+    %% ELK handles complex layouts better
+    %% Merge edges reduces visual clutter
+```
+
+**Performance tips:**
+- Use ELK layout for diagrams with >20 nodes
+- Enable edge merging for simplified connections
+- Split very large diagrams into multiple focused views
+- Consider using subgraphs to organize complexity
+- Limit styling to essential elements
+
+## Integration Examples
+
+### Markdown Files
+
+````markdown
+# System Architecture
+
+```mermaid
+flowchart LR
+    A --> B
+```
+````
+
+### HTML Files
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <script type="module">
+        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+        mermaid.initialize({ 
+            startOnLoad: true,
+            theme: 'dark',
+            look: 'handDrawn'
+        });
+    </script>
+</head>
+<body>
+    <pre class="mermaid">
+        flowchart LR
+            A --> B
+    </pre>
+</body>
+</html>
+```
+
+### React Components
+
+```jsx
+import React from 'react';
+import mermaid from 'mermaid';
+
+mermaid.initialize({
+    startOnLoad: true,
+    theme: 'forest'
+});
+
+function DiagramComponent() {
+    React.useEffect(() => {
+        mermaid.contentLoaded();
+    }, []);
+    
+    return (
+        <div className="mermaid">
+            flowchart LR
+                A --> B
+        </div>
+    );
+}
+```

--- a/.agents/skills/mermaid-diagrams/references/architecture-diagrams.md
+++ b/.agents/skills/mermaid-diagrams/references/architecture-diagrams.md
@@ -1,0 +1,192 @@
+# Architecture Diagrams Reference
+
+Architecture diagrams visualize cloud services, CI/CD deployments, and infrastructure relationships. Introduced in Mermaid v11.1.0.
+
+## Basic Syntax
+
+```mermaid
+architecture-beta
+    group public_api(cloud)[Public API]
+    service api1(server)[API Server] in public_api
+    service db(database)[Database]
+
+    api1:R --> L:db
+```
+
+## Building Blocks
+
+### Groups
+
+Group related services together:
+
+```
+group {groupId}({icon})[{title}] (in {parentId})?
+```
+
+```mermaid
+architecture-beta
+    group public_api(cloud)[Public API]
+    group private_api(cloud)[Private API] in public_api
+```
+
+### Services
+
+Declare services (nodes):
+
+```
+service {serviceId}({icon})[{title}] (in {parentId})?
+```
+
+```mermaid
+architecture-beta
+    service api(server)[API Server]
+    service db(database)[Database]
+    service cache(redis)[Cache] in api
+```
+
+### Edges
+
+Connect services with edges:
+
+```
+{serviceId}{{group}}?:{T|B|L|R} {<}?--{>}? {T|B|L|R}:{serviceId}{{group}}?
+```
+
+**Directions:** `T` (top), `B` (bottom), `L` (left), `R` (right)
+
+**Arrows:** `<` for incoming, `>` for outgoing
+
+```mermaid
+architecture-beta
+    service client(browser)[Client]
+    service api(server)[API]
+    service db(database)[Database]
+
+    client:B --> T:api
+    api:R --> L:db
+```
+
+### Junctions
+
+Create 4-way splits:
+
+```
+junction {junctionId} (in {parentId})?
+```
+
+```mermaid
+architecture-beta
+    service input(server)[Input]
+    service output1(server)[Output 1]
+    service output2(server)[Output 2]
+
+    junction j1
+
+    input:R --> L:j1
+    j1:T --> B:output1
+    j1:B --> T:output2
+```
+
+## Icons
+
+**Default icons:** `cloud`, `database`, `disk`, `internet`, `server`
+
+**Custom icons:** Use any of 200,000+ icons from iconify.design:
+
+```mermaid
+architecture-beta
+    service web(aws:ec2)[Web Server]
+    service storage(aws:s3)[Storage]
+```
+
+### Using @iconify-json Icon Packs
+
+Use npm icon packs with Mermaid CLI for a wide variety of technology logos:
+
+```bash
+npm install @iconify-json/logos @mermaid-js/mermaid-cli
+mmdc --iconPacks @iconify-json/logos -i ./diagram.mmd -o ./output.svg
+```
+
+Use icons with the `logos:` prefix:
+
+```mermaid
+architecture-beta
+    service web(logos:docker)[Docker Container]
+    service k8s(logos:kubernetes)[Kubernetes Cluster]
+    service aws(logos:aws)[AWS Services]
+    service github(logos:github)[GitHub Actions]
+
+    web:R --> L:k8s
+    k8s:R --> L:aws
+    web:R --> L:github
+```
+
+**Popular icon packs:**
+
+| Icon Pack                    | Description                                   | Install                            |
+| ---------------------------- | --------------------------------------------- | ---------------------------------- |
+| `@iconify-json/logos`        | Technology brands (Docker, AWS, GitHub, etc.) | `npm i @iconify-json/logos`        |
+| `@iconify-json/bi`           | Bootstrap icons                               | `npm i @iconify-json/bi`           |
+| `@iconify-json/mdi`          | Material Design icons                         | `npm i @iconify-json/mdi`          |
+| `@iconify-json/simple-icons` | Simple icons                                  | `npm i @iconify-json/simple-icons` |
+
+Usage: `pack:icon-name` (e.g., `logos:docker`, `mdi:database`)
+
+## Complex Example
+
+```mermaid
+architecture-beta
+    group internet(cloud)[Internet]
+    group private_vpc(cloud)[Private VPC]
+
+    service lb(load_balancer)[Load Balancer] in internet
+    service api1(api)[API Server 1] in private_vpc
+    service api2(api)[API Server 2] in private_vpc
+    service db(database)[Primary Database] in private_vpc
+    service replica(database)[Read Replica] in private_vpc
+
+    lb:R --> L:api1
+    lb:R --> L:api2
+    api1:R --> L:db
+    api2:R --> L:db
+    db:R --> L:replica
+```
+
+## Edge Patterns
+
+| Pattern              | Description               |
+| -------------------- | ------------------------- |
+| `A:R -- L:B`         | Horizontal edge           |
+| `A:T -- B:B`         | Vertical edge (90 degree) |
+| `A:R --> L:B`        | Edge with arrow           |
+| `A:R <--> L:B`       | Bidirectional edge        |
+| `A{group}:R --> L:B` | Edge from group boundary  |
+
+## Group Edges
+
+Connect groups using the `{group}` modifier:
+
+```mermaid
+architecture-beta
+    group frontend(cloud)[Frontend]
+    group backend(cloud)[Backend]
+
+    service client(browser)[Client] in frontend
+    service api(server)[API] in backend
+
+    client{group}:B --> T:api{group}
+```
+
+## Best Practices
+
+1. Group services by environment (public/private) or layer (frontend/backend)
+2. Use consistent icons for service types
+3. Label edges with protocols (HTTPS, TCP, etc.)
+4. Use junctions for fan-out patterns
+5. Keep diagrams focused; split complex architectures into multiple views
+
+## Reference
+
+- [Official Documentation](https://mermaid.js.org/syntax/architecture.html)
+- [Iconify Icons](https://iconify.design)

--- a/.agents/skills/mermaid-diagrams/references/c4-diagrams.md
+++ b/.agents/skills/mermaid-diagrams/references/c4-diagrams.md
@@ -1,0 +1,410 @@
+# C4 Model Diagrams
+
+The C4 model provides a hierarchical way to visualize software architecture at different levels of abstraction: Context, Containers, Components, and Code.
+
+## C4 Model Levels
+
+1. **System Context** - Shows the system and its users/external systems
+2. **Container** - Shows applications, databases, and services within the system
+3. **Component** - Shows internal structure of containers
+4. **Code** - Class diagrams showing implementation details (use regular class diagrams)
+
+## C4 Context Diagram
+
+Shows the big picture: your system and its relationships with users and external systems.
+
+### Basic Syntax
+
+```mermaid
+C4Context
+    title System Context for Banking System
+    
+    Person(customer, "Customer", "A banking customer")
+    System(banking, "Banking System", "Allows customers to manage accounts")
+    System_Ext(email, "Email System", "Sends emails")
+    
+    Rel(customer, banking, "Uses")
+    Rel(banking, email, "Sends emails via")
+```
+
+### Elements
+
+**People:**
+```mermaid
+C4Context
+    Person(user, "User", "Description")
+    Person_Ext(external, "External User", "Outside organization")
+```
+
+**Systems:**
+```mermaid
+C4Context
+    System(internal, "Internal System", "Description")
+    System_Ext(external, "External System", "Description")
+    SystemDb(database, "Database System", "Description")
+    SystemDb_Ext(external_db, "External DB", "Description")
+    SystemQueue(queue, "Message Queue", "Description")
+    SystemQueue_Ext(external_queue, "External Queue", "Description")
+```
+
+**Relationships:**
+```mermaid
+C4Context
+    Rel(from, to, "Label")
+    Rel(from, to, "Label", "Optional Technology")
+    BiRel(system1, system2, "Bidirectional")
+```
+
+### Comprehensive Context Example
+
+```mermaid
+C4Context
+    title System Context - E-Commerce Platform
+    
+    Person(customer, "Customer", "Shops online")
+    Person(admin, "Administrator", "Manages products and orders")
+    Person_Ext(delivery, "Delivery Personnel", "Delivers orders")
+    
+    System(ecommerce, "E-Commerce Platform", "Online shopping platform")
+    
+    System_Ext(payment, "Payment Gateway", "Processes payments")
+    System_Ext(email, "Email Service", "Sends notifications")
+    System_Ext(sms, "SMS Service", "Sends SMS alerts")
+    System_Ext(analytics, "Analytics Platform", "Tracks user behavior")
+    SystemQueue_Ext(shipping, "Shipping API", "Calculates shipping rates")
+    
+    Rel(customer, ecommerce, "Browses products, places orders")
+    Rel(admin, ecommerce, "Manages catalog, reviews orders")
+    Rel(delivery, ecommerce, "Updates delivery status")
+    
+    Rel(ecommerce, payment, "Processes payments via", "HTTPS/REST")
+    Rel(ecommerce, email, "Sends emails via", "SMTP")
+    Rel(ecommerce, sms, "Sends SMS via", "REST API")
+    Rel(ecommerce, analytics, "Tracks events", "JavaScript SDK")
+    Rel(ecommerce, shipping, "Gets shipping rates", "REST API")
+    
+    UpdateRelStyle(customer, ecommerce, $offsetX="-50", $offsetY="-30")
+    UpdateRelStyle(admin, ecommerce, $offsetX="50", $offsetY="-30")
+```
+
+## C4 Container Diagram
+
+Zooms into the system to show containers (applications, databases, services).
+
+### Basic Syntax
+
+```mermaid
+C4Container
+    title Container Diagram for Banking System
+    
+    Person(customer, "Customer")
+    
+    Container_Boundary(banking, "Banking System") {
+        Container(web, "Web Application", "React", "Delivers static content")
+        Container(api, "API Application", "Node.js", "Provides banking API")
+        ContainerDb(db, "Database", "PostgreSQL", "Stores account data")
+    }
+    
+    Rel(customer, web, "Uses", "HTTPS")
+    Rel(web, api, "Makes API calls", "HTTPS/JSON")
+    Rel(api, db, "Reads/writes", "SQL/TCP")
+```
+
+### Container Elements
+
+```mermaid
+C4Container
+    Container(app, "Application", "Technology", "Description")
+    ContainerDb(db, "Database", "PostgreSQL", "Description")
+    ContainerQueue(queue, "Queue", "RabbitMQ", "Description")
+    Container_Ext(external, "External Service", "Tech", "Description")
+```
+
+### Container Boundaries
+
+```mermaid
+C4Container
+    Container_Boundary(boundary_name, "Boundary Label") {
+        Container(app1, "App 1", "Tech")
+        Container(app2, "App 2", "Tech")
+    }
+```
+
+### Comprehensive Container Example
+
+```mermaid
+C4Container
+    title Container Diagram - E-Commerce Platform
+    
+    Person(customer, "Customer")
+    Person(admin, "Admin")
+    System_Ext(payment, "Payment Gateway")
+    System_Ext(email, "Email Service")
+    
+    Container_Boundary(frontend, "Frontend") {
+        Container(web, "Web App", "React", "Delivers UI")
+        Container(mobile, "Mobile App", "React Native", "Mobile UI")
+    }
+    
+    Container_Boundary(backend, "Backend Services") {
+        Container(api, "API Gateway", "Node.js/Express", "Routes requests")
+        Container(auth, "Auth Service", "Node.js", "Handles authentication")
+        Container(catalog, "Catalog Service", "Python/FastAPI", "Manages products")
+        Container(order, "Order Service", "Java/Spring", "Processes orders")
+        Container(notification, "Notification Service", "Node.js", "Sends notifications")
+    }
+    
+    Container_Boundary(data, "Data Layer") {
+        ContainerDb(postgres, "Main Database", "PostgreSQL", "Stores core data")
+        ContainerDb(mongo, "Product DB", "MongoDB", "Product catalog")
+        ContainerDb(redis, "Cache", "Redis", "Session & caching")
+        ContainerQueue(queue, "Message Queue", "RabbitMQ", "Async processing")
+    }
+    
+    Rel(customer, web, "Uses", "HTTPS")
+    Rel(customer, mobile, "Uses", "HTTPS")
+    Rel(admin, web, "Manages via", "HTTPS")
+    
+    Rel(web, api, "Makes calls", "HTTPS/JSON")
+    Rel(mobile, api, "Makes calls", "HTTPS/JSON")
+    
+    Rel(api, auth, "Authenticates", "gRPC")
+    Rel(api, catalog, "Gets products", "REST")
+    Rel(api, order, "Creates orders", "REST")
+    
+    Rel(auth, postgres, "Reads/writes users", "SQL")
+    Rel(catalog, mongo, "Reads/writes products", "MongoDB Protocol")
+    Rel(order, postgres, "Reads/writes orders", "SQL")
+    
+    Rel(auth, redis, "Stores sessions", "Redis Protocol")
+    Rel(api, redis, "Caches data", "Redis Protocol")
+    
+    Rel(order, queue, "Publishes events", "AMQP")
+    Rel(notification, queue, "Consumes events", "AMQP")
+    Rel(notification, email, "Sends via", "SMTP")
+    Rel(order, payment, "Processes payment", "HTTPS/REST")
+```
+
+## C4 Component Diagram
+
+Zooms into a container to show its internal components.
+
+### Basic Syntax
+
+```mermaid
+C4Component
+    title Component Diagram for API Application
+    
+    Container(web, "Web App", "React")
+    ContainerDb(db, "Database", "PostgreSQL")
+    System_Ext(email, "Email System")
+    
+    Container_Boundary(api, "API Application") {
+        Component(controller, "Controller", "Express Router", "Handles HTTP")
+        Component(service, "Business Logic", "Service Layer", "Core logic")
+        Component(repository, "Data Access", "Repository", "DB operations")
+        Component(emailClient, "Email Client", "Client", "Sends emails")
+    }
+    
+    Rel(web, controller, "Makes requests", "HTTPS")
+    Rel(controller, service, "Uses")
+    Rel(service, repository, "Uses")
+    Rel(repository, db, "Reads/writes", "SQL")
+    Rel(service, emailClient, "Sends emails via")
+    Rel(emailClient, email, "Sends", "SMTP")
+```
+
+### Comprehensive Component Example
+
+```mermaid
+C4Component
+    title Component Diagram - Order Service
+    
+    Container(api_gateway, "API Gateway", "Node.js")
+    ContainerDb(postgres, "Database", "PostgreSQL")
+    ContainerQueue(queue, "Message Queue", "RabbitMQ")
+    System_Ext(payment, "Payment Gateway")
+    System_Ext(inventory, "Inventory Service")
+    
+    Container_Boundary(order_service, "Order Service") {
+        Component(controller, "REST Controllers", "Spring MVC", "HTTP endpoints")
+        Component(order_logic, "Order Manager", "Service", "Order processing logic")
+        Component(payment_client, "Payment Client", "REST Client", "Payment integration")
+        Component(inventory_client, "Inventory Client", "REST Client", "Inventory integration")
+        Component(repository, "Order Repository", "JPA", "Database operations")
+        Component(event_publisher, "Event Publisher", "Component", "Publishes domain events")
+        Component(validator, "Order Validator", "Component", "Validates orders")
+    }
+    
+    Rel(api_gateway, controller, "Routes requests", "HTTPS/REST")
+    
+    Rel(controller, order_logic, "Delegates to")
+    Rel(controller, validator, "Validates with")
+    
+    Rel(order_logic, payment_client, "Processes payment")
+    Rel(order_logic, inventory_client, "Checks stock")
+    Rel(order_logic, repository, "Persists orders")
+    Rel(order_logic, event_publisher, "Publishes events")
+    
+    Rel(payment_client, payment, "Calls", "HTTPS/REST")
+    Rel(inventory_client, inventory, "Calls", "HTTPS/REST")
+    Rel(repository, postgres, "Reads/writes", "JDBC/SQL")
+    Rel(event_publisher, queue, "Publishes to", "AMQP")
+```
+
+## Microservices Architecture Example
+
+```mermaid
+C4Container
+    title Microservices Architecture - Streaming Platform
+    
+    Person(user, "User", "Platform user")
+    Person(creator, "Content Creator", "Uploads videos")
+    System_Ext(cdn, "CDN", "Delivers media")
+    System_Ext(storage, "Object Storage", "Stores videos")
+    System_Ext(transcoding, "Transcoding Service", "Processes videos")
+    
+    Container_Boundary(frontend, "Frontend Layer") {
+        Container(web, "Web Application", "Next.js", "Server-rendered UI")
+        Container(mobile, "Mobile Apps", "React Native", "iOS/Android apps")
+    }
+    
+    Container_Boundary(api_layer, "API Layer") {
+        Container(api_gateway, "API Gateway", "Kong", "Routing, auth, rate limiting")
+        Container(graphql, "GraphQL Gateway", "Apollo", "Unified API")
+    }
+    
+    Container_Boundary(services, "Microservices") {
+        Container(auth, "Auth Service", "Go", "Authentication & authorization")
+        Container(user, "User Service", "Node.js", "User profiles & preferences")
+        Container(video, "Video Service", "Python", "Video metadata & management")
+        Container(recommendation, "Recommendation Engine", "Python/ML", "Content recommendations")
+        Container(analytics, "Analytics Service", "Go", "View tracking & metrics")
+        Container(search, "Search Service", "Elasticsearch", "Content search")
+        Container(comment, "Comment Service", "Node.js", "Comments & discussions")
+    }
+    
+    Container_Boundary(data, "Data Layer") {
+        ContainerDb(user_db, "User Database", "PostgreSQL", "User data")
+        ContainerDb(video_db, "Video Database", "MongoDB", "Video metadata")
+        ContainerDb(analytics_db, "Analytics DB", "ClickHouse", "Analytics data")
+        ContainerDb(cache, "Cache Layer", "Redis Cluster", "Caching & sessions")
+        ContainerQueue(event_bus, "Event Bus", "Kafka", "Event streaming")
+        ContainerDb(search_index, "Search Index", "Elasticsearch", "Search data")
+    }
+    
+    Rel(user, web, "Uses", "HTTPS")
+    Rel(creator, web, "Uploads via", "HTTPS")
+    Rel(user, mobile, "Uses", "HTTPS")
+    
+    Rel(web, api_gateway, "API calls", "HTTPS/REST")
+    Rel(mobile, api_gateway, "API calls", "HTTPS/REST")
+    Rel(web, graphql, "Queries", "HTTPS/GraphQL")
+    
+    Rel(api_gateway, auth, "Authenticates", "gRPC")
+    Rel(graphql, video, "Gets videos", "gRPC")
+    Rel(graphql, user, "Gets users", "gRPC")
+    Rel(graphql, recommendation, "Gets recommendations", "gRPC")
+    
+    Rel(video, storage, "Stores videos", "S3 API")
+    Rel(video, transcoding, "Sends for transcoding", "REST")
+    Rel(video, cdn, "Publishes to", "API")
+    
+    Rel(auth, user_db, "Manages credentials", "SQL")
+    Rel(user, user_db, "Stores profiles", "SQL")
+    Rel(video, video_db, "Stores metadata", "MongoDB")
+    Rel(analytics, analytics_db, "Stores metrics", "SQL")
+    
+    Rel(auth, cache, "Sessions", "Redis")
+    Rel(video, cache, "Caches metadata", "Redis")
+    Rel(search, search_index, "Indexes & queries", "REST")
+    
+    Rel(video, event_bus, "Publishes VideoUploaded", "Kafka")
+    Rel(analytics, event_bus, "Publishes ViewStarted", "Kafka")
+    Rel(recommendation, event_bus, "Consumes events", "Kafka")
+    Rel(search, event_bus, "Consumes events", "Kafka")
+```
+
+## Best Practices
+
+1. **Use appropriate level** - Context for stakeholders, Container for architects, Component for developers
+2. **Keep it focused** - One system per Context diagram, one container per Component diagram
+3. **Show key relationships** - Don't clutter with every possible connection
+4. **Use consistent naming** - Same names across all diagram levels
+5. **Add technology details** - Specify frameworks, languages, protocols at Container/Component level
+6. **Update regularly** - Keep diagrams in sync with architecture
+7. **Use boundaries** - Group related containers/components logically
+8. **Document protocols** - Show communication methods (REST, gRPC, messaging)
+9. **Highlight external systems** - Use *_Ext variants for clarity
+10. **Start simple** - Begin with Context, drill down as needed
+
+## Common Architecture Patterns
+
+### Monolithic Application
+```mermaid
+C4Container
+    Person(user, "User")
+    
+    Container_Boundary(system, "Application") {
+        Container(app, "Web Application", "Ruby on Rails", "Monolithic application")
+        ContainerDb(db, "Database", "PostgreSQL", "Application database")
+        ContainerDb(cache, "Cache", "Redis", "Session store")
+    }
+    
+    Rel(user, app, "Uses", "HTTPS")
+    Rel(app, db, "Reads/writes", "SQL")
+    Rel(app, cache, "Caches", "Redis Protocol")
+```
+
+### Three-Tier Architecture
+```mermaid
+C4Container
+    Person(user, "User")
+    
+    Container_Boundary(presentation, "Presentation Tier") {
+        Container(web, "Web Server", "Nginx", "Static content")
+        Container(app, "App Server", "Node.js", "Application logic")
+    }
+    
+    Container_Boundary(business, "Business Tier") {
+        Container(api, "API Server", "Java", "Business logic")
+    }
+    
+    Container_Boundary(data, "Data Tier") {
+        ContainerDb(db, "Database", "MySQL", "Data storage")
+    }
+    
+    Rel(user, web, "Uses", "HTTPS")
+    Rel(web, app, "Proxies to", "HTTP")
+    Rel(app, api, "Calls", "REST")
+    Rel(api, db, "Reads/writes", "SQL")
+```
+
+### Event-Driven Architecture
+```mermaid
+C4Container
+    Person(user, "User")
+    
+    Container(frontend, "Frontend", "React", "User interface")
+    Container(api, "API Gateway", "Kong", "API routing")
+    
+    Container_Boundary(services, "Services") {
+        Container(order, "Order Service", "Java", "Order processing")
+        Container(inventory, "Inventory Service", "Go", "Stock management")
+        Container(notification, "Notification Service", "Node.js", "Alerts")
+    }
+    
+    ContainerQueue(events, "Event Bus", "Kafka", "Event streaming")
+    ContainerDb(db, "Databases", "Various", "Service databases")
+    
+    Rel(user, frontend, "Uses")
+    Rel(frontend, api, "Calls")
+    Rel(api, order, "Routes to")
+    
+    Rel(order, events, "Publishes OrderCreated")
+    Rel(events, inventory, "Consumes events")
+    Rel(events, notification, "Consumes events")
+    
+    Rel(order, db, "Persists")
+    Rel(inventory, db, "Persists")
+```

--- a/.agents/skills/mermaid-diagrams/references/class-diagrams.md
+++ b/.agents/skills/mermaid-diagrams/references/class-diagrams.md
@@ -1,0 +1,361 @@
+# Class Diagrams
+
+Class diagrams model object-oriented designs and domain models. They show entities (classes), their attributes/methods, and relationships.
+
+## Basic Syntax
+
+```mermaid
+classDiagram
+    ClassName
+```
+
+## Defining Classes with Members
+
+```mermaid
+classDiagram
+    class BankAccount {
+        +String owner
+        +Decimal balance
+        -String accountNumber
+        +deposit(amount)
+        +withdraw(amount)
+        +getBalance() Decimal
+    }
+```
+
+**Visibility modifiers:**
+- `+` Public
+- `-` Private
+- `#` Protected
+- `~` Package/Internal
+
+**Member syntax:**
+- `+type attribute` - Attribute with type
+- `+method(params) ReturnType` - Method with parameters and return type
+
+## Relationships
+
+### Association (`--`)
+Loose relationship where entities use each other but exist independently.
+
+```mermaid
+classDiagram
+    Title -- Genre
+```
+
+### Composition (`*--`)
+Strong ownership - child cannot exist without parent. When parent is deleted, children are deleted.
+
+```mermaid
+classDiagram
+    Order *-- LineItem
+    House *-- Room
+```
+
+### Aggregation (`o--`)
+Weaker ownership - child can exist independently. Represents "has-a" relationship.
+
+```mermaid
+classDiagram
+    Department o-- Employee
+    Playlist o-- Song
+```
+
+### Inheritance (`<|--`)
+"Is-a" relationship. Child class inherits from parent class.
+
+```mermaid
+classDiagram
+    Animal <|-- Dog
+    Animal <|-- Cat
+    
+    class Animal {
+        +String name
+        +makeSound()
+    }
+    
+    class Dog {
+        +bark()
+    }
+```
+
+### Dependency (`<..`)
+One class depends on another, often as a parameter or local variable.
+
+```mermaid
+classDiagram
+    OrderProcessor <.. PaymentGateway
+```
+
+### Realization/Implementation (`<|..`)
+Class implements an interface.
+
+```mermaid
+classDiagram
+    class Drawable {
+        <<interface>>
+        +draw()
+    }
+    Drawable <|.. Circle
+    Drawable <|.. Rectangle
+```
+
+## Multiplicity
+
+Show how many instances participate in a relationship:
+
+```mermaid
+classDiagram
+    Customer "1" --> "0..*" Order : places
+    Order "1" *-- "1..*" LineItem : contains
+    Author "1..*" -- "1..*" Book : writes
+```
+
+**Common multiplicities:**
+- `1` - Exactly one
+- `0..1` - Zero or one
+- `0..*` or `*` - Zero or many
+- `1..*` - One or many
+- `m..n` - Between m and n
+
+## Relationship Labels
+
+```mermaid
+classDiagram
+    Customer --> Order : places
+    Order --> Product : contains
+    Driver --> Vehicle : drives
+```
+
+## Class Stereotypes
+
+Mark special class types:
+
+```mermaid
+classDiagram
+    class IRepository {
+        <<interface>>
+        +save(entity)
+        +findById(id)
+    }
+    
+    class UserService {
+        <<service>>
+        +createUser()
+    }
+    
+    class UserDTO {
+        <<dataclass>>
+        +String name
+        +String email
+    }
+```
+
+## Abstract Classes and Methods
+
+```mermaid
+classDiagram
+    class Shape {
+        <<abstract>>
+        +int x
+        +int y
+        +draw()* abstract
+        +move(x, y)
+    }
+    
+    Shape <|-- Circle
+    Shape <|-- Rectangle
+```
+
+## Generic Classes
+
+```mermaid
+classDiagram
+    class List~T~ {
+        +add(item: T)
+        +get(index: int) T
+    }
+    
+    List~String~ <-- StringProcessor
+```
+
+## Comprehensive Example: E-Commerce Domain
+
+```mermaid
+classDiagram
+    %% Core entities
+    class Customer {
+        +UUID id
+        +String email
+        +String name
+        +Address shippingAddress
+        +placeOrder(cart: Cart) Order
+        +getOrderHistory() List~Order~
+    }
+    
+    class Order {
+        +UUID id
+        +DateTime orderDate
+        +OrderStatus status
+        +Decimal total
+        +calculateTotal() Decimal
+        +ship()
+        +cancel()
+    }
+    
+    class LineItem {
+        +int quantity
+        +Decimal pricePerUnit
+        +getSubtotal() Decimal
+    }
+    
+    class Product {
+        +UUID id
+        +String name
+        +String description
+        +Decimal price
+        +int stockQuantity
+        +reduceStock(quantity: int)
+        +isAvailable() bool
+    }
+    
+    class Category {
+        +String name
+        +String description
+    }
+    
+    class Cart {
+        +addItem(product: Product, quantity: int)
+        +removeItem(product: Product)
+        +getTotal() Decimal
+        +clear()
+    }
+    
+    %% Relationships
+    Customer "1" --> "0..*" Order : places
+    Customer "1" --> "1" Cart : has
+    Order "1" *-- "1..*" LineItem : contains
+    LineItem "1" --> "1" Product : references
+    Product "0..*" --> "1" Category : belongs to
+    Cart "1" o-- "0..*" Product : contains
+    
+    %% Enums
+    class OrderStatus {
+        <<enumeration>>
+        PENDING
+        PAID
+        SHIPPED
+        DELIVERED
+        CANCELLED
+    }
+    
+    Order --> OrderStatus
+```
+
+## Domain-Driven Design Patterns
+
+### Entities
+```mermaid
+classDiagram
+    class User {
+        <<entity>>
+        -UUID id
+        +String email
+        +String name
+    }
+```
+
+### Value Objects
+```mermaid
+classDiagram
+    class Money {
+        <<value object>>
+        +Decimal amount
+        +String currency
+        +add(other: Money) Money
+    }
+    
+    class Address {
+        <<value object>>
+        +String street
+        +String city
+        +String postalCode
+    }
+```
+
+### Aggregates
+```mermaid
+classDiagram
+    class Order {
+        <<aggregate root>>
+        -UUID id
+        +addLineItem(item)
+        +removeLineItem(item)
+    }
+    
+    Order *-- LineItem
+```
+
+## Tips for Effective Class Diagrams
+
+1. **Start with core entities** - Add attributes and methods incrementally
+2. **Show only relevant details** - Omit obvious getters/setters unless important
+3. **Use appropriate relationships** - Choose between association, aggregation, and composition carefully
+4. **Add multiplicity** - Clarifies how many instances participate
+5. **Group related classes** - Use notes or visual proximity
+6. **Document invariants** - Use notes to explain business rules
+
+## Common Patterns
+
+### Repository Pattern
+```mermaid
+classDiagram
+    class IRepository~T~ {
+        <<interface>>
+        +save(entity: T)
+        +findById(id: UUID) T
+        +delete(entity: T)
+    }
+    
+    class UserRepository {
+        +findByEmail(email: String) User
+    }
+    
+    IRepository~User~ <|.. UserRepository
+```
+
+### Factory Pattern
+```mermaid
+classDiagram
+    class ShapeFactory {
+        +createShape(type: String) Shape
+    }
+    
+    class Shape {
+        <<abstract>>
+        +draw()*
+    }
+    
+    ShapeFactory ..> Shape : creates
+    Shape <|-- Circle
+    Shape <|-- Rectangle
+```
+
+### Strategy Pattern
+```mermaid
+classDiagram
+    class PaymentProcessor {
+        -PaymentStrategy strategy
+        +setStrategy(strategy: PaymentStrategy)
+        +processPayment(amount: Decimal)
+    }
+    
+    class PaymentStrategy {
+        <<interface>>
+        +pay(amount: Decimal)*
+    }
+    
+    PaymentStrategy <|.. CreditCardPayment
+    PaymentStrategy <|.. PayPalPayment
+    PaymentProcessor --> PaymentStrategy
+```

--- a/.agents/skills/mermaid-diagrams/references/erd-diagrams.md
+++ b/.agents/skills/mermaid-diagrams/references/erd-diagrams.md
@@ -1,0 +1,510 @@
+# Entity Relationship Diagrams (ERD)
+
+ERDs model database schemas, showing tables (entities), their columns (attributes), and relationships between tables. Essential for database design and documentation.
+
+## Basic Syntax
+
+```mermaid
+erDiagram
+    CUSTOMER ||--o{ ORDER : places
+```
+
+## Defining Entities
+
+```mermaid
+erDiagram
+    CUSTOMER
+    ORDER
+    PRODUCT
+```
+
+## Entity Attributes
+
+Define columns with type and constraints:
+
+```mermaid
+erDiagram
+    CUSTOMER {
+        int id PK
+        string email UK
+        string name
+        string phone
+        datetime created_at
+    }
+```
+
+**Attribute format:** `type name constraints`
+
+**Common constraints:**
+- `PK` - Primary Key
+- `FK` - Foreign Key
+- `UK` - Unique Key
+- `NN` - Not Null
+
+## Relationships
+
+### Relationship Symbols
+
+**Cardinality indicators:**
+- `||` - Exactly one
+- `|o` - Zero or one
+- `}{` - One or many
+- `}o` - Zero or many
+
+**Relationship line:**
+- `--` - Non-identifying relationship
+- `..` - Identifying relationship (rare in practice)
+
+### Common Relationships
+
+```mermaid
+erDiagram
+    %% One-to-One
+    USER ||--|| PROFILE : has
+    
+    %% One-to-Many
+    CUSTOMER ||--o{ ORDER : places
+    
+    %% Many-to-Many (with junction table)
+    STUDENT }o--o{ COURSE : enrolls
+    STUDENT ||--o{ ENROLLMENT : has
+    COURSE ||--o{ ENROLLMENT : includes
+    
+    %% Optional Relationships
+    EMPLOYEE |o--o{ DEPARTMENT : manages
+```
+
+### Relationship with Labels
+
+```mermaid
+erDiagram
+    AUTHOR ||--o{ BOOK : writes
+    BOOK }o--|| PUBLISHER : "published by"
+    READER }o--o{ BOOK : reads
+```
+
+## Data Types
+
+Use standard database types:
+- `int`, `bigint`, `smallint`
+- `varchar`, `text`, `char`
+- `decimal`, `float`, `double`
+- `boolean`, `bool`
+- `date`, `datetime`, `timestamp`
+- `json`, `jsonb`
+- `uuid`
+- `blob`, `bytea`
+
+## Comprehensive Example: E-Commerce Database
+
+```mermaid
+erDiagram
+    CUSTOMER ||--o{ ORDER : places
+    CUSTOMER ||--o{ REVIEW : writes
+    CUSTOMER ||--o{ ADDRESS : has
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : "ordered in"
+    PRODUCT }o--|| CATEGORY : "belongs to"
+    PRODUCT ||--o{ REVIEW : receives
+    PRODUCT ||--o{ INVENTORY : tracks
+    ORDER ||--|| PAYMENT : "paid by"
+    ORDER ||--o| SHIPMENT : "shipped via"
+    
+    CUSTOMER {
+        uuid id PK
+        varchar email UK "NOT NULL"
+        varchar name "NOT NULL"
+        varchar phone
+        timestamp created_at "DEFAULT NOW()"
+        timestamp updated_at
+    }
+    
+    ADDRESS {
+        uuid id PK
+        uuid customer_id FK
+        varchar street "NOT NULL"
+        varchar city "NOT NULL"
+        varchar state
+        varchar postal_code
+        varchar country "NOT NULL"
+        boolean is_default
+    }
+    
+    ORDER {
+        uuid id PK
+        uuid customer_id FK "NOT NULL"
+        decimal total "NOT NULL"
+        varchar status "NOT NULL"
+        timestamp order_date "DEFAULT NOW()"
+        timestamp shipped_date
+        timestamp delivered_date
+    }
+    
+    LINE_ITEM {
+        uuid id PK
+        uuid order_id FK "NOT NULL"
+        uuid product_id FK "NOT NULL"
+        int quantity "NOT NULL"
+        decimal price_per_unit "NOT NULL"
+        decimal subtotal "COMPUTED"
+    }
+    
+    PRODUCT {
+        uuid id PK
+        varchar sku UK "NOT NULL"
+        varchar name "NOT NULL"
+        text description
+        decimal price "NOT NULL"
+        uuid category_id FK
+        boolean is_active "DEFAULT TRUE"
+        timestamp created_at "DEFAULT NOW()"
+    }
+    
+    CATEGORY {
+        uuid id PK
+        varchar name UK "NOT NULL"
+        text description
+        uuid parent_category_id FK
+    }
+    
+    INVENTORY {
+        uuid id PK
+        uuid product_id FK "NOT NULL"
+        int quantity "DEFAULT 0"
+        varchar warehouse_location
+        timestamp last_updated
+    }
+    
+    REVIEW {
+        uuid id PK
+        uuid customer_id FK "NOT NULL"
+        uuid product_id FK "NOT NULL"
+        int rating "CHECK 1-5"
+        text comment
+        timestamp created_at "DEFAULT NOW()"
+    }
+    
+    PAYMENT {
+        uuid id PK
+        uuid order_id FK "NOT NULL"
+        varchar payment_method "NOT NULL"
+        decimal amount "NOT NULL"
+        varchar status "NOT NULL"
+        varchar transaction_id UK
+        timestamp processed_at
+    }
+    
+    SHIPMENT {
+        uuid id PK
+        uuid order_id FK "NOT NULL"
+        varchar carrier
+        varchar tracking_number
+        timestamp shipped_date
+        timestamp estimated_delivery
+        timestamp actual_delivery
+    }
+```
+
+## Blog Platform Schema
+
+```mermaid
+erDiagram
+    USER ||--o{ POST : creates
+    USER ||--o{ COMMENT : writes
+    POST ||--o{ COMMENT : receives
+    POST }o--o{ TAG : tagged_with
+    POST ||--o{ POST_TAG : has
+    TAG ||--o{ POST_TAG : applied_to
+    POST }o--|| CATEGORY : "belongs to"
+    USER ||--o{ LIKE : gives
+    POST ||--o{ LIKE : receives
+    COMMENT ||--o{ LIKE : receives
+    
+    USER {
+        bigint id PK "AUTO_INCREMENT"
+        varchar email UK "NOT NULL"
+        varchar username UK "NOT NULL"
+        varchar password_hash "NOT NULL"
+        varchar display_name
+        text bio
+        varchar avatar_url
+        timestamp created_at "DEFAULT NOW()"
+        timestamp last_login
+    }
+    
+    POST {
+        bigint id PK "AUTO_INCREMENT"
+        bigint user_id FK "NOT NULL"
+        bigint category_id FK
+        varchar title "NOT NULL"
+        varchar slug UK "NOT NULL"
+        text content "NOT NULL"
+        text excerpt
+        varchar featured_image_url
+        varchar status "NOT NULL DEFAULT 'draft'"
+        int view_count "DEFAULT 0"
+        timestamp published_at
+        timestamp created_at "DEFAULT NOW()"
+        timestamp updated_at
+    }
+    
+    COMMENT {
+        bigint id PK "AUTO_INCREMENT"
+        bigint user_id FK "NOT NULL"
+        bigint post_id FK "NOT NULL"
+        bigint parent_comment_id FK "NULL"
+        text content "NOT NULL"
+        varchar status "DEFAULT 'pending'"
+        timestamp created_at "DEFAULT NOW()"
+    }
+    
+    CATEGORY {
+        bigint id PK "AUTO_INCREMENT"
+        varchar name UK "NOT NULL"
+        varchar slug UK "NOT NULL"
+        text description
+        bigint parent_id FK
+    }
+    
+    TAG {
+        bigint id PK "AUTO_INCREMENT"
+        varchar name UK "NOT NULL"
+        varchar slug UK "NOT NULL"
+    }
+    
+    POST_TAG {
+        bigint post_id FK "NOT NULL"
+        bigint tag_id FK "NOT NULL"
+    }
+    
+    LIKE {
+        bigint id PK "AUTO_INCREMENT"
+        bigint user_id FK "NOT NULL"
+        varchar likeable_type "NOT NULL"
+        bigint likeable_id "NOT NULL"
+        timestamp created_at "DEFAULT NOW()"
+    }
+```
+
+## Social Media Schema
+
+```mermaid
+erDiagram
+    USER ||--o{ POST : creates
+    USER ||--o{ FOLLOW : follows
+    USER ||--o{ FOLLOW : "followed by"
+    POST ||--o{ LIKE : receives
+    POST ||--o{ COMMENT : has
+    USER ||--o{ LIKE : gives
+    USER ||--o{ COMMENT : makes
+    USER ||--o{ NOTIFICATION : receives
+    POST ||--o{ POST_MEDIA : contains
+    USER }o--o{ GROUP : "member of"
+    USER ||--o{ MESSAGE : sends
+    USER ||--o{ MESSAGE : receives
+    
+    USER {
+        uuid id PK
+        varchar username UK "NOT NULL"
+        varchar email UK "NOT NULL"
+        varchar password_hash "NOT NULL"
+        varchar full_name
+        text bio
+        varchar profile_picture_url
+        varchar cover_photo_url
+        boolean is_verified "DEFAULT FALSE"
+        boolean is_private "DEFAULT FALSE"
+        timestamp created_at "DEFAULT NOW()"
+    }
+    
+    POST {
+        uuid id PK
+        uuid user_id FK "NOT NULL"
+        text content
+        varchar visibility "DEFAULT 'public'"
+        int likes_count "DEFAULT 0"
+        int comments_count "DEFAULT 0"
+        int shares_count "DEFAULT 0"
+        timestamp created_at "DEFAULT NOW()"
+        timestamp edited_at
+    }
+    
+    POST_MEDIA {
+        uuid id PK
+        uuid post_id FK "NOT NULL"
+        varchar media_type "NOT NULL"
+        varchar media_url "NOT NULL"
+        int display_order
+    }
+    
+    FOLLOW {
+        uuid id PK
+        uuid follower_id FK "NOT NULL"
+        uuid following_id FK "NOT NULL"
+        timestamp created_at "DEFAULT NOW()"
+    }
+    
+    LIKE {
+        uuid id PK
+        uuid user_id FK "NOT NULL"
+        uuid post_id FK "NOT NULL"
+        timestamp created_at "DEFAULT NOW()"
+    }
+    
+    COMMENT {
+        uuid id PK
+        uuid user_id FK "NOT NULL"
+        uuid post_id FK "NOT NULL"
+        uuid parent_comment_id FK
+        text content "NOT NULL"
+        int likes_count "DEFAULT 0"
+        timestamp created_at "DEFAULT NOW()"
+    }
+    
+    MESSAGE {
+        uuid id PK
+        uuid sender_id FK "NOT NULL"
+        uuid receiver_id FK "NOT NULL"
+        text content "NOT NULL"
+        boolean is_read "DEFAULT FALSE"
+        timestamp created_at "DEFAULT NOW()"
+        timestamp read_at
+    }
+    
+    NOTIFICATION {
+        uuid id PK
+        uuid user_id FK "NOT NULL"
+        varchar notification_type "NOT NULL"
+        text content "NOT NULL"
+        boolean is_read "DEFAULT FALSE"
+        varchar related_entity_type
+        uuid related_entity_id
+        timestamp created_at "DEFAULT NOW()"
+    }
+    
+    GROUP {
+        uuid id PK
+        varchar name "NOT NULL"
+        text description
+        uuid created_by FK "NOT NULL"
+        boolean is_private "DEFAULT FALSE"
+        timestamp created_at "DEFAULT NOW()"
+    }
+```
+
+## Best Practices
+
+1. **Name entities in UPPERCASE** - Convention for clarity
+2. **Use singular names** - `USER` not `USERS`, `ORDER` not `ORDERS`
+3. **Define all constraints** - Document PKs, FKs, UKs, NOT NULL
+4. **Show cardinality accurately** - Be precise about one-to-many vs many-to-many
+5. **Include timestamps** - created_at, updated_at for auditing
+6. **Document computed columns** - Mark calculated/derived values
+7. **Add meaningful comments** - Use quotes for constraints and descriptions
+8. **Consider junction tables** - Explicitly model many-to-many relationships
+9. **Use appropriate types** - Match database-specific types
+10. **Show indexes** - Document UK (unique keys) beyond PKs
+
+## Common Patterns
+
+### Self-Referencing (Hierarchical)
+```mermaid
+erDiagram
+    CATEGORY ||--o{ CATEGORY : "parent of"
+    
+    CATEGORY {
+        uuid id PK
+        varchar name "NOT NULL"
+        uuid parent_id FK "NULLABLE"
+    }
+```
+
+### Junction Table (Many-to-Many)
+```mermaid
+erDiagram
+    STUDENT }o--o{ COURSE : enrolls
+    STUDENT ||--o{ ENROLLMENT : has
+    COURSE ||--o{ ENROLLMENT : includes
+    
+    STUDENT {
+        uuid id PK
+        varchar name "NOT NULL"
+    }
+    
+    ENROLLMENT {
+        uuid student_id FK PK
+        uuid course_id FK PK
+        date enrolled_date
+        varchar grade
+    }
+    
+    COURSE {
+        uuid id PK
+        varchar title "NOT NULL"
+    }
+```
+
+### Polymorphic Relationship
+```mermaid
+erDiagram
+    COMMENT {
+        uuid id PK
+        uuid user_id FK
+        varchar commentable_type "NOT NULL"
+        uuid commentable_id "NOT NULL"
+        text content
+    }
+    
+    POST {
+        uuid id PK
+        varchar title
+    }
+    
+    VIDEO {
+        uuid id PK
+        varchar title
+    }
+```
+
+### Soft Deletes
+```mermaid
+erDiagram
+    USER {
+        uuid id PK
+        varchar email UK
+        varchar name
+        timestamp deleted_at "NULLABLE"
+    }
+```
+
+### Audit Trail
+```mermaid
+erDiagram
+    DOCUMENT ||--o{ DOCUMENT_VERSION : has
+    
+    DOCUMENT {
+        uuid id PK
+        varchar title "NOT NULL"
+        int current_version "DEFAULT 1"
+    }
+    
+    DOCUMENT_VERSION {
+        uuid id PK
+        uuid document_id FK "NOT NULL"
+        int version_number "NOT NULL"
+        text content "NOT NULL"
+        uuid modified_by FK
+        timestamp created_at "DEFAULT NOW()"
+    }
+```
+
+## Tips for Database Design
+
+1. **Normalize appropriately** - Balance normalization with query performance
+2. **Use surrogate keys** - UUID or auto-increment integers as PKs
+3. **Index foreign keys** - Essential for join performance
+4. **Plan for soft deletes** - Add deleted_at columns instead of hard deletes
+5. **Version critical data** - Maintain history for important entities
+6. **Set appropriate defaults** - created_at, status, boolean flags
+7. **Consider denormalization** - Counts and cached values for performance
+8. **Use enum/check constraints** - Enforce valid values at database level

--- a/.agents/skills/mermaid-diagrams/references/flowcharts.md
+++ b/.agents/skills/mermaid-diagrams/references/flowcharts.md
@@ -1,0 +1,450 @@
+# Flowcharts
+
+Flowcharts visualize processes, algorithms, decision trees, and user journeys. They show step-by-step progression through a system or workflow.
+
+## Basic Syntax
+
+```mermaid
+flowchart TD
+    A --> B
+```
+
+**Directions:**
+- `TD` or `TB` - Top to Bottom (default)
+- `BT` - Bottom to Top
+- `LR` - Left to Right
+- `RL` - Right to Left
+
+## Node Shapes
+
+### Rectangle (default)
+```mermaid
+flowchart LR
+    A[Process step]
+```
+
+### Rounded Rectangle
+```mermaid
+flowchart LR
+    B([Rounded process])
+```
+
+### Stadium/Pill Shape
+```mermaid
+flowchart LR
+    C(Start or End)
+```
+
+### Subroutine (Double Border)
+```mermaid
+flowchart LR
+    D[[Subroutine]]
+```
+
+### Cylindrical (Database)
+```mermaid
+flowchart LR
+    E[(Database)]
+```
+
+### Circle
+```mermaid
+flowchart LR
+    F((Circle node))
+```
+
+### Asymmetric/Flag
+```mermaid
+flowchart LR
+    G>Flag node]
+```
+
+### Rhombus (Decision)
+```mermaid
+flowchart LR
+    H{Decision?}
+```
+
+### Hexagon
+```mermaid
+flowchart LR
+    I{{Hexagon}}
+```
+
+### Parallelogram (Input/Output)
+```mermaid
+flowchart LR
+    J[/Input or Output/]
+    K[\Alternative IO\]
+```
+
+### Trapezoid
+```mermaid
+flowchart LR
+    L[/Trapezoid\]
+    M[\Alt trapezoid/]
+```
+
+## Connections
+
+### Basic Arrow
+```mermaid
+flowchart LR
+    A --> B
+```
+
+### Open Link (No Arrow)
+```mermaid
+flowchart LR
+    A --- B
+```
+
+### Text on Links
+```mermaid
+flowchart LR
+    A -->|Label text| B
+    C ---|"Text with spaces"| D
+```
+
+### Dotted Links
+```mermaid
+flowchart LR
+    A -.-> B
+    C -.- D
+    E -.Label.-> F
+```
+
+### Thick Links
+```mermaid
+flowchart LR
+    A ==> B
+    C === D
+    E ==Label==> F
+```
+
+### Chaining
+```mermaid
+flowchart LR
+    A --> B --> C --> D
+    E --> F & G --> H
+```
+
+### Multi-directional
+```mermaid
+flowchart LR
+    A --> B & C & D
+    B & C & D --> E
+```
+
+## Subgraphs
+
+Group related nodes:
+
+```mermaid
+flowchart TB
+    A[Start]
+    
+    subgraph Processing
+        B[Step 1]
+        C[Step 2]
+        D[Step 3]
+    end
+    
+    E[End]
+    
+    A --> B
+    D --> E
+```
+
+### Nested Subgraphs
+```mermaid
+flowchart TB
+    subgraph Outer
+        A[Node A]
+        
+        subgraph Inner
+            B[Node B]
+            C[Node C]
+        end
+    end
+```
+
+### Subgraph Direction
+```mermaid
+flowchart LR
+    subgraph one
+        direction TB
+        A1 --> A2
+    end
+    
+    subgraph two
+        direction TB
+        B1 --> B2
+    end
+    
+    one --> two
+```
+
+## Styling
+
+### Individual Node Styling
+```mermaid
+flowchart LR
+    A[Normal]
+    B[Styled]
+    
+    style B fill:#ff6b6b,stroke:#333,stroke-width:4px,color:#fff
+```
+
+### Class-based Styling
+```mermaid
+flowchart LR
+    A[Node 1]:::className
+    B[Node 2]:::className
+    C[Node 3]
+    
+    classDef className fill:#f9f,stroke:#333,stroke-width:2px
+```
+
+### Link Styling
+```mermaid
+flowchart LR
+    A --> B
+    linkStyle 0 stroke:#ff3,stroke-width:4px,color:red
+```
+
+## Comprehensive Example: User Registration Flow
+
+```mermaid
+flowchart TD
+    Start([User visits registration page]) --> Form[Show registration form]
+    Form --> Input[User enters details]
+    Input --> Validate{Valid input?}
+    
+    Validate -->|No| ShowError[Show validation errors]
+    ShowError --> Form
+    
+    Validate -->|Yes| CheckEmail{Email exists?}
+    
+    CheckEmail -->|Yes| EmailError[Show 'Email already registered']
+    EmailError --> Form
+    
+    CheckEmail -->|No| CreateAccount[Create user account]
+    CreateAccount --> Hash[Hash password]
+    Hash --> SaveDB[(Save to database)]
+    SaveDB --> GenerateToken[Generate verification token]
+    GenerateToken --> SendEmail[Send verification email]
+    SendEmail --> ShowSuccess[Show success message]
+    ShowSuccess --> End([Redirect to login])
+    
+    style Start fill:#90EE90,stroke:#333,stroke-width:2px
+    style End fill:#90EE90,stroke:#333,stroke-width:2px
+    style CreateAccount fill:#87CEEB,stroke:#333,stroke-width:2px
+    style SaveDB fill:#FFD700,stroke:#333,stroke-width:2px
+```
+
+## Algorithm Example: Binary Search
+
+```mermaid
+flowchart TD
+    Start([Start Binary Search]) --> Init[Set low = 0, high = array.length - 1]
+    Init --> Check{low <= high?}
+    
+    Check -->|No| NotFound[Return -1: Not found]
+    NotFound --> End([End])
+    
+    Check -->|Yes| CalcMid[mid = low + (high - low) / 2]
+    CalcMid --> Compare{array[mid] == target?}
+    
+    Compare -->|Yes| Found[Return mid: Found]
+    Found --> End
+    
+    Compare -->|No| CheckLess{array[mid] < target?}
+    
+    CheckLess -->|Yes| MoveLow[low = mid + 1]
+    MoveLow --> Check
+    
+    CheckLess -->|No| MoveHigh[high = mid - 1]
+    MoveHigh --> Check
+    
+    style Start fill:#90EE90
+    style End fill:#90EE90
+    style Found fill:#FFD700
+    style NotFound fill:#FF6B6B
+```
+
+## CI/CD Pipeline
+
+```mermaid
+flowchart LR
+    subgraph Development
+        Commit[Developer commits code] --> Push[Push to repository]
+    end
+    
+    subgraph CI
+        Push --> Trigger[Trigger CI pipeline]
+        Trigger --> Checkout[Checkout code]
+        Checkout --> Install[Install dependencies]
+        Install --> Lint[Run linters]
+        Lint --> Test[Run tests]
+        Test --> Build[Build application]
+    end
+    
+    subgraph QA
+        Build --> DeployStaging[Deploy to staging]
+        DeployStaging --> E2E[Run E2E tests]
+        E2E --> ManualQA{Manual QA approval?}
+    end
+    
+    subgraph Production
+        ManualQA -->|Approved| DeployProd[Deploy to production]
+        DeployProd --> HealthCheck{Health check passed?}
+        HealthCheck -->|Yes| Success([Deployment successful])
+        HealthCheck -->|No| Rollback[Rollback deployment]
+        Rollback --> Alert[Alert team]
+    end
+    
+    ManualQA -->|Rejected| FixIssues[Fix issues]
+    FixIssues --> Development
+    
+    Test -->|Failed| NotifyDev[Notify developer]
+    NotifyDev --> FixIssues
+```
+
+## E-Commerce Checkout Flow
+
+```mermaid
+flowchart TD
+    Start([User clicks Checkout]) --> Auth{Authenticated?}
+    
+    Auth -->|No| Login[Redirect to login]
+    Login --> Auth
+    
+    Auth -->|Yes| Cart{Cart empty?}
+    Cart -->|Yes| EmptyCart[Show empty cart message]
+    EmptyCart --> Browse[Redirect to products]
+    
+    Cart -->|No| Address[Show shipping address form]
+    Address --> ValidateAddr{Valid address?}
+    ValidateAddr -->|No| Address
+    ValidateAddr -->|Yes| Shipping[Select shipping method]
+    
+    Shipping --> Payment[Enter payment details]
+    Payment --> ValidatePayment{Valid payment info?}
+    ValidatePayment -->|No| Payment
+    
+    ValidatePayment -->|Yes| Review[Show order review]
+    Review --> Confirm{Confirm order?}
+    
+    Confirm -->|No| Edit{Edit what?}
+    Edit -->|Address| Address
+    Edit -->|Shipping| Shipping
+    Edit -->|Payment| Payment
+    
+    Confirm -->|Yes| ProcessPayment[Process payment]
+    ProcessPayment --> PaymentResult{Payment successful?}
+    
+    PaymentResult -->|No| PaymentError[Show payment error]
+    PaymentError --> RetryPayment{Retry?}
+    RetryPayment -->|Yes| Payment
+    RetryPayment -->|No| Cancel([Order cancelled])
+    
+    PaymentResult -->|Yes| CreateOrder[(Create order record)]
+    CreateOrder --> ReduceStock[Reduce inventory]
+    ReduceStock --> SendConfirmation[Send confirmation email]
+    SendConfirmation --> Success([Order complete - Show confirmation])
+    
+    style Start fill:#90EE90
+    style Success fill:#90EE90
+    style Cancel fill:#FF6B6B
+    style CreateOrder fill:#FFD700
+```
+
+## Decision Matrix Example
+
+```mermaid
+flowchart TD
+    Start([Select deployment strategy]) --> Env{Environment?}
+    
+    Env -->|Development| DevDecision{Automated tests?}
+    DevDecision -->|Pass| DevDeploy[Auto-deploy to dev]
+    DevDecision -->|Fail| Block[Block deployment]
+    
+    Env -->|Staging| StageDecision{All checks pass?}
+    StageDecision -->|Yes| StageDeploy[Deploy to staging]
+    StageDecision -->|No| Block
+    
+    Env -->|Production| ProdDecision{Change type?}
+    
+    ProdDecision -->|Hotfix| Urgent{Critical bug?}
+    Urgent -->|Yes| FastTrack[Emergency approval + deploy]
+    Urgent -->|No| NormalProcess
+    
+    ProdDecision -->|Feature| NormalProcess{Approval status?}
+    NormalProcess -->|Approved| Schedule{Deploy window?}
+    NormalProcess -->|Pending| Wait[Wait for approval]
+    NormalProcess -->|Rejected| Block
+    
+    Schedule -->|Now| ImmediateDeploy[Deploy immediately]
+    Schedule -->|Scheduled| QueueDeploy[Queue for deploy window]
+    
+    DevDeploy --> Monitor[Monitor metrics]
+    StageDeploy --> Monitor
+    FastTrack --> Monitor
+    ImmediateDeploy --> Monitor
+    QueueDeploy --> Monitor
+    
+    Monitor --> End([Deployment complete])
+    Block --> End
+    Wait --> End
+```
+
+## Best Practices
+
+1. **Use meaningful labels** - Node text should be clear and action-oriented
+2. **Consistent node shapes** - Same shapes for same types of actions
+3. **Decision nodes as diamonds** - Standard convention for yes/no decisions
+4. **Flow top-to-bottom or left-to-right** - Natural reading direction
+5. **Start and end nodes** - Use stadium/pill shapes to mark entry/exit
+6. **Group related steps** - Use subgraphs for logical groupings
+7. **Color code** - Use colors to highlight different types of actions
+8. **Minimize crossing lines** - Reorganize for clarity
+9. **Keep it focused** - One process per diagram
+
+## Common Patterns
+
+### Simple Linear Flow
+```mermaid
+flowchart LR
+    A[Step 1] --> B[Step 2] --> C[Step 3] --> D[Step 4]
+```
+
+### Branching Decision
+```mermaid
+flowchart TD
+    A[Input] --> B{Condition?}
+    B -->|True| C[Path 1]
+    B -->|False| D[Path 2]
+    C --> E[Merge]
+    D --> E
+```
+
+### Loop Pattern
+```mermaid
+flowchart TD
+    A[Initialize] --> B[Process]
+    B --> C{Continue?}
+    C -->|Yes| B
+    C -->|No| D[Exit]
+```
+
+### Error Handling
+```mermaid
+flowchart TD
+    A[Try operation] --> B{Success?}
+    B -->|Yes| C[Continue]
+    B -->|No| D[Handle error]
+    D --> E{Retry?}
+    E -->|Yes| A
+    E -->|No| F[Abort]
+```

--- a/.agents/skills/mermaid-diagrams/references/sequence-diagrams.md
+++ b/.agents/skills/mermaid-diagrams/references/sequence-diagrams.md
@@ -1,0 +1,394 @@
+# Sequence Diagrams
+
+Sequence diagrams show interactions between participants over time. They're ideal for API flows, authentication sequences, and system component interactions.
+
+## Basic Syntax
+
+```mermaid
+sequenceDiagram
+    participant A
+    participant B
+    A->>B: Message
+```
+
+## Participants and Actors
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Frontend
+    participant API
+    participant Database
+    
+    User->>Frontend: Click button
+    Frontend->>API: POST /data
+```
+
+**Difference:**
+- `participant` - System components (services, classes, databases)
+- `actor` - External entities (users, external systems)
+
+## Message Types
+
+### Solid Arrow (Synchronous)
+```mermaid
+sequenceDiagram
+    Client->>Server: Request
+    Server-->>Client: Response
+```
+
+- `->>`  Solid arrow (request)
+- `-->>`  Dotted arrow (response/return)
+
+### Open Arrow (Asynchronous)
+```mermaid
+sequenceDiagram
+    Client-)Server: Async message
+    Server--)Client: Async response
+```
+
+- `-)` Solid open arrow
+- `--)` Dotted open arrow
+
+### Cross/X (Delete)
+```mermaid
+sequenceDiagram
+    Client-xServer: Delete
+```
+
+## Activations
+
+Show when a participant is actively processing:
+
+```mermaid
+sequenceDiagram
+    Client->>+Server: Request
+    Server->>+Database: Query
+    Database-->>-Server: Data
+    Server-->>-Client: Response
+```
+
+- `+` after arrow activates
+- `-` before arrow deactivates
+
+## Alt/Else (Conditional Logic)
+
+```mermaid
+sequenceDiagram
+    User->>API: POST /login
+    API->>Database: Query user
+    Database-->>API: User data
+    
+    alt Valid credentials
+        API-->>User: 200 OK + Token
+    else Invalid credentials
+        API-->>User: 401 Unauthorized
+    else Account locked
+        API-->>User: 403 Forbidden
+    end
+```
+
+## Opt (Optional)
+
+```mermaid
+sequenceDiagram
+    User->>API: POST /order
+    API->>PaymentService: Process payment
+    
+    opt Payment successful
+        API->>EmailService: Send confirmation
+    end
+    
+    API-->>User: Order result
+```
+
+## Par (Parallel)
+
+Show concurrent operations:
+
+```mermaid
+sequenceDiagram
+    API->>Service: Process order
+    
+    par Send email
+        Service->>EmailService: Send confirmation
+    and Update inventory
+        Service->>InventoryService: Reduce stock
+    and Log event
+        Service->>LogService: Log order
+    end
+    
+    Service-->>API: Complete
+```
+
+## Loop
+
+```mermaid
+sequenceDiagram
+    Client->>Server: Request batch
+    
+    loop For each item
+        Server->>Database: Process item
+        Database-->>Server: Result
+    end
+    
+    Server-->>Client: All results
+```
+
+**Loop with condition:**
+```mermaid
+sequenceDiagram
+    loop Every 5 seconds
+        Monitor->>API: Health check
+        API-->>Monitor: Status
+    end
+```
+
+## Break (Early Exit)
+
+```mermaid
+sequenceDiagram
+    User->>API: Submit form
+    API->>Validator: Validate input
+    
+    break Input invalid
+        API-->>User: 400 Bad Request
+    end
+    
+    API->>Database: Save data
+    Database-->>API: Success
+    API-->>User: 200 OK
+```
+
+## Notes
+
+### Note over single participant
+```mermaid
+sequenceDiagram
+    User->>API: Request
+    Note over API: Validates JWT token
+    API-->>User: Response
+```
+
+### Note spanning participants
+```mermaid
+sequenceDiagram
+    Frontend->>API: Request
+    Note over Frontend,API: HTTPS encrypted
+    API-->>Frontend: Response
+```
+
+### Right/Left notes
+```mermaid
+sequenceDiagram
+    User->>System: Action
+    Note right of System: Logs to database
+    System-->>User: Response
+    Note left of User: Updates UI
+```
+
+## Sequence Numbers
+
+Automatically number messages:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    
+    User->>Frontend: Login
+    Frontend->>API: Authenticate
+    API->>Database: Verify credentials
+    Database-->>API: User data
+    API-->>Frontend: JWT token
+    Frontend-->>User: Success
+```
+
+## Links and Tooltips
+
+Add clickable links:
+
+```mermaid
+sequenceDiagram
+    participant A as Service A
+    link A: Dashboard @ https://dashboard.example.com
+    link A: API Docs @ https://docs.example.com
+    
+    A->>B: Message
+```
+
+## Comprehensive Example: User Authentication Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant Frontend
+    participant AuthAPI
+    participant Database
+    participant Redis
+    participant EmailService
+    
+    User->>+Frontend: Enter credentials
+    Frontend->>+AuthAPI: POST /auth/login
+    
+    AuthAPI->>+Database: Query user by email
+    Database-->>-AuthAPI: User record
+    
+    alt User not found
+        AuthAPI-->>Frontend: 404 User not found
+        Frontend-->>User: Show error
+    else User found
+        AuthAPI->>AuthAPI: Verify password hash
+        
+        alt Invalid password
+            AuthAPI->>Database: Increment failed attempts
+            
+            opt Failed attempts > 5
+                AuthAPI->>Database: Lock account
+                AuthAPI->>EmailService: Send security alert
+            end
+            
+            AuthAPI-->>Frontend: 401 Invalid credentials
+            Frontend-->>User: Show error
+        else Valid password
+            AuthAPI->>AuthAPI: Generate JWT token
+            AuthAPI->>+Redis: Store session
+            Redis-->>-AuthAPI: Confirm
+            
+            par Update login metadata
+                AuthAPI->>Database: Update last_login
+            and Track analytics
+                AuthAPI->>Database: Log login event
+            end
+            
+            AuthAPI-->>-Frontend: 200 OK + JWT token
+            Frontend->>Frontend: Store token in localStorage
+            Frontend-->>-User: Redirect to dashboard
+            
+            opt First login
+                EmailService->>User: Welcome email
+            end
+        end
+    end
+```
+
+## API Request/Response Example
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client
+    participant Gateway
+    participant AuthService
+    participant UserService
+    participant Database
+    
+    Client->>+Gateway: GET /api/users/123
+    Note over Gateway: Rate limiting check
+    
+    Gateway->>+AuthService: Validate JWT
+    AuthService->>AuthService: Verify signature
+    
+    alt Token invalid or expired
+        AuthService-->>Gateway: 401 Unauthorized
+        Gateway-->>Client: 401 Unauthorized
+    else Token valid
+        AuthService-->>-Gateway: User context
+        
+        Gateway->>+UserService: GET /users/123
+        UserService->>+Database: SELECT * FROM users WHERE id=123
+        Database-->>-UserService: User record
+        
+        alt User not found
+            UserService-->>Gateway: 404 Not Found
+            Gateway-->>Client: 404 Not Found
+        else User found
+            UserService-->>-Gateway: 200 OK + User data
+            Gateway-->>-Client: 200 OK + User data
+        end
+    end
+```
+
+## Microservices Communication
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Gateway
+    participant OrderService
+    participant PaymentService
+    participant InventoryService
+    participant NotificationService
+    participant MessageQueue
+    
+    User->>+Gateway: POST /orders
+    Gateway->>+OrderService: Create order
+    
+    OrderService->>+InventoryService: Check stock
+    InventoryService-->>-OrderService: Stock available
+    
+    break Insufficient stock
+        OrderService-->>Gateway: 400 Out of stock
+        Gateway-->>User: Error message
+    end
+    
+    OrderService->>OrderService: Reserve order
+    OrderService->>+PaymentService: Charge customer
+    
+    alt Payment successful
+        PaymentService-->>-OrderService: Payment confirmed
+        OrderService->>MessageQueue: Publish OrderConfirmed event
+        
+        par Async processing
+            MessageQueue->>InventoryService: Reduce stock
+        and
+            MessageQueue->>NotificationService: Send confirmation
+            NotificationService->>User: Email confirmation
+        end
+        
+        OrderService-->>-Gateway: 201 Created
+        Gateway-->>User: Order confirmed
+    else Payment failed
+        PaymentService-->>OrderService: Payment declined
+        OrderService->>OrderService: Release reservation
+        OrderService-->>Gateway: 402 Payment Required
+        Gateway-->>User: Payment failed
+    end
+```
+
+## Best Practices
+
+1. **Order participants logically** - Typically: User → Frontend → Backend → Database
+2. **Use activations** - Shows when components are actively processing
+3. **Group related logic** - Use alt/opt/par to organize conditional flows
+4. **Add descriptive notes** - Explain complex logic or important details
+5. **Keep diagrams focused** - One scenario per diagram
+6. **Number messages** - Use autonumber for complex flows
+7. **Show error paths** - Document failure scenarios with alt/else
+8. **Indicate async operations** - Use open arrows for fire-and-forget messages
+
+## Common Use Cases
+
+### Authentication
+- Login flows
+- OAuth/SSO flows
+- Token refresh
+- Password reset
+
+### API Operations
+- CRUD operations
+- Search and filtering
+- Batch processing
+- Webhook handling
+
+### System Integration
+- Microservice communication
+- Third-party API calls
+- Message queue processing
+- Event-driven architecture
+
+### Business Processes
+- Order fulfillment
+- Payment processing
+- Approval workflows
+- Notification chains

--- a/.agents/skills/receiving-code-review/SKILL.md
+++ b/.agents/skills/receiving-code-review/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: receiving-code-review
+description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
+---
+
+# Code Review Reception
+
+## Overview
+
+Code review requires technical evaluation, not emotional performance.
+
+**Core principle:** Verify before implementing. Ask before assuming. Technical correctness over social comfort.
+
+## The Response Pattern
+
+```
+WHEN receiving code review feedback:
+
+1. READ: Complete feedback without reacting
+2. UNDERSTAND: Restate requirement in own words (or ask)
+3. VERIFY: Check against codebase reality
+4. EVALUATE: Technically sound for THIS codebase?
+5. RESPOND: Technical acknowledgment or reasoned pushback
+6. IMPLEMENT: One item at a time, test each
+```
+
+## Forbidden Responses
+
+**NEVER:**
+- "You're absolutely right!" (explicit CLAUDE.md violation)
+- "Great point!" / "Excellent feedback!" (performative)
+- "Let me implement that now" (before verification)
+
+**INSTEAD:**
+- Restate the technical requirement
+- Ask clarifying questions
+- Push back with technical reasoning if wrong
+- Just start working (actions > words)
+
+## Handling Unclear Feedback
+
+```
+IF any item is unclear:
+  STOP - do not implement anything yet
+  ASK for clarification on unclear items
+
+WHY: Items may be related. Partial understanding = wrong implementation.
+```
+
+**Example:**
+```
+your human partner: "Fix 1-6"
+You understand 1,2,3,6. Unclear on 4,5.
+
+❌ WRONG: Implement 1,2,3,6 now, ask about 4,5 later
+✅ RIGHT: "I understand items 1,2,3,6. Need clarification on 4 and 5 before proceeding."
+```
+
+## Source-Specific Handling
+
+### From your human partner
+- **Trusted** - implement after understanding
+- **Still ask** if scope unclear
+- **No performative agreement**
+- **Skip to action** or technical acknowledgment
+
+### From External Reviewers
+```
+BEFORE implementing:
+  1. Check: Technically correct for THIS codebase?
+  2. Check: Breaks existing functionality?
+  3. Check: Reason for current implementation?
+  4. Check: Works on all platforms/versions?
+  5. Check: Does reviewer understand full context?
+
+IF suggestion seems wrong:
+  Push back with technical reasoning
+
+IF can't easily verify:
+  Say so: "I can't verify this without [X]. Should I [investigate/ask/proceed]?"
+
+IF conflicts with your human partner's prior decisions:
+  Stop and discuss with your human partner first
+```
+
+**your human partner's rule:** "External feedback - be skeptical, but check carefully"
+
+## YAGNI Check for "Professional" Features
+
+```
+IF reviewer suggests "implementing properly":
+  grep codebase for actual usage
+
+  IF unused: "This endpoint isn't called. Remove it (YAGNI)?"
+  IF used: Then implement properly
+```
+
+**your human partner's rule:** "You and reviewer both report to me. If we don't need this feature, don't add it."
+
+## Implementation Order
+
+```
+FOR multi-item feedback:
+  1. Clarify anything unclear FIRST
+  2. Then implement in this order:
+     - Blocking issues (breaks, security)
+     - Simple fixes (typos, imports)
+     - Complex fixes (refactoring, logic)
+  3. Test each fix individually
+  4. Verify no regressions
+```
+
+## When To Push Back
+
+Push back when:
+- Suggestion breaks existing functionality
+- Reviewer lacks full context
+- Violates YAGNI (unused feature)
+- Technically incorrect for this stack
+- Legacy/compatibility reasons exist
+- Conflicts with your human partner's architectural decisions
+
+**How to push back:**
+- Use technical reasoning, not defensiveness
+- Ask specific questions
+- Reference working tests/code
+- Involve your human partner if architectural
+
+**Signal if uncomfortable pushing back out loud:** "Strange things are afoot at the Circle K"
+
+## Acknowledging Correct Feedback
+
+When feedback IS correct:
+```
+✅ "Fixed. [Brief description of what changed]"
+✅ "Good catch - [specific issue]. Fixed in [location]."
+✅ [Just fix it and show in the code]
+
+❌ "You're absolutely right!"
+❌ "Great point!"
+❌ "Thanks for catching that!"
+❌ "Thanks for [anything]"
+❌ ANY gratitude expression
+```
+
+**Why no thanks:** Actions speak. Just fix it. The code itself shows you heard the feedback.
+
+**If you catch yourself about to write "Thanks":** DELETE IT. State the fix instead.
+
+## Gracefully Correcting Your Pushback
+
+If you pushed back and were wrong:
+```
+✅ "You were right - I checked [X] and it does [Y]. Implementing now."
+✅ "Verified this and you're correct. My initial understanding was wrong because [reason]. Fixing."
+
+❌ Long apology
+❌ Defending why you pushed back
+❌ Over-explaining
+```
+
+State the correction factually and move on.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Performative agreement | State requirement or just act |
+| Blind implementation | Verify against codebase first |
+| Batch without testing | One at a time, test each |
+| Assuming reviewer is right | Check if breaks things |
+| Avoiding pushback | Technical correctness > comfort |
+| Partial implementation | Clarify all items first |
+| Can't verify, proceed anyway | State limitation, ask for direction |
+
+## Real Examples
+
+**Performative Agreement (Bad):**
+```
+Reviewer: "Remove legacy code"
+❌ "You're absolutely right! Let me remove that..."
+```
+
+**Technical Verification (Good):**
+```
+Reviewer: "Remove legacy code"
+✅ "Checking... build target is 10.15+, this API needs 13+. Need legacy for backward compat. Current impl has wrong bundle ID - fix it or drop pre-13 support?"
+```
+
+**YAGNI (Good):**
+```
+Reviewer: "Implement proper metrics tracking with database, date filters, CSV export"
+✅ "Grepped codebase - nothing calls this endpoint. Remove it (YAGNI)? Or is there usage I'm missing?"
+```
+
+**Unclear Item (Good):**
+```
+your human partner: "Fix items 1-6"
+You understand 1,2,3,6. Unclear on 4,5.
+✅ "Understand 1,2,3,6. Need clarification on 4 and 5 before implementing."
+```
+
+## GitHub Thread Replies
+
+When replying to inline review comments on GitHub, reply in the comment thread (`gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies`), not as a top-level PR comment.
+
+## The Bottom Line
+
+**External feedback = suggestions to evaluate, not orders to follow.**
+
+Verify. Question. Then implement.
+
+No performative agreement. Technical rigor always.

--- a/.agents/skills/requesting-code-review/SKILL.md
+++ b/.agents/skills/requesting-code-review/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: requesting-code-review
+description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements
+---
+
+# Requesting Code Review
+
+Dispatch a code reviewer subagent to catch issues before they cascade. The reviewer gets precisely crafted context for evaluation — never your session's history. This keeps the reviewer focused on the work product, not your thought process, and preserves your own context for continued work.
+
+**Core principle:** Review early, review often.
+
+## When to Request Review
+
+**Mandatory:**
+- After each task in subagent-driven development
+- After completing major feature
+- Before merge to main
+
+**Optional but valuable:**
+- When stuck (fresh perspective)
+- Before refactoring (baseline check)
+- After fixing complex bug
+
+## How to Request
+
+**1. Get git SHAs:**
+```bash
+BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+**2. Dispatch code reviewer subagent:**
+
+Use Task tool with `general-purpose` type, fill template at `code-reviewer.md`
+
+**Placeholders:**
+- `{DESCRIPTION}` - Brief summary of what you built
+- `{PLAN_OR_REQUIREMENTS}` - What it should do
+- `{BASE_SHA}` - Starting commit
+- `{HEAD_SHA}` - Ending commit
+
+**3. Act on feedback:**
+- Fix Critical issues immediately
+- Fix Important issues before proceeding
+- Note Minor issues for later
+- Push back if reviewer is wrong (with reasoning)
+
+## Example
+
+```
+[Just completed Task 2: Add verification function]
+
+You: Let me request code review before proceeding.
+
+BASE_SHA=$(git log --oneline | grep "Task 1" | head -1 | awk '{print $1}')
+HEAD_SHA=$(git rev-parse HEAD)
+
+[Dispatch code reviewer subagent]
+  DESCRIPTION: Added verifyIndex() and repairIndex() with 4 issue types
+  PLAN_OR_REQUIREMENTS: Task 2 from docs/superpowers/plans/deployment-plan.md
+  BASE_SHA: a7981ec
+  HEAD_SHA: 3df7661
+
+[Subagent returns]:
+  Strengths: Clean architecture, real tests
+  Issues:
+    Important: Missing progress indicators
+    Minor: Magic number (100) for reporting interval
+  Assessment: Ready to proceed
+
+You: [Fix progress indicators]
+[Continue to Task 3]
+```
+
+## Integration with Workflows
+
+**Subagent-Driven Development:**
+- Review after EACH task
+- Catch issues before they compound
+- Fix before moving to next task
+
+**Executing Plans:**
+- Review after each task or at natural checkpoints
+- Get feedback, apply, continue
+
+**Ad-Hoc Development:**
+- Review before merge
+- Review when stuck
+
+## Red Flags
+
+**Never:**
+- Skip review because "it's simple"
+- Ignore Critical issues
+- Proceed with unfixed Important issues
+- Argue with valid technical feedback
+
+**If reviewer wrong:**
+- Push back with technical reasoning
+- Show code/tests that prove it works
+- Request clarification
+
+See template at: requesting-code-review/code-reviewer.md

--- a/.agents/skills/requesting-code-review/code-reviewer.md
+++ b/.agents/skills/requesting-code-review/code-reviewer.md
@@ -1,0 +1,168 @@
+# Code Reviewer Prompt Template
+
+Use this template when dispatching a code reviewer subagent.
+
+**Purpose:** Review completed work against requirements and code quality standards before it cascades into more work.
+
+```
+Task tool (general-purpose):
+  description: "Review code changes"
+  prompt: |
+    You are a Senior Code Reviewer with expertise in software architecture,
+    design patterns, and best practices. Your job is to review completed work
+    against its plan or requirements and identify issues before they cascade.
+
+    ## What Was Implemented
+
+    {DESCRIPTION}
+
+    ## Requirements / Plan
+
+    {PLAN_OR_REQUIREMENTS}
+
+    ## Git Range to Review
+
+    **Base:** {BASE_SHA}
+    **Head:** {HEAD_SHA}
+
+    ```bash
+    git diff --stat {BASE_SHA}..{HEAD_SHA}
+    git diff {BASE_SHA}..{HEAD_SHA}
+    ```
+
+    ## What to Check
+
+    **Plan alignment:**
+    - Does the implementation match the plan / requirements?
+    - Are deviations justified improvements, or problematic departures?
+    - Is all planned functionality present?
+
+    **Code quality:**
+    - Clean separation of concerns?
+    - Proper error handling?
+    - Type safety where applicable?
+    - DRY without premature abstraction?
+    - Edge cases handled?
+
+    **Architecture:**
+    - Sound design decisions?
+    - Reasonable scalability and performance?
+    - Security concerns?
+    - Integrates cleanly with surrounding code?
+
+    **Testing:**
+    - Tests verify real behavior, not mocks?
+    - Edge cases covered?
+    - Integration tests where they matter?
+    - All tests passing?
+
+    **Production readiness:**
+    - Migration strategy if schema changed?
+    - Backward compatibility considered?
+    - Documentation complete?
+    - No obvious bugs?
+
+    ## Calibration
+
+    Categorize issues by actual severity. Not everything is Critical.
+    Acknowledge what was done well before listing issues — accurate praise
+    helps the implementer trust the rest of the feedback.
+
+    If you find significant deviations from the plan, flag them specifically
+    so the implementer can confirm whether the deviation was intentional.
+    If you find issues with the plan itself rather than the implementation,
+    say so.
+
+    ## Output Format
+
+    ### Strengths
+    [What's well done? Be specific.]
+
+    ### Issues
+
+    #### Critical (Must Fix)
+    [Bugs, security issues, data loss risks, broken functionality]
+
+    #### Important (Should Fix)
+    [Architecture problems, missing features, poor error handling, test gaps]
+
+    #### Minor (Nice to Have)
+    [Code style, optimization opportunities, documentation polish]
+
+    For each issue:
+    - File:line reference
+    - What's wrong
+    - Why it matters
+    - How to fix (if not obvious)
+
+    ### Recommendations
+    [Improvements for code quality, architecture, or process]
+
+    ### Assessment
+
+    **Ready to merge?** [Yes | No | With fixes]
+
+    **Reasoning:** [1-2 sentence technical assessment]
+
+    ## Critical Rules
+
+    **DO:**
+    - Categorize by actual severity
+    - Be specific (file:line, not vague)
+    - Explain WHY each issue matters
+    - Acknowledge strengths
+    - Give a clear verdict
+
+    **DON'T:**
+    - Say "looks good" without checking
+    - Mark nitpicks as Critical
+    - Give feedback on code you didn't actually read
+    - Be vague ("improve error handling")
+    - Avoid giving a clear verdict
+```
+
+**Placeholders:**
+- `{DESCRIPTION}` — brief summary of what was built
+- `{PLAN_OR_REQUIREMENTS}` — what it should do (plan file path, task text, or requirements)
+- `{BASE_SHA}` — starting commit
+- `{HEAD_SHA}` — ending commit
+
+**Reviewer returns:** Strengths, Issues (Critical / Important / Minor), Recommendations, Assessment
+
+## Example Output
+
+```
+### Strengths
+- Clean database schema with proper migrations (db.ts:15-42)
+- Comprehensive test coverage (18 tests, all edge cases)
+- Good error handling with fallbacks (summarizer.ts:85-92)
+
+### Issues
+
+#### Important
+1. **Missing help text in CLI wrapper**
+   - File: index-conversations:1-31
+   - Issue: No --help flag, users won't discover --concurrency
+   - Fix: Add --help case with usage examples
+
+2. **Date validation missing**
+   - File: search.ts:25-27
+   - Issue: Invalid dates silently return no results
+   - Fix: Validate ISO format, throw error with example
+
+#### Minor
+1. **Progress indicators**
+   - File: indexer.ts:130
+   - Issue: No "X of Y" counter for long operations
+   - Impact: Users don't know how long to wait
+
+### Recommendations
+- Add progress reporting for user experience
+- Consider config file for excluded projects (portability)
+
+### Assessment
+
+**Ready to merge: With fixes**
+
+**Reasoning:** Core implementation is solid with good architecture and tests. Important issues (help text, date validation) are easily fixed and don't affect core functionality.
+```

--- a/.agents/skills/skill-creator/LICENSE.txt
+++ b/.agents/skills/skill-creator/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/skills/skill-creator/SKILL.md
+++ b/.agents/skills/skill-creator/SKILL.md
@@ -1,0 +1,485 @@
+---
+name: skill-creator
+description: Create new skills, modify and improve existing skills, and measure skill performance. Use when users want to create a skill from scratch, edit, or optimize an existing skill, run evals to test a skill, benchmark skill performance with variance analysis, or optimize a skill's description for better triggering accuracy.
+---
+
+# Skill Creator
+
+A skill for creating new skills and iteratively improving them.
+
+At a high level, the process of creating a skill goes like this:
+
+- Decide what you want the skill to do and roughly how it should do it
+- Write a draft of the skill
+- Create a few test prompts and run claude-with-access-to-the-skill on them
+- Help the user evaluate the results both qualitatively and quantitatively
+  - While the runs happen in the background, draft some quantitative evals if there aren't any (if there are some, you can either use as is or modify if you feel something needs to change about them). Then explain them to the user (or if they already existed, explain the ones that already exist)
+  - Use the `eval-viewer/generate_review.py` script to show the user the results for them to look at, and also let them look at the quantitative metrics
+- Rewrite the skill based on feedback from the user's evaluation of the results (and also if there are any glaring flaws that become apparent from the quantitative benchmarks)
+- Repeat until you're satisfied
+- Expand the test set and try again at larger scale
+
+Your job when using this skill is to figure out where the user is in this process and then jump in and help them progress through these stages. So for instance, maybe they're like "I want to make a skill for X". You can help narrow down what they mean, write a draft, write the test cases, figure out how they want to evaluate, run all the prompts, and repeat.
+
+On the other hand, maybe they already have a draft of the skill. In this case you can go straight to the eval/iterate part of the loop.
+
+Of course, you should always be flexible and if the user is like "I don't need to run a bunch of evaluations, just vibe with me", you can do that instead.
+
+Then after the skill is done (but again, the order is flexible), you can also run the skill description improver, which we have a whole separate script for, to optimize the triggering of the skill.
+
+Cool? Cool.
+
+## Communicating with the user
+
+The skill creator is liable to be used by people across a wide range of familiarity with coding jargon. If you haven't heard (and how could you, it's only very recently that it started), there's a trend now where the power of Claude is inspiring plumbers to open up their terminals, parents and grandparents to google "how to install npm". On the other hand, the bulk of users are probably fairly computer-literate.
+
+So please pay attention to context cues to understand how to phrase your communication! In the default case, just to give you some idea:
+
+- "evaluation" and "benchmark" are borderline, but OK
+- for "JSON" and "assertion" you want to see serious cues from the user that they know what those things are before using them without explaining them
+
+It's OK to briefly explain terms if you're in doubt, and feel free to clarify terms with a short definition if you're unsure if the user will get it.
+
+---
+
+## Creating a skill
+
+### Capture Intent
+
+Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding to the next step.
+
+1. What should this skill enable Claude to do?
+2. When should this skill trigger? (what user phrases/contexts)
+3. What's the expected output format?
+4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on the skill type, but let the user decide.
+
+### Interview and Research
+
+Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.
+
+Check available MCPs - if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via subagents if available, otherwise inline. Come prepared with context to reduce burden on the user.
+
+### Write the SKILL.md
+
+Based on the user interview, fill in these components:
+
+- **name**: Skill identifier
+- **description**: When to trigger, what it does. This is the primary triggering mechanism - include both what the skill does AND specific contexts for when to use it. All "when to use" info goes here, not in the body. Note: currently Claude has a tendency to "undertrigger" skills -- to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'"
+- **compatibility**: Required tools, dependencies (optional, rarely needed)
+- **the rest of the skill :)**
+
+### Skill Writing Guide
+
+#### Anatomy of a Skill
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter (name, description required)
+│   └── Markdown instructions
+└── Bundled Resources (optional)
+    ├── scripts/    - Executable code for deterministic/repetitive tasks
+    ├── references/ - Docs loaded into context as needed
+    └── assets/     - Files used in output (templates, icons, fonts)
+```
+
+#### Progressive Disclosure
+
+Skills use a three-level loading system:
+1. **Metadata** (name + description) - Always in context (~100 words)
+2. **SKILL.md body** - In context whenever skill triggers (<500 lines ideal)
+3. **Bundled resources** - As needed (unlimited, scripts can execute without loading)
+
+These word counts are approximate and you can feel free to go longer if needed.
+
+**Key patterns:**
+- Keep SKILL.md under 500 lines; if you're approaching this limit, add an additional layer of hierarchy along with clear pointers about where the model using the skill should go next to follow up.
+- Reference files clearly from SKILL.md with guidance on when to read them
+- For large reference files (>300 lines), include a table of contents
+
+**Domain organization**: When a skill supports multiple domains/frameworks, organize by variant:
+```
+cloud-deploy/
+├── SKILL.md (workflow + selection)
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+Claude reads only the relevant reference file.
+
+#### Principle of Lack of Surprise
+
+This goes without saying, but skills must not contain malware, exploit code, or any content that could compromise system security. A skill's contents should not surprise the user in their intent if described. Don't go along with requests to create misleading skills or skills designed to facilitate unauthorized access, data exfiltration, or other malicious activities. Things like a "roleplay as an XYZ" are OK though.
+
+#### Writing Patterns
+
+Prefer using the imperative form in instructions.
+
+**Defining output formats** - You can do it like this:
+```markdown
+## Report structure
+ALWAYS use this exact template:
+# [Title]
+## Executive summary
+## Key findings
+## Recommendations
+```
+
+**Examples pattern** - It's useful to include examples. You can format them like this (but if "Input" and "Output" are in the examples you might want to deviate a little):
+```markdown
+## Commit message format
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output: feat(auth): implement JWT-based authentication
+```
+
+### Writing Style
+
+Try to explain to the model why things are important in lieu of heavy-handed musty MUSTs. Use theory of mind and try to make the skill general and not super-narrow to specific examples. Start by writing a draft and then look at it with fresh eyes and improve it.
+
+### Test Cases
+
+After writing the skill draft, come up with 2-3 realistic test prompts — the kind of thing a real user would actually say. Share them with the user: [you don't have to use this exact language] "Here are a few test cases I'd like to try. Do these look right, or do you want to add more?" Then run them.
+
+Save test cases to `evals/evals.json`. Don't write assertions yet — just the prompts. You'll draft assertions in the next step while the runs are in progress.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's task prompt",
+      "expected_output": "Description of expected result",
+      "files": []
+    }
+  ]
+}
+```
+
+See `references/schemas.md` for the full schema (including the `assertions` field, which you'll add later).
+
+## Running and evaluating test cases
+
+This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
+
+Put results in `<skill-name>-workspace/` as a sibling to the skill directory. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+
+### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
+
+For each test case, spawn two subagents in the same turn — one with the skill, one without. This is important: don't spawn the with-skill runs first and then come back for baselines later. Launch everything at once so it all finishes around the same time.
+
+**With-skill run:**
+
+```
+Execute this task:
+- Skill path: <path-to-skill>
+- Task: <eval prompt>
+- Input files: <eval files if any, or "none">
+- Save outputs to: <workspace>/iteration-<N>/eval-<ID>/with_skill/outputs/
+- Outputs to save: <what the user cares about — e.g., "the .docx file", "the final CSV">
+```
+
+**Baseline run** (same prompt, but the baseline depends on context):
+- **Creating a new skill**: no skill at all. Same prompt, no skill path, save to `without_skill/outputs/`.
+- **Improving an existing skill**: the old version. Before editing, snapshot the skill (`cp -r <skill-path> <workspace>/skill-snapshot/`), then point the baseline subagent at the snapshot. Save to `old_skill/outputs/`.
+
+Write an `eval_metadata.json` for each test case (assertions can be empty for now). Give each eval a descriptive name based on what it's testing — not just "eval-0". Use this name for the directory too. If this iteration uses new or modified eval prompts, create these files for each new eval directory — don't assume they carry over from previous iterations.
+
+```json
+{
+  "eval_id": 0,
+  "eval_name": "descriptive-name-here",
+  "prompt": "The user's task prompt",
+  "assertions": []
+}
+```
+
+### Step 2: While runs are in progress, draft assertions
+
+Don't just wait for the runs to finish — you can use this time productively. Draft quantitative assertions for each test case and explain them to the user. If assertions already exist in `evals/evals.json`, review them and explain what they check.
+
+Good assertions are objectively verifiable and have descriptive names — they should read clearly in the benchmark viewer so someone glancing at the results immediately understands what each one checks. Subjective skills (writing style, design quality) are better evaluated qualitatively — don't force assertions onto things that need human judgment.
+
+Update the `eval_metadata.json` files and `evals/evals.json` with the assertions once drafted. Also explain to the user what they'll see in the viewer — both the qualitative outputs and the quantitative benchmark.
+
+### Step 3: As runs complete, capture timing data
+
+When each subagent task completes, you receive a notification containing `total_tokens` and `duration_ms`. Save this data immediately to `timing.json` in the run directory:
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3
+}
+```
+
+This is the only opportunity to capture this data — it comes through the task notification and isn't persisted elsewhere. Process each notification as it arrives rather than trying to batch them.
+
+### Step 4: Grade, aggregate, and launch the viewer
+
+Once all runs are done:
+
+1. **Grade each run** — spawn a grader subagent (or grade inline) that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
+
+2. **Aggregate into benchmark** — run the aggregation script from the skill-creator directory:
+   ```bash
+   python -m scripts.aggregate_benchmark <workspace>/iteration-N --skill-name <name>
+   ```
+   This produces `benchmark.json` and `benchmark.md` with pass_rate, time, and tokens for each configuration, with mean ± stddev and the delta. If generating benchmark.json manually, see `references/schemas.md` for the exact schema the viewer expects.
+Put each with_skill version before its baseline counterpart.
+
+3. **Do an analyst pass** — read the benchmark data and surface patterns the aggregate stats might hide. See `agents/analyzer.md` (the "Analyzing Benchmark Results" section) for what to look for — things like assertions that always pass regardless of skill (non-discriminating), high-variance evals (possibly flaky), and time/token tradeoffs.
+
+4. **Launch the viewer** with both qualitative outputs and quantitative data:
+   ```bash
+   nohup python <skill-creator-path>/eval-viewer/generate_review.py \
+     <workspace>/iteration-N \
+     --skill-name "my-skill" \
+     --benchmark <workspace>/iteration-N/benchmark.json \
+     > /dev/null 2>&1 &
+   VIEWER_PID=$!
+   ```
+   For iteration 2+, also pass `--previous-workspace <workspace>/iteration-<N-1>`.
+
+   **Cowork / headless environments:** If `webbrowser.open()` is not available or the environment has no display, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
+
+Note: please use generate_review.py to create the viewer; there's no need to write custom HTML.
+
+5. **Tell the user** something like: "I've opened the results in your browser. There are two tabs — 'Outputs' lets you click through each test case and leave feedback, 'Benchmark' shows the quantitative comparison. When you're done, come back here and let me know."
+
+### What the user sees in the viewer
+
+The "Outputs" tab shows one test case at a time:
+- **Prompt**: the task that was given
+- **Output**: the files the skill produced, rendered inline where possible
+- **Previous Output** (iteration 2+): collapsed section showing last iteration's output
+- **Formal Grades** (if grading was run): collapsed section showing assertion pass/fail
+- **Feedback**: a textbox that auto-saves as they type
+- **Previous Feedback** (iteration 2+): their comments from last time, shown below the textbox
+
+The "Benchmark" tab shows the stats summary: pass rates, timing, and token usage for each configuration, with per-eval breakdowns and analyst observations.
+
+Navigation is via prev/next buttons or arrow keys. When done, they click "Submit All Reviews" which saves all feedback to `feedback.json`.
+
+### Step 5: Read the feedback
+
+When the user tells you they're done, read `feedback.json`:
+
+```json
+{
+  "reviews": [
+    {"run_id": "eval-0-with_skill", "feedback": "the chart is missing axis labels", "timestamp": "..."},
+    {"run_id": "eval-1-with_skill", "feedback": "", "timestamp": "..."},
+    {"run_id": "eval-2-with_skill", "feedback": "perfect, love this", "timestamp": "..."}
+  ],
+  "status": "complete"
+}
+```
+
+Empty feedback means the user thought it was fine. Focus your improvements on the test cases where the user had specific complaints.
+
+Kill the viewer server when you're done with it:
+
+```bash
+kill $VIEWER_PID 2>/dev/null
+```
+
+---
+
+## Improving the skill
+
+This is the heart of the loop. You've run the test cases, the user has reviewed the results, and now you need to make the skill better based on their feedback.
+
+### How to think about improvements
+
+1. **Generalize from the feedback.** The big picture thing that's happening here is that we're trying to create skills that can be used a million times (maybe literally, maybe even more who knows) across many different prompts. Here you and the user are iterating on only a few examples over and over again because it helps move faster. The user knows these examples in and out and it's quick for them to assess new outputs. But if the skill you and the user are codeveloping works only for those examples, it's useless. Rather than put in fiddly overfitty changes, or oppressively constrictive MUSTs, if there's some stubborn issue, you might try branching out and using different metaphors, or recommending different patterns of working. It's relatively cheap to try and maybe you'll land on something great.
+
+2. **Keep the prompt lean.** Remove things that aren't pulling their weight. Make sure to read the transcripts, not just the final outputs — if it looks like the skill is making the model waste a bunch of time doing things that are unproductive, you can try getting rid of the parts of the skill that are making it do that and seeing what happens.
+
+3. **Explain the why.** Try hard to explain the **why** behind everything you're asking the model to do. Today's LLMs are *smart*. They have good theory of mind and when given a good harness can go beyond rote instructions and really make things happen. Even if the feedback from the user is terse or frustrated, try to actually understand the task and why the user is writing what they wrote, and what they actually wrote, and then transmit this understanding into the instructions. If you find yourself writing ALWAYS or NEVER in all caps, or using super rigid structures, that's a yellow flag — if possible, reframe and explain the reasoning so that the model understands why the thing you're asking for is important. That's a more humane, powerful, and effective approach.
+
+4. **Look for repeated work across test cases.** Read the transcripts from the test runs and notice if the subagents all independently wrote similar helper scripts or took the same multi-step approach to something. If all 3 test cases resulted in the subagent writing a `create_docx.py` or a `build_chart.py`, that's a strong signal the skill should bundle that script. Write it once, put it in `scripts/`, and tell the skill to use it. This saves every future invocation from reinventing the wheel.
+
+This task is pretty important (we are trying to create billions a year in economic value here!) and your thinking time is not the blocker; take your time and really mull things over. I'd suggest writing a draft revision and then looking at it anew and making improvements. Really do your best to get into the head of the user and understand what they want and need.
+
+### The iteration loop
+
+After improving the skill:
+
+1. Apply your improvements to the skill
+2. Rerun all test cases into a new `iteration-<N+1>/` directory, including baseline runs. If you're creating a new skill, the baseline is always `without_skill` (no skill) — that stays the same across iterations. If you're improving an existing skill, use your judgment on what makes sense as the baseline: the original version the user came in with, or the previous iteration.
+3. Launch the reviewer with `--previous-workspace` pointing at the previous iteration
+4. Wait for the user to review and tell you they're done
+5. Read the new feedback, improve again, repeat
+
+Keep going until:
+- The user says they're happy
+- The feedback is all empty (everything looks good)
+- You're not making meaningful progress
+
+---
+
+## Advanced: Blind comparison
+
+For situations where you want a more rigorous comparison between two versions of a skill (e.g., the user asks "is the new version actually better?"), there's a blind comparison system. Read `agents/comparator.md` and `agents/analyzer.md` for the details. The basic idea is: give two outputs to an independent agent without telling it which is which, and let it judge quality. Then analyze why the winner won.
+
+This is optional, requires subagents, and most users won't need it. The human review loop is usually sufficient.
+
+---
+
+## Description Optimization
+
+The description field in SKILL.md frontmatter is the primary mechanism that determines whether Claude invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy.
+
+### Step 1: Generate trigger eval queries
+
+Create 20 eval queries — a mix of should-trigger and should-not-trigger. Save as JSON:
+
+```json
+[
+  {"query": "the user prompt", "should_trigger": true},
+  {"query": "another prompt", "should_trigger": false}
+]
+```
+
+The queries must be realistic and something a Claude Code or Claude.ai user would actually type. Not abstract requests, but requests that are concrete and specific and have a good amount of detail. For instance, file paths, personal context about the user's job or situation, column names and values, company names, URLs. A little bit of backstory. Some might be in lowercase or contain abbreviations or typos or casual speech. Use a mix of different lengths, and focus on edge cases rather than making them clear-cut (the user will get a chance to sign off on them).
+
+Bad: `"Format this data"`, `"Extract text from PDF"`, `"Create a chart"`
+
+Good: `"ok so my boss just sent me this xlsx file (its in my downloads, called something like 'Q4 sales final FINAL v2.xlsx') and she wants me to add a column that shows the profit margin as a percentage. The revenue is in column C and costs are in column D i think"`
+
+For the **should-trigger** queries (8-10), think about coverage. You want different phrasings of the same intent — some formal, some casual. Include cases where the user doesn't explicitly name the skill or file type but clearly needs it. Throw in some uncommon use cases and cases where this skill competes with another but should win.
+
+For the **should-not-trigger** queries (8-10), the most valuable ones are the near-misses — queries that share keywords or concepts with the skill but actually need something different. Think adjacent domains, ambiguous phrasing where a naive keyword match would trigger but shouldn't, and cases where the query touches on something the skill does but in a context where another tool is more appropriate.
+
+The key thing to avoid: don't make should-not-trigger queries obviously irrelevant. "Write a fibonacci function" as a negative test for a PDF skill is too easy — it doesn't test anything. The negative cases should be genuinely tricky.
+
+### Step 2: Review with user
+
+Present the eval set to the user for review using the HTML template:
+
+1. Read the template from `assets/eval_review.html`
+2. Replace the placeholders:
+   - `__EVAL_DATA_PLACEHOLDER__` → the JSON array of eval items (no quotes around it — it's a JS variable assignment)
+   - `__SKILL_NAME_PLACEHOLDER__` → the skill's name
+   - `__SKILL_DESCRIPTION_PLACEHOLDER__` → the skill's current description
+3. Write to a temp file (e.g., `/tmp/eval_review_<skill-name>.html`) and open it: `open /tmp/eval_review_<skill-name>.html`
+4. The user can edit queries, toggle should-trigger, add/remove entries, then click "Export Eval Set"
+5. The file downloads to `~/Downloads/eval_set.json` — check the Downloads folder for the most recent version in case there are multiple (e.g., `eval_set (1).json`)
+
+This step matters — bad eval queries lead to bad descriptions.
+
+### Step 3: Run the optimization loop
+
+Tell the user: "This will take some time — I'll run the optimization loop in the background and check on it periodically."
+
+Save the eval set to the workspace, then run in the background:
+
+```bash
+python -m scripts.run_loop \
+  --eval-set <path-to-trigger-eval.json> \
+  --skill-path <path-to-skill> \
+  --model <model-id-powering-this-session> \
+  --max-iterations 5 \
+  --verbose
+```
+
+Use the model ID from your system prompt (the one powering the current session) so the triggering test matches what the user actually experiences.
+
+While it runs, periodically tail the output to give the user updates on which iteration it's on and what the scores look like.
+
+This handles the full optimization loop automatically. It splits the eval set into 60% train and 40% held-out test, evaluates the current description (running each query 3 times to get a reliable trigger rate), then calls Claude to propose improvements based on what failed. It re-evaluates each new description on both train and test, iterating up to 5 times. When it's done, it opens an HTML report in the browser showing the results per iteration and returns JSON with `best_description` — selected by test score rather than train score to avoid overfitting.
+
+### How skill triggering works
+
+Understanding the triggering mechanism helps design better eval queries. Skills appear in Claude's `available_skills` list with their name + description, and Claude decides whether to consult a skill based on that description. The important thing to know is that Claude only consults skills for tasks it can't easily handle on its own — simple, one-step queries like "read this PDF" may not trigger a skill even if the description matches perfectly, because Claude can handle them directly with basic tools. Complex, multi-step, or specialized queries reliably trigger skills when the description matches.
+
+This means your eval queries should be substantive enough that Claude would actually benefit from consulting a skill. Simple queries like "read file X" are poor test cases — they won't trigger skills regardless of description quality.
+
+### Step 4: Apply the result
+
+Take `best_description` from the JSON output and update the skill's SKILL.md frontmatter. Show the user before/after and report the scores.
+
+---
+
+### Package and Present (only if `present_files` tool is available)
+
+Check whether you have access to the `present_files` tool. If you don't, skip this step. If you do, package the skill and present the .skill file to the user:
+
+```bash
+python -m scripts.package_skill <path/to/skill-folder>
+```
+
+After packaging, direct the user to the resulting `.skill` file path so they can install it.
+
+---
+
+## Claude.ai-specific instructions
+
+In Claude.ai, the core workflow is the same (draft → test → review → improve → repeat), but because Claude.ai doesn't have subagents, some mechanics change. Here's what to adapt:
+
+**Running test cases**: No subagents means no parallel execution. For each test case, read the skill's SKILL.md, then follow its instructions to accomplish the test prompt yourself. Do them one at a time. This is less rigorous than independent subagents (you wrote the skill and you're also running it, so you have full context), but it's a useful sanity check — and the human review step compensates. Skip the baseline runs — just use the skill to complete the task as requested.
+
+**Reviewing results**: If you can't open a browser (e.g., Claude.ai's VM has no display, or you're on a remote server), skip the browser reviewer entirely. Instead, present results directly in the conversation. For each test case, show the prompt and the output. If the output is a file the user needs to see (like a .docx or .xlsx), save it to the filesystem and tell them where it is so they can download and inspect it. Ask for feedback inline: "How does this look? Anything you'd change?"
+
+**Benchmarking**: Skip the quantitative benchmarking — it relies on baseline comparisons which aren't meaningful without subagents. Focus on qualitative feedback from the user.
+
+**The iteration loop**: Same as before — improve the skill, rerun the test cases, ask for feedback — just without the browser reviewer in the middle. You can still organize results into iteration directories on the filesystem if you have one.
+
+**Description optimization**: This section requires the `claude` CLI tool (specifically `claude -p`) which is only available in Claude Code. Skip it if you're on Claude.ai.
+
+**Blind comparison**: Requires subagents. Skip it.
+
+**Packaging**: The `package_skill.py` script works anywhere with Python and a filesystem. On Claude.ai, you can run it and the user can download the resulting `.skill` file.
+
+**Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. In this case:
+- **Preserve the original name.** Note the skill's directory name and `name` frontmatter field -- use them unchanged. E.g., if the installed skill is `research-helper`, output `research-helper.skill` (not `research-helper-v2`).
+- **Copy to a writeable location before editing.** The installed skill path may be read-only. Copy to `/tmp/skill-name/`, edit there, and package from the copy.
+- **If packaging manually, stage in `/tmp/` first**, then copy to the output directory -- direct writes may fail due to permissions.
+
+---
+
+## Cowork-Specific Instructions
+
+If you're in Cowork, the main things to know are:
+
+- You have subagents, so the main workflow (spawn test cases in parallel, run baselines, grade, etc.) all works. (However, if you run into severe problems with timeouts, it's OK to run the test prompts in series rather than parallel.)
+- You don't have a browser or display, so when generating the eval viewer, use `--static <output_path>` to write a standalone HTML file instead of starting a server. Then proffer a link that the user can click to open the HTML in their browser.
+- For whatever reason, the Cowork setup seems to disincline Claude from generating the eval viewer after running the tests, so just to reiterate: whether you're in Cowork or in Claude Code, after running tests, you should always generate the eval viewer for the human to look at examples before revising the skill yourself and trying to make corrections, using `generate_review.py` (not writing your own boutique html code). Sorry in advance but I'm gonna go all caps here: GENERATE THE EVAL VIEWER *BEFORE* evaluating inputs yourself. You want to get them in front of the human ASAP!
+- Feedback works differently: since there's no running server, the viewer's "Submit All Reviews" button will download `feedback.json` as a file. You can then read it from there (you may have to request access first).
+- Packaging works — `package_skill.py` just needs Python and a filesystem.
+- Description optimization (`run_loop.py` / `run_eval.py`) should work in Cowork just fine since it uses `claude -p` via subprocess, not a browser, but please save it until you've fully finished making the skill and the user agrees it's in good shape.
+- **Updating an existing skill**: The user might be asking you to update an existing skill, not create a new one. Follow the update guidance in the claude.ai section above.
+
+---
+
+## Reference files
+
+The agents/ directory contains instructions for specialized subagents. Read them when you need to spawn the relevant subagent.
+
+- `agents/grader.md` — How to evaluate assertions against outputs
+- `agents/comparator.md` — How to do blind A/B comparison between two outputs
+- `agents/analyzer.md` — How to analyze why one version beat another
+
+The references/ directory has additional documentation:
+- `references/schemas.md` — JSON structures for evals.json, grading.json, etc.
+
+---
+
+Repeating one more time the core loop here for emphasis:
+
+- Figure out what the skill is about
+- Draft or edit the skill
+- Run claude-with-access-to-the-skill on test prompts
+- With the user, evaluate the outputs:
+  - Create benchmark.json and run `eval-viewer/generate_review.py` to help the user review them
+  - Run quantitative evals
+- Repeat until you and the user are satisfied
+- Package the final skill and return it to the user.
+
+Please add steps to your TodoList, if you have such a thing, to make sure you don't forget. If you're in Cowork, please specifically put "Create evals JSON and run `eval-viewer/generate_review.py` so human can review test cases" in your TodoList to make sure it happens.
+
+Good luck!

--- a/.agents/skills/skill-creator/agents/analyzer.md
+++ b/.agents/skills/skill-creator/agents/analyzer.md
@@ -1,0 +1,274 @@
+# Post-hoc Analyzer Agent
+
+Analyze blind comparison results to understand WHY the winner won and generate improvement suggestions.
+
+## Role
+
+After the blind comparator determines a winner, the Post-hoc Analyzer "unblids" the results by examining the skills and transcripts. The goal is to extract actionable insights: what made the winner better, and how can the loser be improved?
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **winner**: "A" or "B" (from blind comparison)
+- **winner_skill_path**: Path to the skill that produced the winning output
+- **winner_transcript_path**: Path to the execution transcript for the winner
+- **loser_skill_path**: Path to the skill that produced the losing output
+- **loser_transcript_path**: Path to the execution transcript for the loser
+- **comparison_result_path**: Path to the blind comparator's output JSON
+- **output_path**: Where to save the analysis results
+
+## Process
+
+### Step 1: Read Comparison Result
+
+1. Read the blind comparator's output at comparison_result_path
+2. Note the winning side (A or B), the reasoning, and any scores
+3. Understand what the comparator valued in the winning output
+
+### Step 2: Read Both Skills
+
+1. Read the winner skill's SKILL.md and key referenced files
+2. Read the loser skill's SKILL.md and key referenced files
+3. Identify structural differences:
+   - Instructions clarity and specificity
+   - Script/tool usage patterns
+   - Example coverage
+   - Edge case handling
+
+### Step 3: Read Both Transcripts
+
+1. Read the winner's transcript
+2. Read the loser's transcript
+3. Compare execution patterns:
+   - How closely did each follow their skill's instructions?
+   - What tools were used differently?
+   - Where did the loser diverge from optimal behavior?
+   - Did either encounter errors or make recovery attempts?
+
+### Step 4: Analyze Instruction Following
+
+For each transcript, evaluate:
+- Did the agent follow the skill's explicit instructions?
+- Did the agent use the skill's provided tools/scripts?
+- Were there missed opportunities to leverage skill content?
+- Did the agent add unnecessary steps not in the skill?
+
+Score instruction following 1-10 and note specific issues.
+
+### Step 5: Identify Winner Strengths
+
+Determine what made the winner better:
+- Clearer instructions that led to better behavior?
+- Better scripts/tools that produced better output?
+- More comprehensive examples that guided edge cases?
+- Better error handling guidance?
+
+Be specific. Quote from skills/transcripts where relevant.
+
+### Step 6: Identify Loser Weaknesses
+
+Determine what held the loser back:
+- Ambiguous instructions that led to suboptimal choices?
+- Missing tools/scripts that forced workarounds?
+- Gaps in edge case coverage?
+- Poor error handling that caused failures?
+
+### Step 7: Generate Improvement Suggestions
+
+Based on the analysis, produce actionable suggestions for improving the loser skill:
+- Specific instruction changes to make
+- Tools/scripts to add or modify
+- Examples to include
+- Edge cases to address
+
+Prioritize by impact. Focus on changes that would have changed the outcome.
+
+### Step 8: Write Analysis Results
+
+Save structured analysis to `{output_path}`.
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors",
+    "Explicit guidance on fallback behavior when OCR fails"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise and made errors",
+    "No guidance on OCR failure, agent gave up instead of trying alternatives"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": [
+        "Minor: skipped optional logging step"
+      ]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3",
+        "Missed the 'always validate output' instruction"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps: 1) Extract text, 2) Identify sections, 3) Format per template",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    },
+    {
+      "priority": "high",
+      "category": "tools",
+      "suggestion": "Add validate_output.py script similar to winner skill's validation approach",
+      "expected_impact": "Would catch formatting errors before final output"
+    },
+    {
+      "priority": "medium",
+      "category": "error_handling",
+      "suggestion": "Add fallback instructions: 'If OCR fails, try: 1) different resolution, 2) image preprocessing, 3) manual extraction'",
+      "expected_impact": "Would prevent early failure on difficult documents"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script -> Fixed 2 issues -> Produced output",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods -> No validation -> Output had errors"
+  }
+}
+```
+
+## Guidelines
+
+- **Be specific**: Quote from skills and transcripts, don't just say "instructions were unclear"
+- **Be actionable**: Suggestions should be concrete changes, not vague advice
+- **Focus on skill improvements**: The goal is to improve the losing skill, not critique the agent
+- **Prioritize by impact**: Which changes would most likely have changed the outcome?
+- **Consider causation**: Did the skill weakness actually cause the worse output, or is it incidental?
+- **Stay objective**: Analyze what happened, don't editorialize
+- **Think about generalization**: Would this improvement help on other evals too?
+
+## Categories for Suggestions
+
+Use these categories to organize improvement suggestions:
+
+| Category | Description |
+|----------|-------------|
+| `instructions` | Changes to the skill's prose instructions |
+| `tools` | Scripts, templates, or utilities to add/modify |
+| `examples` | Example inputs/outputs to include |
+| `error_handling` | Guidance for handling failures |
+| `structure` | Reorganization of skill content |
+| `references` | External docs or resources to add |
+
+## Priority Levels
+
+- **high**: Would likely change the outcome of this comparison
+- **medium**: Would improve quality but may not change win/loss
+- **low**: Nice to have, marginal improvement
+
+---
+
+# Analyzing Benchmark Results
+
+When analyzing benchmark results, the analyzer's purpose is to **surface patterns and anomalies** across multiple runs, not suggest skill improvements.
+
+## Role
+
+Review all benchmark run results and generate freeform notes that help the user understand skill performance. Focus on patterns that wouldn't be visible from aggregate metrics alone.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **benchmark_data_path**: Path to the in-progress benchmark.json with all run results
+- **skill_path**: Path to the skill being benchmarked
+- **output_path**: Where to save the notes (as JSON array of strings)
+
+## Process
+
+### Step 1: Read Benchmark Data
+
+1. Read the benchmark.json containing all run results
+2. Note the configurations tested (with_skill, without_skill)
+3. Understand the run_summary aggregates already calculated
+
+### Step 2: Analyze Per-Assertion Patterns
+
+For each expectation across all runs:
+- Does it **always pass** in both configurations? (may not differentiate skill value)
+- Does it **always fail** in both configurations? (may be broken or beyond capability)
+- Does it **always pass with skill but fail without**? (skill clearly adds value here)
+- Does it **always fail with skill but pass without**? (skill may be hurting)
+- Is it **highly variable**? (flaky expectation or non-deterministic behavior)
+
+### Step 3: Analyze Cross-Eval Patterns
+
+Look for patterns across evals:
+- Are certain eval types consistently harder/easier?
+- Do some evals show high variance while others are stable?
+- Are there surprising results that contradict expectations?
+
+### Step 4: Analyze Metrics Patterns
+
+Look at time_seconds, tokens, tool_calls:
+- Does the skill significantly increase execution time?
+- Is there high variance in resource usage?
+- Are there outlier runs that skew the aggregates?
+
+### Step 5: Generate Notes
+
+Write freeform observations as a list of strings. Each note should:
+- State a specific observation
+- Be grounded in the data (not speculation)
+- Help the user understand something the aggregate metrics don't show
+
+Examples:
+- "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value"
+- "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure that may be flaky"
+- "Without-skill runs consistently fail on table extraction expectations (0% pass rate)"
+- "Skill adds 13s average execution time but improves pass rate by 50%"
+- "Token usage is 80% higher with skill, primarily due to script output parsing"
+- "All 3 without-skill runs for eval 1 produced empty output"
+
+### Step 6: Write Notes
+
+Save notes to `{output_path}` as a JSON array of strings:
+
+```json
+[
+  "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+  "Eval 3 shows high variance (50% ± 40%) - run 2 had an unusual failure",
+  "Without-skill runs consistently fail on table extraction expectations",
+  "Skill adds 13s average execution time but improves pass rate by 50%"
+]
+```
+
+## Guidelines
+
+**DO:**
+- Report what you observe in the data
+- Be specific about which evals, expectations, or runs you're referring to
+- Note patterns that aggregate metrics would hide
+- Provide context that helps interpret the numbers
+
+**DO NOT:**
+- Suggest improvements to the skill (that's for the improvement step, not benchmarking)
+- Make subjective quality judgments ("the output was good/bad")
+- Speculate about causes without evidence
+- Repeat information already in the run_summary aggregates

--- a/.agents/skills/skill-creator/agents/comparator.md
+++ b/.agents/skills/skill-creator/agents/comparator.md
@@ -1,0 +1,202 @@
+# Blind Comparator Agent
+
+Compare two outputs WITHOUT knowing which skill produced them.
+
+## Role
+
+The Blind Comparator judges which output better accomplishes the eval task. You receive two outputs labeled A and B, but you do NOT know which skill produced which. This prevents bias toward a particular skill or approach.
+
+Your judgment is based purely on output quality and task completion.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **output_a_path**: Path to the first output file or directory
+- **output_b_path**: Path to the second output file or directory
+- **eval_prompt**: The original task/prompt that was executed
+- **expectations**: List of expectations to check (optional - may be empty)
+
+## Process
+
+### Step 1: Read Both Outputs
+
+1. Examine output A (file or directory)
+2. Examine output B (file or directory)
+3. Note the type, structure, and content of each
+4. If outputs are directories, examine all relevant files inside
+
+### Step 2: Understand the Task
+
+1. Read the eval_prompt carefully
+2. Identify what the task requires:
+   - What should be produced?
+   - What qualities matter (accuracy, completeness, format)?
+   - What would distinguish a good output from a poor one?
+
+### Step 3: Generate Evaluation Rubric
+
+Based on the task, generate a rubric with two dimensions:
+
+**Content Rubric** (what the output contains):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Correctness | Major errors | Minor errors | Fully correct |
+| Completeness | Missing key elements | Mostly complete | All elements present |
+| Accuracy | Significant inaccuracies | Minor inaccuracies | Accurate throughout |
+
+**Structure Rubric** (how the output is organized):
+| Criterion | 1 (Poor) | 3 (Acceptable) | 5 (Excellent) |
+|-----------|----------|----------------|---------------|
+| Organization | Disorganized | Reasonably organized | Clear, logical structure |
+| Formatting | Inconsistent/broken | Mostly consistent | Professional, polished |
+| Usability | Difficult to use | Usable with effort | Easy to use |
+
+Adapt criteria to the specific task. For example:
+- PDF form → "Field alignment", "Text readability", "Data placement"
+- Document → "Section structure", "Heading hierarchy", "Paragraph flow"
+- Data output → "Schema correctness", "Data types", "Completeness"
+
+### Step 4: Evaluate Each Output Against the Rubric
+
+For each output (A and B):
+
+1. **Score each criterion** on the rubric (1-5 scale)
+2. **Calculate dimension totals**: Content score, Structure score
+3. **Calculate overall score**: Average of dimension scores, scaled to 1-10
+
+### Step 5: Check Assertions (if provided)
+
+If expectations are provided:
+
+1. Check each expectation against output A
+2. Check each expectation against output B
+3. Count pass rates for each output
+4. Use expectation scores as secondary evidence (not the primary decision factor)
+
+### Step 6: Determine the Winner
+
+Compare A and B based on (in priority order):
+
+1. **Primary**: Overall rubric score (content + structure)
+2. **Secondary**: Assertion pass rates (if applicable)
+3. **Tiebreaker**: If truly equal, declare a TIE
+
+Be decisive - ties should be rare. One output is usually better, even if marginally.
+
+### Step 7: Write Comparison Results
+
+Save results to a JSON file at the path specified (or `comparison.json` if not specified).
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": true},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true},
+        {"text": "Output includes date", "passed": false},
+        {"text": "Format is PDF", "passed": true},
+        {"text": "Contains signature", "passed": false},
+        {"text": "Readable text", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+If no expectations were provided, omit the `expectation_results` field entirely.
+
+## Field Descriptions
+
+- **winner**: "A", "B", or "TIE"
+- **reasoning**: Clear explanation of why the winner was chosen (or why it's a tie)
+- **rubric**: Structured rubric evaluation for each output
+  - **content**: Scores for content criteria (correctness, completeness, accuracy)
+  - **structure**: Scores for structure criteria (organization, formatting, usability)
+  - **content_score**: Average of content criteria (1-5)
+  - **structure_score**: Average of structure criteria (1-5)
+  - **overall_score**: Combined score scaled to 1-10
+- **output_quality**: Summary quality assessment
+  - **score**: 1-10 rating (should match rubric overall_score)
+  - **strengths**: List of positive aspects
+  - **weaknesses**: List of issues or shortcomings
+- **expectation_results**: (Only if expectations provided)
+  - **passed**: Number of expectations that passed
+  - **total**: Total number of expectations
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+  - **details**: Individual expectation results
+
+## Guidelines
+
+- **Stay blind**: DO NOT try to infer which skill produced which output. Judge purely on output quality.
+- **Be specific**: Cite specific examples when explaining strengths and weaknesses.
+- **Be decisive**: Choose a winner unless outputs are genuinely equivalent.
+- **Output quality first**: Assertion scores are secondary to overall task completion.
+- **Be objective**: Don't favor outputs based on style preferences; focus on correctness and completeness.
+- **Explain your reasoning**: The reasoning field should make it clear why you chose the winner.
+- **Handle edge cases**: If both outputs fail, pick the one that fails less badly. If both are excellent, pick the one that's marginally better.

--- a/.agents/skills/skill-creator/agents/grader.md
+++ b/.agents/skills/skill-creator/agents/grader.md
@@ -1,0 +1,223 @@
+# Grader Agent
+
+Evaluate expectations against an execution transcript and outputs.
+
+## Role
+
+The Grader reviews a transcript and output files, then determines whether each expectation passes or fails. Provide clear evidence for each judgment.
+
+You have two jobs: grade the outputs, and critique the evals themselves. A passing grade on a weak assertion is worse than useless — it creates false confidence. When you notice an assertion that's trivially satisfied, or an important outcome that no assertion checks, say so.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **expectations**: List of expectations to evaluate (strings)
+- **transcript_path**: Path to the execution transcript (markdown file)
+- **outputs_dir**: Directory containing output files from execution
+
+## Process
+
+### Step 1: Read the Transcript
+
+1. Read the transcript file completely
+2. Note the eval prompt, execution steps, and final result
+3. Identify any issues or errors documented
+
+### Step 2: Examine Output Files
+
+1. List files in outputs_dir
+2. Read/examine each file relevant to the expectations. If outputs aren't plain text, use the inspection tools provided in your prompt — don't rely solely on what the transcript says the executor produced.
+3. Note contents, structure, and quality
+
+### Step 3: Evaluate Each Assertion
+
+For each expectation:
+
+1. **Search for evidence** in the transcript and outputs
+2. **Determine verdict**:
+   - **PASS**: Clear evidence the expectation is true AND the evidence reflects genuine task completion, not just surface-level compliance
+   - **FAIL**: No evidence, or evidence contradicts the expectation, or the evidence is superficial (e.g., correct filename but empty/wrong content)
+3. **Cite the evidence**: Quote the specific text or describe what you found
+
+### Step 4: Extract and Verify Claims
+
+Beyond the predefined expectations, extract implicit claims from the outputs and verify them:
+
+1. **Extract claims** from the transcript and outputs:
+   - Factual statements ("The form has 12 fields")
+   - Process claims ("Used pypdf to fill the form")
+   - Quality claims ("All fields were filled correctly")
+
+2. **Verify each claim**:
+   - **Factual claims**: Can be checked against the outputs or external sources
+   - **Process claims**: Can be verified from the transcript
+   - **Quality claims**: Evaluate whether the claim is justified
+
+3. **Flag unverifiable claims**: Note claims that cannot be verified with available information
+
+This catches issues that predefined expectations might miss.
+
+### Step 5: Read User Notes
+
+If `{outputs_dir}/user_notes.md` exists:
+1. Read it and note any uncertainties or issues flagged by the executor
+2. Include relevant concerns in the grading output
+3. These may reveal problems even when expectations pass
+
+### Step 6: Critique the Evals
+
+After grading, consider whether the evals themselves could be improved. Only surface suggestions when there's a clear gap.
+
+Good suggestions test meaningful outcomes — assertions that are hard to satisfy without actually doing the work correctly. Think about what makes an assertion *discriminating*: it passes when the skill genuinely succeeds and fails when it doesn't.
+
+Suggestions worth raising:
+- An assertion that passed but would also pass for a clearly wrong output (e.g., checking filename existence but not file content)
+- An important outcome you observed — good or bad — that no assertion covers at all
+- An assertion that can't actually be verified from the available outputs
+
+Keep the bar high. The goal is to flag things the eval author would say "good catch" about, not to nitpick every assertion.
+
+### Step 7: Write Grading Results
+
+Save results to `{outputs_dir}/../grading.json` (sibling to outputs_dir).
+
+## Grading Criteria
+
+**PASS when**:
+- The transcript or outputs clearly demonstrate the expectation is true
+- Specific evidence can be cited
+- The evidence reflects genuine substance, not just surface compliance (e.g., a file exists AND contains correct content, not just the right filename)
+
+**FAIL when**:
+- No evidence found for the expectation
+- Evidence contradicts the expectation
+- The expectation cannot be verified from available information
+- The evidence is superficial — the assertion is technically satisfied but the underlying task outcome is wrong or incomplete
+- The output appears to meet the assertion by coincidence rather than by actually doing the work
+
+**When uncertain**: The burden of proof to pass is on the expectation.
+
+### Step 8: Read Executor Metrics and Timing
+
+1. If `{outputs_dir}/metrics.json` exists, read it and include in grading output
+2. If `{outputs_dir}/../timing.json` exists, read it and include timing data
+
+## Output Format
+
+Write a JSON file with this structure:
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    },
+    {
+      "text": "The assistant used the skill's OCR script",
+      "passed": true,
+      "evidence": "Transcript Step 2 shows: 'Tool: Bash - python ocr_script.py image.png'"
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    },
+    {
+      "claim": "All required fields were populated",
+      "type": "quality",
+      "verified": false,
+      "evidence": "Reference section was left blank despite data being available"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass — consider checking it appears as the primary contact with matching phone and email from the input"
+      },
+      {
+        "reason": "No assertion checks whether the extracted phone numbers match the input — I observed incorrect numbers in the output that went uncaught"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness. Consider adding content verification."
+  }
+}
+```
+
+## Field Descriptions
+
+- **expectations**: Array of graded expectations
+  - **text**: The original expectation text
+  - **passed**: Boolean - true if expectation passes
+  - **evidence**: Specific quote or description supporting the verdict
+- **summary**: Aggregate statistics
+  - **passed**: Count of passed expectations
+  - **failed**: Count of failed expectations
+  - **total**: Total expectations evaluated
+  - **pass_rate**: Fraction passed (0.0 to 1.0)
+- **execution_metrics**: Copied from executor's metrics.json (if available)
+  - **output_chars**: Total character count of output files (proxy for tokens)
+  - **transcript_chars**: Character count of transcript
+- **timing**: Wall clock timing from timing.json (if available)
+  - **executor_duration_seconds**: Time spent in executor subagent
+  - **total_duration_seconds**: Total elapsed time for the run
+- **claims**: Extracted and verified claims from the output
+  - **claim**: The statement being verified
+  - **type**: "factual", "process", or "quality"
+  - **verified**: Boolean - whether the claim holds
+  - **evidence**: Supporting or contradicting evidence
+- **user_notes_summary**: Issues flagged by the executor
+  - **uncertainties**: Things the executor wasn't sure about
+  - **needs_review**: Items requiring human attention
+  - **workarounds**: Places where the skill didn't work as expected
+- **eval_feedback**: Improvement suggestions for the evals (only when warranted)
+  - **suggestions**: List of concrete suggestions, each with a `reason` and optionally an `assertion` it relates to
+  - **overall**: Brief assessment — can be "No suggestions, evals look solid" if nothing to flag
+
+## Guidelines
+
+- **Be objective**: Base verdicts on evidence, not assumptions
+- **Be specific**: Quote the exact text that supports your verdict
+- **Be thorough**: Check both transcript and output files
+- **Be consistent**: Apply the same standard to each expectation
+- **Explain failures**: Make it clear why evidence was insufficient
+- **No partial credit**: Each expectation is pass or fail, not partial

--- a/.agents/skills/skill-creator/assets/eval_review.html
+++ b/.agents/skills/skill-creator/assets/eval_review.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Set Review - __SKILL_NAME_PLACEHOLDER__</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Lora', Georgia, serif; background: #faf9f5; padding: 2rem; color: #141413; }
+    h1 { font-family: 'Poppins', sans-serif; margin-bottom: 0.5rem; font-size: 1.5rem; }
+    .description { color: #b0aea5; margin-bottom: 1.5rem; font-style: italic; max-width: 900px; }
+    .controls { margin-bottom: 1rem; display: flex; gap: 0.5rem; }
+    .btn { font-family: 'Poppins', sans-serif; padding: 0.5rem 1rem; border: none; border-radius: 6px; cursor: pointer; font-size: 0.875rem; font-weight: 500; }
+    .btn-add { background: #6a9bcc; color: white; }
+    .btn-add:hover { background: #5889b8; }
+    .btn-export { background: #d97757; color: white; }
+    .btn-export:hover { background: #c4613f; }
+    table { width: 100%; max-width: 1100px; border-collapse: collapse; background: white; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    th { font-family: 'Poppins', sans-serif; background: #141413; color: #faf9f5; padding: 0.75rem 1rem; text-align: left; font-size: 0.875rem; }
+    td { padding: 0.75rem 1rem; border-bottom: 1px solid #e8e6dc; vertical-align: top; }
+    tr:nth-child(even) td { background: #faf9f5; }
+    tr:hover td { background: #f3f1ea; }
+    .section-header td { background: #e8e6dc; font-family: 'Poppins', sans-serif; font-weight: 500; font-size: 0.8rem; color: #141413; text-transform: uppercase; letter-spacing: 0.05em; }
+    .query-input { width: 100%; padding: 0.4rem; border: 1px solid #e8e6dc; border-radius: 4px; font-size: 0.875rem; font-family: 'Lora', Georgia, serif; resize: vertical; min-height: 60px; }
+    .query-input:focus { outline: none; border-color: #d97757; box-shadow: 0 0 0 2px rgba(217,119,87,0.15); }
+    .toggle { position: relative; display: inline-block; width: 44px; height: 24px; }
+    .toggle input { opacity: 0; width: 0; height: 0; }
+    .toggle .slider { position: absolute; inset: 0; background: #b0aea5; border-radius: 24px; cursor: pointer; transition: 0.2s; }
+    .toggle .slider::before { content: ""; position: absolute; width: 18px; height: 18px; left: 3px; bottom: 3px; background: white; border-radius: 50%; transition: 0.2s; }
+    .toggle input:checked + .slider { background: #d97757; }
+    .toggle input:checked + .slider::before { transform: translateX(20px); }
+    .btn-delete { background: #c44; color: white; padding: 0.3rem 0.6rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.75rem; font-family: 'Poppins', sans-serif; }
+    .btn-delete:hover { background: #a33; }
+    .summary { margin-top: 1rem; color: #b0aea5; font-size: 0.875rem; }
+  </style>
+</head>
+<body>
+  <h1>Eval Set Review: <span id="skill-name">__SKILL_NAME_PLACEHOLDER__</span></h1>
+  <p class="description">Current description: <span id="skill-desc">__SKILL_DESCRIPTION_PLACEHOLDER__</span></p>
+
+  <div class="controls">
+    <button class="btn btn-add" onclick="addRow()">+ Add Query</button>
+    <button class="btn btn-export" onclick="exportEvalSet()">Export Eval Set</button>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th style="width:65%">Query</th>
+        <th style="width:18%">Should Trigger</th>
+        <th style="width:10%">Actions</th>
+      </tr>
+    </thead>
+    <tbody id="eval-body"></tbody>
+  </table>
+
+  <p class="summary" id="summary"></p>
+
+  <script>
+    const EVAL_DATA = __EVAL_DATA_PLACEHOLDER__;
+
+    let evalItems = [...EVAL_DATA];
+
+    function render() {
+      const tbody = document.getElementById('eval-body');
+      tbody.innerHTML = '';
+
+      // Sort: should-trigger first, then should-not-trigger
+      const sorted = evalItems
+        .map((item, origIdx) => ({ ...item, origIdx }))
+        .sort((a, b) => (b.should_trigger ? 1 : 0) - (a.should_trigger ? 1 : 0));
+
+      let lastGroup = null;
+      sorted.forEach(item => {
+        const group = item.should_trigger ? 'trigger' : 'no-trigger';
+        if (group !== lastGroup) {
+          const headerRow = document.createElement('tr');
+          headerRow.className = 'section-header';
+          headerRow.innerHTML = `<td colspan="3">${item.should_trigger ? 'Should Trigger' : 'Should NOT Trigger'}</td>`;
+          tbody.appendChild(headerRow);
+          lastGroup = group;
+        }
+
+        const idx = item.origIdx;
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td><textarea class="query-input" onchange="updateQuery(${idx}, this.value)">${escapeHtml(item.query)}</textarea></td>
+          <td>
+            <label class="toggle">
+              <input type="checkbox" ${item.should_trigger ? 'checked' : ''} onchange="updateTrigger(${idx}, this.checked)">
+              <span class="slider"></span>
+            </label>
+            <span style="margin-left:8px;font-size:0.8rem;color:#b0aea5">${item.should_trigger ? 'Yes' : 'No'}</span>
+          </td>
+          <td><button class="btn-delete" onclick="deleteRow(${idx})">Delete</button></td>
+        `;
+        tbody.appendChild(tr);
+      });
+      updateSummary();
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    function updateQuery(idx, value) { evalItems[idx].query = value; updateSummary(); }
+    function updateTrigger(idx, value) { evalItems[idx].should_trigger = value; render(); }
+    function deleteRow(idx) { evalItems.splice(idx, 1); render(); }
+
+    function addRow() {
+      evalItems.push({ query: '', should_trigger: true });
+      render();
+      const inputs = document.querySelectorAll('.query-input');
+      inputs[inputs.length - 1].focus();
+    }
+
+    function updateSummary() {
+      const trigger = evalItems.filter(i => i.should_trigger).length;
+      const noTrigger = evalItems.filter(i => !i.should_trigger).length;
+      document.getElementById('summary').textContent =
+        `${evalItems.length} queries total: ${trigger} should trigger, ${noTrigger} should not trigger`;
+    }
+
+    function exportEvalSet() {
+      const valid = evalItems.filter(i => i.query.trim() !== '');
+      const data = valid.map(i => ({ query: i.query.trim(), should_trigger: i.should_trigger }));
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'eval_set.json';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+
+    render();
+  </script>
+</body>
+</html>

--- a/.agents/skills/skill-creator/eval-viewer/generate_review.py
+++ b/.agents/skills/skill-creator/eval-viewer/generate_review.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Generate and serve a review page for eval results.
+
+Reads the workspace directory, discovers runs (directories with outputs/),
+embeds all output data into a self-contained HTML page, and serves it via
+a tiny HTTP server. Feedback auto-saves to feedback.json in the workspace.
+
+Usage:
+    python generate_review.py <workspace-path> [--port PORT] [--skill-name NAME]
+    python generate_review.py <workspace-path> --previous-feedback /path/to/old/feedback.json
+
+No dependencies beyond the Python stdlib are required.
+"""
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import webbrowser
+from functools import partial
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+
+# Files to exclude from output listings
+METADATA_FILES = {"transcript.md", "user_notes.md", "metrics.json"}
+
+# Extensions we render as inline text
+TEXT_EXTENSIONS = {
+    ".txt", ".md", ".json", ".csv", ".py", ".js", ".ts", ".tsx", ".jsx",
+    ".yaml", ".yml", ".xml", ".html", ".css", ".sh", ".rb", ".go", ".rs",
+    ".java", ".c", ".cpp", ".h", ".hpp", ".sql", ".r", ".toml",
+}
+
+# Extensions we render as inline images
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
+
+# MIME type overrides for common types
+MIME_OVERRIDES = {
+    ".svg": "image/svg+xml",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+
+
+def get_mime_type(path: Path) -> str:
+    ext = path.suffix.lower()
+    if ext in MIME_OVERRIDES:
+        return MIME_OVERRIDES[ext]
+    mime, _ = mimetypes.guess_type(str(path))
+    return mime or "application/octet-stream"
+
+
+def find_runs(workspace: Path) -> list[dict]:
+    """Recursively find directories that contain an outputs/ subdirectory."""
+    runs: list[dict] = []
+    _find_runs_recursive(workspace, workspace, runs)
+    runs.sort(key=lambda r: (r.get("eval_id", float("inf")), r["id"]))
+    return runs
+
+
+def _find_runs_recursive(root: Path, current: Path, runs: list[dict]) -> None:
+    if not current.is_dir():
+        return
+
+    outputs_dir = current / "outputs"
+    if outputs_dir.is_dir():
+        run = build_run(root, current)
+        if run:
+            runs.append(run)
+        return
+
+    skip = {"node_modules", ".git", "__pycache__", "skill", "inputs"}
+    for child in sorted(current.iterdir()):
+        if child.is_dir() and child.name not in skip:
+            _find_runs_recursive(root, child, runs)
+
+
+def build_run(root: Path, run_dir: Path) -> dict | None:
+    """Build a run dict with prompt, outputs, and grading data."""
+    prompt = ""
+    eval_id = None
+
+    # Try eval_metadata.json
+    for candidate in [run_dir / "eval_metadata.json", run_dir.parent / "eval_metadata.json"]:
+        if candidate.exists():
+            try:
+                metadata = json.loads(candidate.read_text())
+                prompt = metadata.get("prompt", "")
+                eval_id = metadata.get("eval_id")
+            except (json.JSONDecodeError, OSError):
+                pass
+            if prompt:
+                break
+
+    # Fall back to transcript.md
+    if not prompt:
+        for candidate in [run_dir / "transcript.md", run_dir / "outputs" / "transcript.md"]:
+            if candidate.exists():
+                try:
+                    text = candidate.read_text()
+                    match = re.search(r"## Eval Prompt\n\n([\s\S]*?)(?=\n##|$)", text)
+                    if match:
+                        prompt = match.group(1).strip()
+                except OSError:
+                    pass
+                if prompt:
+                    break
+
+    if not prompt:
+        prompt = "(No prompt found)"
+
+    run_id = str(run_dir.relative_to(root)).replace("/", "-").replace("\\", "-")
+
+    # Collect output files
+    outputs_dir = run_dir / "outputs"
+    output_files: list[dict] = []
+    if outputs_dir.is_dir():
+        for f in sorted(outputs_dir.iterdir()):
+            if f.is_file() and f.name not in METADATA_FILES:
+                output_files.append(embed_file(f))
+
+    # Load grading if present
+    grading = None
+    for candidate in [run_dir / "grading.json", run_dir.parent / "grading.json"]:
+        if candidate.exists():
+            try:
+                grading = json.loads(candidate.read_text())
+            except (json.JSONDecodeError, OSError):
+                pass
+            if grading:
+                break
+
+    return {
+        "id": run_id,
+        "prompt": prompt,
+        "eval_id": eval_id,
+        "outputs": output_files,
+        "grading": grading,
+    }
+
+
+def embed_file(path: Path) -> dict:
+    """Read a file and return an embedded representation."""
+    ext = path.suffix.lower()
+    mime = get_mime_type(path)
+
+    if ext in TEXT_EXTENSIONS:
+        try:
+            content = path.read_text(errors="replace")
+        except OSError:
+            content = "(Error reading file)"
+        return {
+            "name": path.name,
+            "type": "text",
+            "content": content,
+        }
+    elif ext in IMAGE_EXTENSIONS:
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "image",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".pdf":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "pdf",
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+    elif ext == ".xlsx":
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "xlsx",
+            "data_b64": b64,
+        }
+    else:
+        # Binary / unknown — base64 download link
+        try:
+            raw = path.read_bytes()
+            b64 = base64.b64encode(raw).decode("ascii")
+        except OSError:
+            return {"name": path.name, "type": "error", "content": "(Error reading file)"}
+        return {
+            "name": path.name,
+            "type": "binary",
+            "mime": mime,
+            "data_uri": f"data:{mime};base64,{b64}",
+        }
+
+
+def load_previous_iteration(workspace: Path) -> dict[str, dict]:
+    """Load previous iteration's feedback and outputs.
+
+    Returns a map of run_id -> {"feedback": str, "outputs": list[dict]}.
+    """
+    result: dict[str, dict] = {}
+
+    # Load feedback
+    feedback_map: dict[str, str] = {}
+    feedback_path = workspace / "feedback.json"
+    if feedback_path.exists():
+        try:
+            data = json.loads(feedback_path.read_text())
+            feedback_map = {
+                r["run_id"]: r["feedback"]
+                for r in data.get("reviews", [])
+                if r.get("feedback", "").strip()
+            }
+        except (json.JSONDecodeError, OSError, KeyError):
+            pass
+
+    # Load runs (to get outputs)
+    prev_runs = find_runs(workspace)
+    for run in prev_runs:
+        result[run["id"]] = {
+            "feedback": feedback_map.get(run["id"], ""),
+            "outputs": run.get("outputs", []),
+        }
+
+    # Also add feedback for run_ids that had feedback but no matching run
+    for run_id, fb in feedback_map.items():
+        if run_id not in result:
+            result[run_id] = {"feedback": fb, "outputs": []}
+
+    return result
+
+
+def generate_html(
+    runs: list[dict],
+    skill_name: str,
+    previous: dict[str, dict] | None = None,
+    benchmark: dict | None = None,
+) -> str:
+    """Generate the complete standalone HTML page with embedded data."""
+    template_path = Path(__file__).parent / "viewer.html"
+    template = template_path.read_text()
+
+    # Build previous_feedback and previous_outputs maps for the template
+    previous_feedback: dict[str, str] = {}
+    previous_outputs: dict[str, list[dict]] = {}
+    if previous:
+        for run_id, data in previous.items():
+            if data.get("feedback"):
+                previous_feedback[run_id] = data["feedback"]
+            if data.get("outputs"):
+                previous_outputs[run_id] = data["outputs"]
+
+    embedded = {
+        "skill_name": skill_name,
+        "runs": runs,
+        "previous_feedback": previous_feedback,
+        "previous_outputs": previous_outputs,
+    }
+    if benchmark:
+        embedded["benchmark"] = benchmark
+
+    data_json = json.dumps(embedded)
+
+    return template.replace("/*__EMBEDDED_DATA__*/", f"const EMBEDDED_DATA = {data_json};")
+
+
+# ---------------------------------------------------------------------------
+# HTTP server (stdlib only, zero dependencies)
+# ---------------------------------------------------------------------------
+
+def _kill_port(port: int) -> None:
+    """Kill any process listening on the given port."""
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f":{port}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        for pid_str in result.stdout.strip().split("\n"):
+            if pid_str.strip():
+                try:
+                    os.kill(int(pid_str.strip()), signal.SIGTERM)
+                except (ProcessLookupError, ValueError):
+                    pass
+        if result.stdout.strip():
+            time.sleep(0.5)
+    except subprocess.TimeoutExpired:
+        pass
+    except FileNotFoundError:
+        print("Note: lsof not found, cannot check if port is in use", file=sys.stderr)
+
+class ReviewHandler(BaseHTTPRequestHandler):
+    """Serves the review HTML and handles feedback saves.
+
+    Regenerates the HTML on each page load so that refreshing the browser
+    picks up new eval outputs without restarting the server.
+    """
+
+    def __init__(
+        self,
+        workspace: Path,
+        skill_name: str,
+        feedback_path: Path,
+        previous: dict[str, dict],
+        benchmark_path: Path | None,
+        *args,
+        **kwargs,
+    ):
+        self.workspace = workspace
+        self.skill_name = skill_name
+        self.feedback_path = feedback_path
+        self.previous = previous
+        self.benchmark_path = benchmark_path
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self) -> None:
+        if self.path == "/" or self.path == "/index.html":
+            # Regenerate HTML on each request (re-scans workspace for new outputs)
+            runs = find_runs(self.workspace)
+            benchmark = None
+            if self.benchmark_path and self.benchmark_path.exists():
+                try:
+                    benchmark = json.loads(self.benchmark_path.read_text())
+                except (json.JSONDecodeError, OSError):
+                    pass
+            html = generate_html(runs, self.skill_name, self.previous, benchmark)
+            content = html.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        elif self.path == "/api/feedback":
+            data = b"{}"
+            if self.feedback_path.exists():
+                data = self.feedback_path.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+        else:
+            self.send_error(404)
+
+    def do_POST(self) -> None:
+        if self.path == "/api/feedback":
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            try:
+                data = json.loads(body)
+                if not isinstance(data, dict) or "reviews" not in data:
+                    raise ValueError("Expected JSON object with 'reviews' key")
+                self.feedback_path.write_text(json.dumps(data, indent=2) + "\n")
+                resp = b'{"ok":true}'
+                self.send_response(200)
+            except (json.JSONDecodeError, OSError, ValueError) as e:
+                resp = json.dumps({"error": str(e)}).encode()
+                self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(resp)))
+            self.end_headers()
+            self.wfile.write(resp)
+        else:
+            self.send_error(404)
+
+    def log_message(self, format: str, *args: object) -> None:
+        # Suppress request logging to keep terminal clean
+        pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate and serve eval review")
+    parser.add_argument("workspace", type=Path, help="Path to workspace directory")
+    parser.add_argument("--port", "-p", type=int, default=3117, help="Server port (default: 3117)")
+    parser.add_argument("--skill-name", "-n", type=str, default=None, help="Skill name for header")
+    parser.add_argument(
+        "--previous-workspace", type=Path, default=None,
+        help="Path to previous iteration's workspace (shows old outputs and feedback as context)",
+    )
+    parser.add_argument(
+        "--benchmark", type=Path, default=None,
+        help="Path to benchmark.json to show in the Benchmark tab",
+    )
+    parser.add_argument(
+        "--static", "-s", type=Path, default=None,
+        help="Write standalone HTML to this path instead of starting a server",
+    )
+    args = parser.parse_args()
+
+    workspace = args.workspace.resolve()
+    if not workspace.is_dir():
+        print(f"Error: {workspace} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    runs = find_runs(workspace)
+    if not runs:
+        print(f"No runs found in {workspace}", file=sys.stderr)
+        sys.exit(1)
+
+    skill_name = args.skill_name or workspace.name.replace("-workspace", "")
+    feedback_path = workspace / "feedback.json"
+
+    previous: dict[str, dict] = {}
+    if args.previous_workspace:
+        previous = load_previous_iteration(args.previous_workspace.resolve())
+
+    benchmark_path = args.benchmark.resolve() if args.benchmark else None
+    benchmark = None
+    if benchmark_path and benchmark_path.exists():
+        try:
+            benchmark = json.loads(benchmark_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    if args.static:
+        html = generate_html(runs, skill_name, previous, benchmark)
+        args.static.parent.mkdir(parents=True, exist_ok=True)
+        args.static.write_text(html)
+        print(f"\n  Static viewer written to: {args.static}\n")
+        sys.exit(0)
+
+    # Kill any existing process on the target port
+    port = args.port
+    _kill_port(port)
+    handler = partial(ReviewHandler, workspace, skill_name, feedback_path, previous, benchmark_path)
+    try:
+        server = HTTPServer(("127.0.0.1", port), handler)
+    except OSError:
+        # Port still in use after kill attempt — find a free one
+        server = HTTPServer(("127.0.0.1", 0), handler)
+        port = server.server_address[1]
+
+    url = f"http://localhost:{port}"
+    print(f"\n  Eval Viewer")
+    print(f"  ─────────────────────────────────")
+    print(f"  URL:       {url}")
+    print(f"  Workspace: {workspace}")
+    print(f"  Feedback:  {feedback_path}")
+    if previous:
+        print(f"  Previous:  {args.previous_workspace} ({len(previous)} runs)")
+    if benchmark_path:
+        print(f"  Benchmark: {benchmark_path}")
+    print(f"\n  Press Ctrl+C to stop.\n")
+
+    webbrowser.open(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopped.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/eval-viewer/viewer.html
+++ b/.agents/skills/skill-creator/eval-viewer/viewer.html
@@ -1,0 +1,1325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Eval Review</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+  <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js" integrity="sha384-EnyY0/GSHQGSxSgMwaIPzSESbqoOLSexfnSMN2AP+39Ckmn92stwABZynq1JyzdT" crossorigin="anonymous"></script>
+  <style>
+    :root {
+      --bg: #faf9f5;
+      --surface: #ffffff;
+      --border: #e8e6dc;
+      --text: #141413;
+      --text-muted: #b0aea5;
+      --accent: #d97757;
+      --accent-hover: #c4613f;
+      --green: #788c5d;
+      --green-bg: #eef2e8;
+      --red: #c44;
+      --red-bg: #fceaea;
+      --header-bg: #141413;
+      --header-text: #faf9f5;
+      --radius: 6px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Lora', Georgia, serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ---- Header ---- */
+    .header {
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 1rem 2rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .header h1 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .header .instructions {
+      font-size: 0.8rem;
+      opacity: 0.7;
+      margin-top: 0.25rem;
+    }
+    .header .progress {
+      font-size: 0.875rem;
+      opacity: 0.8;
+      text-align: right;
+    }
+
+    /* ---- Main content ---- */
+    .main {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1.5rem 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    /* ---- Sections ---- */
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      flex-shrink: 0;
+    }
+    .section-header {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.75rem 1rem;
+      font-size: 0.75rem;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+    }
+    .section-body {
+      padding: 1rem;
+    }
+
+    /* ---- Config badge ---- */
+    .config-badge {
+      display: inline-block;
+      padding: 0.2rem 0.625rem;
+      border-radius: 9999px;
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      margin-left: 0.75rem;
+      vertical-align: middle;
+    }
+    .config-badge.config-primary {
+      background: rgba(33, 150, 243, 0.12);
+      color: #1976d2;
+    }
+    .config-badge.config-baseline {
+      background: rgba(255, 193, 7, 0.15);
+      color: #f57f17;
+    }
+
+    /* ---- Prompt ---- */
+    .prompt-text {
+      white-space: pre-wrap;
+      font-size: 0.9375rem;
+      line-height: 1.6;
+    }
+
+    /* ---- Outputs ---- */
+    .output-file {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .output-file + .output-file {
+      margin-top: 1rem;
+    }
+    .output-file-header {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .output-file-header .dl-btn {
+      font-size: 0.7rem;
+      color: var(--accent);
+      text-decoration: none;
+      cursor: pointer;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 500;
+      opacity: 0.8;
+    }
+    .output-file-header .dl-btn:hover {
+      opacity: 1;
+      text-decoration: underline;
+    }
+    .output-file-content {
+      padding: 0.75rem;
+      overflow-x: auto;
+    }
+    .output-file-content pre {
+      font-size: 0.8125rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    }
+    .output-file-content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 4px;
+    }
+    .output-file-content iframe {
+      width: 100%;
+      height: 600px;
+      border: none;
+    }
+    .output-file-content table {
+      border-collapse: collapse;
+      font-size: 0.8125rem;
+      width: 100%;
+    }
+    .output-file-content table td,
+    .output-file-content table th {
+      border: 1px solid var(--border);
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+    }
+    .output-file-content table th {
+      background: var(--bg);
+      font-weight: 600;
+    }
+    .output-file-content .download-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 1rem;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 0.875rem;
+      cursor: pointer;
+    }
+    .output-file-content .download-link:hover {
+      background: var(--border);
+    }
+    .empty-state {
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 2rem;
+      text-align: center;
+    }
+
+    /* ---- Feedback ---- */
+    .prev-feedback {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.625rem 0.75rem;
+      margin-top: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .prev-feedback-label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-bottom: 0.25rem;
+      color: var(--text-muted);
+    }
+    .feedback-textarea {
+      width: 100%;
+      min-height: 100px;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: inherit;
+      font-size: 0.9375rem;
+      line-height: 1.5;
+      resize: vertical;
+      color: var(--text);
+    }
+    .feedback-textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    }
+    .feedback-status {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      margin-top: 0.5rem;
+      min-height: 1.1em;
+    }
+
+    /* ---- Grades (collapsible) ---- */
+    .grades-toggle {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
+    }
+    .grades-toggle:hover {
+      color: var(--accent);
+    }
+    .grades-toggle .arrow {
+      margin-right: 0.5rem;
+      transition: transform 0.15s;
+      font-size: 0.75rem;
+    }
+    .grades-toggle .arrow.open {
+      transform: rotate(90deg);
+    }
+    .grades-content {
+      display: none;
+      margin-top: 0.75rem;
+    }
+    .grades-content.open {
+      display: block;
+    }
+    .grades-summary {
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .grade-badge {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+    .grade-pass { background: var(--green-bg); color: var(--green); }
+    .grade-fail { background: var(--red-bg); color: var(--red); }
+    .assertion-list {
+      list-style: none;
+    }
+    .assertion-item {
+      padding: 0.625rem 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.8125rem;
+    }
+    .assertion-item:last-child { border-bottom: none; }
+    .assertion-status {
+      font-weight: 600;
+      margin-right: 0.5rem;
+    }
+    .assertion-status.pass { color: var(--green); }
+    .assertion-status.fail { color: var(--red); }
+    .assertion-evidence {
+      color: var(--text-muted);
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      padding-left: 1.5rem;
+    }
+
+    /* ---- View tabs ---- */
+    .view-tabs {
+      display: flex;
+      gap: 0;
+      padding: 0 2rem;
+      background: var(--bg);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .view-tab {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.625rem 1.25rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      border-bottom: 2px solid transparent;
+      transition: all 0.15s;
+    }
+    .view-tab:hover { color: var(--text); }
+    .view-tab.active {
+      color: var(--accent);
+      border-bottom-color: var(--accent);
+    }
+    .view-panel { display: none; }
+    .view-panel.active { display: flex; flex-direction: column; flex: 1; overflow: hidden; }
+
+    /* ---- Benchmark view ---- */
+    .benchmark-view {
+      padding: 1.5rem 2rem;
+      overflow-y: auto;
+      flex: 1;
+    }
+    .benchmark-table {
+      border-collapse: collapse;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      font-size: 0.8125rem;
+      width: 100%;
+      margin-bottom: 1.5rem;
+    }
+    .benchmark-table th, .benchmark-table td {
+      padding: 0.625rem 0.75rem;
+      text-align: left;
+      border: 1px solid var(--border);
+    }
+    .benchmark-table th {
+      font-family: 'Poppins', sans-serif;
+      background: var(--header-bg);
+      color: var(--header-text);
+      font-weight: 500;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .benchmark-table tr:hover { background: var(--bg); }
+    .benchmark-table tr.benchmark-row-with { background: rgba(33, 150, 243, 0.06); }
+    .benchmark-table tr.benchmark-row-without { background: rgba(255, 193, 7, 0.06); }
+    .benchmark-table tr.benchmark-row-with:hover { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-without:hover { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-table tr.benchmark-row-avg { font-weight: 600; border-top: 2px solid var(--border); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-with { background: rgba(33, 150, 243, 0.12); }
+    .benchmark-table tr.benchmark-row-avg.benchmark-row-without { background: rgba(255, 193, 7, 0.12); }
+    .benchmark-delta-positive { color: var(--green); font-weight: 600; }
+    .benchmark-delta-negative { color: var(--red); font-weight: 600; }
+    .benchmark-notes {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1rem;
+    }
+    .benchmark-notes h3 {
+      font-family: 'Poppins', sans-serif;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+    }
+    .benchmark-notes ul {
+      list-style: disc;
+      padding-left: 1.25rem;
+    }
+    .benchmark-notes li {
+      font-size: 0.8125rem;
+      line-height: 1.6;
+      margin-bottom: 0.375rem;
+    }
+    .benchmark-empty {
+      color: var(--text-muted);
+      font-style: italic;
+      text-align: center;
+      padding: 3rem;
+    }
+
+    /* ---- Navigation ---- */
+    .nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+      flex-shrink: 0;
+    }
+    .nav-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--text);
+      transition: all 0.15s;
+    }
+    .nav-btn:hover:not(:disabled) {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .nav-btn:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+    .done-btn {
+      font-family: 'Poppins', sans-serif;
+      padding: 0.5rem 1.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.15s;
+    }
+    .done-btn:hover {
+      background: var(--bg);
+      border-color: var(--text-muted);
+    }
+    .done-btn.ready {
+      border: none;
+      background: var(--accent);
+      color: white;
+      font-weight: 600;
+    }
+    .done-btn.ready:hover {
+      background: var(--accent-hover);
+    }
+    /* ---- Done overlay ---- */
+    .done-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 100;
+      justify-content: center;
+      align-items: center;
+    }
+    .done-overlay.visible {
+      display: flex;
+    }
+    .done-card {
+      background: var(--surface);
+      border-radius: 12px;
+      padding: 2rem 3rem;
+      text-align: center;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+      max-width: 500px;
+    }
+    .done-card h2 {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .done-card p {
+      color: var(--text-muted);
+      margin-bottom: 1.5rem;
+      line-height: 1.5;
+    }
+    .done-card .btn-row {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .done-card button {
+      padding: 0.5rem 1.25rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+    .done-card button:hover {
+      background: var(--bg);
+    }
+    /* ---- Toast ---- */
+    .toast {
+      position: fixed;
+      bottom: 5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--header-bg);
+      color: var(--header-text);
+      padding: 0.625rem 1.25rem;
+      border-radius: var(--radius);
+      font-size: 0.875rem;
+      opacity: 0;
+      transition: opacity 0.3s;
+      pointer-events: none;
+      z-index: 200;
+    }
+    .toast.visible {
+      opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <div id="app" style="height:100vh; display:flex; flex-direction:column;">
+    <div class="header">
+      <div>
+        <h1>Eval Review: <span id="skill-name"></span></h1>
+        <div class="instructions">Review each output and leave feedback below. Navigate with arrow keys or buttons. When done, copy feedback and paste into Claude Code.</div>
+      </div>
+      <div class="progress" id="progress"></div>
+    </div>
+
+    <!-- View tabs (only shown when benchmark data exists) -->
+    <div class="view-tabs" id="view-tabs" style="display:none;">
+      <button class="view-tab active" onclick="switchView('outputs')">Outputs</button>
+      <button class="view-tab" onclick="switchView('benchmark')">Benchmark</button>
+    </div>
+
+    <!-- Outputs panel (qualitative review) -->
+    <div class="view-panel active" id="panel-outputs">
+    <div class="main">
+      <!-- Prompt -->
+      <div class="section">
+        <div class="section-header">Prompt <span class="config-badge" id="config-badge" style="display:none;"></span></div>
+        <div class="section-body">
+          <div class="prompt-text" id="prompt-text"></div>
+        </div>
+      </div>
+
+      <!-- Outputs -->
+      <div class="section">
+        <div class="section-header">Output</div>
+        <div class="section-body" id="outputs-body">
+          <div class="empty-state">No output files found</div>
+        </div>
+      </div>
+
+      <!-- Previous Output (collapsible) -->
+      <div class="section" id="prev-outputs-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="togglePrevOutputs()">
+            <span class="arrow" id="prev-outputs-arrow">&#9654;</span>
+            Previous Output
+          </div>
+        </div>
+        <div class="grades-content" id="prev-outputs-content"></div>
+      </div>
+
+      <!-- Grades (collapsible) -->
+      <div class="section" id="grades-section" style="display:none;">
+        <div class="section-header">
+          <div class="grades-toggle" onclick="toggleGrades()">
+            <span class="arrow" id="grades-arrow">&#9654;</span>
+            Formal Grades
+          </div>
+        </div>
+        <div class="grades-content" id="grades-content"></div>
+      </div>
+
+      <!-- Feedback -->
+      <div class="section">
+        <div class="section-header">Your Feedback</div>
+        <div class="section-body">
+          <textarea
+            class="feedback-textarea"
+            id="feedback"
+            placeholder="What do you think of this output? Any issues, suggestions, or things that look great?"
+          ></textarea>
+          <div class="feedback-status" id="feedback-status"></div>
+          <div class="prev-feedback" id="prev-feedback" style="display:none;">
+            <div class="prev-feedback-label">Previous feedback</div>
+            <div id="prev-feedback-text"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="nav" id="outputs-nav">
+      <button class="nav-btn" id="prev-btn" onclick="navigate(-1)">&#8592; Previous</button>
+      <button class="done-btn" id="done-btn" onclick="showDoneDialog()">Submit All Reviews</button>
+      <button class="nav-btn" id="next-btn" onclick="navigate(1)">Next &#8594;</button>
+    </div>
+    </div><!-- end panel-outputs -->
+
+    <!-- Benchmark panel (quantitative stats) -->
+    <div class="view-panel" id="panel-benchmark">
+      <div class="benchmark-view" id="benchmark-content">
+        <div class="benchmark-empty">No benchmark data available. Run a benchmark to see quantitative results here.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Done overlay -->
+  <div class="done-overlay" id="done-overlay">
+    <div class="done-card">
+      <h2>Review Complete</h2>
+      <p>Your feedback has been saved. Go back to your Claude Code session and tell Claude you're done reviewing.</p>
+      <div class="btn-row">
+        <button onclick="closeDoneDialog()">OK</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // ---- Embedded data (injected by generate_review.py) ----
+    /*__EMBEDDED_DATA__*/
+
+    // ---- State ----
+    let feedbackMap = {};  // run_id -> feedback text
+    let currentIndex = 0;
+    let visitedRuns = new Set();
+
+    // ---- Init ----
+    async function init() {
+      // Load saved feedback from server — but only if this isn't a fresh
+      // iteration (indicated by previous_feedback being present). When
+      // previous feedback exists, the feedback.json on disk is stale from
+      // the prior iteration and should not pre-fill the textareas.
+      const hasPrevious = Object.keys(EMBEDDED_DATA.previous_feedback || {}).length > 0
+        || Object.keys(EMBEDDED_DATA.previous_outputs || {}).length > 0;
+      if (!hasPrevious) {
+        try {
+          const resp = await fetch("/api/feedback");
+          const data = await resp.json();
+          if (data.reviews) {
+            for (const r of data.reviews) feedbackMap[r.run_id] = r.feedback;
+          }
+        } catch { /* first run, no feedback yet */ }
+      }
+
+      document.getElementById("skill-name").textContent = EMBEDDED_DATA.skill_name;
+      showRun(0);
+
+      // Wire up feedback auto-save
+      const textarea = document.getElementById("feedback");
+      let saveTimeout = null;
+      textarea.addEventListener("input", () => {
+        clearTimeout(saveTimeout);
+        document.getElementById("feedback-status").textContent = "";
+        saveTimeout = setTimeout(() => saveCurrentFeedback(), 800);
+      });
+    }
+
+    // ---- Navigation ----
+    function navigate(delta) {
+      const newIndex = currentIndex + delta;
+      if (newIndex >= 0 && newIndex < EMBEDDED_DATA.runs.length) {
+        saveCurrentFeedback();
+        showRun(newIndex);
+      }
+    }
+
+    function updateNavButtons() {
+      document.getElementById("prev-btn").disabled = currentIndex === 0;
+      document.getElementById("next-btn").disabled =
+        currentIndex === EMBEDDED_DATA.runs.length - 1;
+    }
+
+    // ---- Show a run ----
+    function showRun(index) {
+      currentIndex = index;
+      const run = EMBEDDED_DATA.runs[index];
+
+      // Progress
+      document.getElementById("progress").textContent =
+        `${index + 1} of ${EMBEDDED_DATA.runs.length}`;
+
+      // Prompt
+      document.getElementById("prompt-text").textContent = run.prompt;
+
+      // Config badge
+      const badge = document.getElementById("config-badge");
+      const configMatch = run.id.match(/(with_skill|without_skill|new_skill|old_skill)/);
+      if (configMatch) {
+        const config = configMatch[1];
+        const isBaseline = config === "without_skill" || config === "old_skill";
+        badge.textContent = config.replace(/_/g, " ");
+        badge.className = "config-badge " + (isBaseline ? "config-baseline" : "config-primary");
+        badge.style.display = "inline-block";
+      } else {
+        badge.style.display = "none";
+      }
+
+      // Outputs
+      renderOutputs(run);
+
+      // Previous outputs
+      renderPrevOutputs(run);
+
+      // Grades
+      renderGrades(run);
+
+      // Previous feedback
+      const prevFb = (EMBEDDED_DATA.previous_feedback || {})[run.id];
+      const prevEl = document.getElementById("prev-feedback");
+      if (prevFb) {
+        document.getElementById("prev-feedback-text").textContent = prevFb;
+        prevEl.style.display = "block";
+      } else {
+        prevEl.style.display = "none";
+      }
+
+      // Feedback
+      document.getElementById("feedback").value = feedbackMap[run.id] || "";
+      document.getElementById("feedback-status").textContent = "";
+
+      updateNavButtons();
+
+      // Track visited runs and promote done button when all visited
+      visitedRuns.add(index);
+      const doneBtn = document.getElementById("done-btn");
+      if (visitedRuns.size >= EMBEDDED_DATA.runs.length) {
+        doneBtn.classList.add("ready");
+      }
+
+      // Scroll main content to top
+      document.querySelector(".main").scrollTop = 0;
+    }
+
+    // ---- Render outputs ----
+    function renderOutputs(run) {
+      const container = document.getElementById("outputs-body");
+      container.innerHTML = "";
+
+      const outputs = run.outputs || [];
+      if (outputs.length === 0) {
+        container.innerHTML = '<div class="empty-state">No output files</div>';
+        return;
+      }
+
+      for (const file of outputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        // Always show file header with download link
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const content = document.createElement("div");
+        content.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          content.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          content.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          content.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(content, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          content.appendChild(a);
+        } else if (file.type === "error") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          pre.style.color = "var(--red)";
+          content.appendChild(pre);
+        }
+
+        fileDiv.appendChild(content);
+        container.appendChild(fileDiv);
+      }
+    }
+
+    // ---- XLSX rendering via SheetJS ----
+    function renderXlsx(container, b64Data) {
+      try {
+        const raw = Uint8Array.from(atob(b64Data), c => c.charCodeAt(0));
+        const wb = XLSX.read(raw, { type: "array" });
+
+        for (let i = 0; i < wb.SheetNames.length; i++) {
+          const sheetName = wb.SheetNames[i];
+          const ws = wb.Sheets[sheetName];
+
+          if (wb.SheetNames.length > 1) {
+            const sheetLabel = document.createElement("div");
+            sheetLabel.style.cssText =
+              "font-weight:600; font-size:0.8rem; color:#b0aea5; margin-top:0.5rem; margin-bottom:0.25rem;";
+            sheetLabel.textContent = "Sheet: " + sheetName;
+            container.appendChild(sheetLabel);
+          }
+
+          const htmlStr = XLSX.utils.sheet_to_html(ws, { editable: false });
+          const wrapper = document.createElement("div");
+          wrapper.innerHTML = htmlStr;
+          container.appendChild(wrapper);
+        }
+      } catch (err) {
+        container.textContent = "Error rendering spreadsheet: " + err.message;
+      }
+    }
+
+    // ---- Grades ----
+    function renderGrades(run) {
+      const section = document.getElementById("grades-section");
+      const content = document.getElementById("grades-content");
+
+      if (!run.grading) {
+        section.style.display = "none";
+        return;
+      }
+
+      const grading = run.grading;
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("grades-arrow").classList.remove("open");
+
+      const summary = grading.summary || {};
+      const expectations = grading.expectations || [];
+
+      let html = '<div style="padding: 1rem;">';
+
+      // Summary line
+      const passRate = summary.pass_rate != null
+        ? Math.round(summary.pass_rate * 100) + "%"
+        : "?";
+      const badgeClass = summary.pass_rate >= 0.8 ? "grade-pass" : summary.pass_rate >= 0.5 ? "" : "grade-fail";
+      html += '<div class="grades-summary">';
+      html += '<span class="grade-badge ' + badgeClass + '">' + passRate + '</span>';
+      html += '<span>' + (summary.passed || 0) + ' passed, ' + (summary.failed || 0) + ' failed of ' + (summary.total || 0) + '</span>';
+      html += '</div>';
+
+      // Assertions list
+      html += '<ul class="assertion-list">';
+      for (const exp of expectations) {
+        const statusClass = exp.passed ? "pass" : "fail";
+        const statusIcon = exp.passed ? "\u2713" : "\u2717";
+        html += '<li class="assertion-item">';
+        html += '<span class="assertion-status ' + statusClass + '">' + statusIcon + '</span>';
+        html += '<span>' + escapeHtml(exp.text) + '</span>';
+        if (exp.evidence) {
+          html += '<div class="assertion-evidence">' + escapeHtml(exp.evidence) + '</div>';
+        }
+        html += '</li>';
+      }
+      html += '</ul>';
+
+      html += '</div>';
+      content.innerHTML = html;
+    }
+
+    function toggleGrades() {
+      const content = document.getElementById("grades-content");
+      const arrow = document.getElementById("grades-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Previous outputs (collapsible) ----
+    function renderPrevOutputs(run) {
+      const section = document.getElementById("prev-outputs-section");
+      const content = document.getElementById("prev-outputs-content");
+      const prevOutputs = (EMBEDDED_DATA.previous_outputs || {})[run.id];
+
+      if (!prevOutputs || prevOutputs.length === 0) {
+        section.style.display = "none";
+        return;
+      }
+
+      section.style.display = "block";
+      // Reset to collapsed
+      content.classList.remove("open");
+      document.getElementById("prev-outputs-arrow").classList.remove("open");
+
+      // Render the files into the content area
+      content.innerHTML = "";
+      const wrapper = document.createElement("div");
+      wrapper.style.padding = "1rem";
+
+      for (const file of prevOutputs) {
+        const fileDiv = document.createElement("div");
+        fileDiv.className = "output-file";
+
+        const header = document.createElement("div");
+        header.className = "output-file-header";
+        const nameSpan = document.createElement("span");
+        nameSpan.textContent = file.name;
+        header.appendChild(nameSpan);
+        const dlBtn = document.createElement("a");
+        dlBtn.className = "dl-btn";
+        dlBtn.textContent = "Download";
+        dlBtn.download = file.name;
+        dlBtn.href = getDownloadUri(file);
+        header.appendChild(dlBtn);
+        fileDiv.appendChild(header);
+
+        const fc = document.createElement("div");
+        fc.className = "output-file-content";
+
+        if (file.type === "text") {
+          const pre = document.createElement("pre");
+          pre.textContent = file.content;
+          fc.appendChild(pre);
+        } else if (file.type === "image") {
+          const img = document.createElement("img");
+          img.src = file.data_uri;
+          img.alt = file.name;
+          fc.appendChild(img);
+        } else if (file.type === "pdf") {
+          const iframe = document.createElement("iframe");
+          iframe.src = file.data_uri;
+          fc.appendChild(iframe);
+        } else if (file.type === "xlsx") {
+          renderXlsx(fc, file.data_b64);
+        } else if (file.type === "binary") {
+          const a = document.createElement("a");
+          a.className = "download-link";
+          a.href = file.data_uri;
+          a.download = file.name;
+          a.textContent = "Download " + file.name;
+          fc.appendChild(a);
+        }
+
+        fileDiv.appendChild(fc);
+        wrapper.appendChild(fileDiv);
+      }
+
+      content.appendChild(wrapper);
+    }
+
+    function togglePrevOutputs() {
+      const content = document.getElementById("prev-outputs-content");
+      const arrow = document.getElementById("prev-outputs-arrow");
+      content.classList.toggle("open");
+      arrow.classList.toggle("open");
+    }
+
+    // ---- Feedback (saved to server -> feedback.json) ----
+    function saveCurrentFeedback() {
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // Build reviews array from map
+      const reviews = [];
+      for (const [run_id, feedback] of Object.entries(feedbackMap)) {
+        if (feedback.trim()) {
+          reviews.push({ run_id, feedback, timestamp: new Date().toISOString() });
+        }
+      }
+
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reviews, status: "in_progress" }),
+      }).then(() => {
+        document.getElementById("feedback-status").textContent = "Saved";
+      }).catch(() => {
+        // Static mode or server unavailable — no-op on auto-save,
+        // feedback will be downloaded on final submit
+        document.getElementById("feedback-status").textContent = "Will download on submit";
+      });
+    }
+
+    // ---- Done ----
+    function showDoneDialog() {
+      // Save current textarea to feedbackMap (but don't POST yet)
+      const run = EMBEDDED_DATA.runs[currentIndex];
+      const text = document.getElementById("feedback").value;
+      if (text.trim() === "") {
+        delete feedbackMap[run.id];
+      } else {
+        feedbackMap[run.id] = text;
+      }
+
+      // POST once with status: complete — include ALL runs so the model
+      // can distinguish "no feedback" (looks good) from "not reviewed"
+      const reviews = [];
+      const ts = new Date().toISOString();
+      for (const r of EMBEDDED_DATA.runs) {
+        reviews.push({ run_id: r.id, feedback: feedbackMap[r.id] || "", timestamp: ts });
+      }
+      const payload = JSON.stringify({ reviews, status: "complete" }, null, 2);
+      fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      }).then(() => {
+        document.getElementById("done-overlay").classList.add("visible");
+      }).catch(() => {
+        // Server not available (static mode) — download as file
+        const blob = new Blob([payload], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "feedback.json";
+        a.click();
+        URL.revokeObjectURL(url);
+        document.getElementById("done-overlay").classList.add("visible");
+      });
+    }
+
+    function closeDoneDialog() {
+      // Reset status back to in_progress
+      saveCurrentFeedback();
+      document.getElementById("done-overlay").classList.remove("visible");
+    }
+
+    // ---- Toast ----
+    function showToast(message) {
+      const toast = document.getElementById("toast");
+      toast.textContent = message;
+      toast.classList.add("visible");
+      setTimeout(() => toast.classList.remove("visible"), 2000);
+    }
+
+    // ---- Keyboard nav ----
+    document.addEventListener("keydown", (e) => {
+      // Don't capture when typing in textarea
+      if (e.target.tagName === "TEXTAREA") return;
+
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        navigate(-1);
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        navigate(1);
+      }
+    });
+
+    // ---- Util ----
+    function getDownloadUri(file) {
+      if (file.data_uri) return file.data_uri;
+      if (file.data_b64) return "data:application/octet-stream;base64," + file.data_b64;
+      if (file.type === "text") return "data:text/plain;charset=utf-8," + encodeURIComponent(file.content);
+      return "#";
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement("div");
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    // ---- View switching ----
+    function switchView(view) {
+      document.querySelectorAll(".view-tab").forEach(t => t.classList.remove("active"));
+      document.querySelectorAll(".view-panel").forEach(p => p.classList.remove("active"));
+      document.querySelector(`[onclick="switchView('${view}')"]`).classList.add("active");
+      document.getElementById("panel-" + view).classList.add("active");
+    }
+
+    // ---- Benchmark rendering ----
+    function renderBenchmark() {
+      const data = EMBEDDED_DATA.benchmark;
+      if (!data) return;
+
+      // Show the tabs
+      document.getElementById("view-tabs").style.display = "flex";
+
+      const container = document.getElementById("benchmark-content");
+      const summary = data.run_summary || {};
+      const metadata = data.metadata || {};
+      const notes = data.notes || [];
+
+      let html = "";
+
+      // Header
+      html += "<h2 style='font-family: Poppins, sans-serif; margin-bottom: 0.5rem;'>Benchmark Results</h2>";
+      html += "<p style='color: var(--text-muted); font-size: 0.875rem; margin-bottom: 1.25rem;'>";
+      if (metadata.skill_name) html += "<strong>" + escapeHtml(metadata.skill_name) + "</strong> &mdash; ";
+      if (metadata.timestamp) html += metadata.timestamp + " &mdash; ";
+      if (metadata.evals_run) html += "Evals: " + metadata.evals_run.join(", ") + " &mdash; ";
+      html += (metadata.runs_per_configuration || "?") + " runs per configuration";
+      html += "</p>";
+
+      // Summary table
+      html += '<table class="benchmark-table">';
+
+      function fmtStat(stat, pct) {
+        if (!stat) return "—";
+        const suffix = pct ? "%" : "";
+        const m = pct ? (stat.mean * 100).toFixed(0) : stat.mean.toFixed(1);
+        const s = pct ? (stat.stddev * 100).toFixed(0) : stat.stddev.toFixed(1);
+        return m + suffix + " ± " + s + suffix;
+      }
+
+      function deltaClass(val) {
+        if (!val) return "";
+        const n = parseFloat(val);
+        if (n > 0) return "benchmark-delta-positive";
+        if (n < 0) return "benchmark-delta-negative";
+        return "";
+      }
+
+      // Discover config names dynamically (everything except "delta")
+      const configs = Object.keys(summary).filter(k => k !== "delta");
+      const configA = configs[0] || "config_a";
+      const configB = configs[1] || "config_b";
+      const labelA = configA.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const labelB = configB.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+      const a = summary[configA] || {};
+      const b = summary[configB] || {};
+      const delta = summary.delta || {};
+
+      html += "<thead><tr><th>Metric</th><th>" + escapeHtml(labelA) + "</th><th>" + escapeHtml(labelB) + "</th><th>Delta</th></tr></thead>";
+      html += "<tbody>";
+
+      html += "<tr><td><strong>Pass Rate</strong></td>";
+      html += "<td>" + fmtStat(a.pass_rate, true) + "</td>";
+      html += "<td>" + fmtStat(b.pass_rate, true) + "</td>";
+      html += '<td class="' + deltaClass(delta.pass_rate) + '">' + (delta.pass_rate || "—") + "</td></tr>";
+
+      // Time (only show row if data exists)
+      if (a.time_seconds || b.time_seconds) {
+        html += "<tr><td><strong>Time (s)</strong></td>";
+        html += "<td>" + fmtStat(a.time_seconds, false) + "</td>";
+        html += "<td>" + fmtStat(b.time_seconds, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.time_seconds) + '">' + (delta.time_seconds ? delta.time_seconds + "s" : "—") + "</td></tr>";
+      }
+
+      // Tokens (only show row if data exists)
+      if (a.tokens || b.tokens) {
+        html += "<tr><td><strong>Tokens</strong></td>";
+        html += "<td>" + fmtStat(a.tokens, false) + "</td>";
+        html += "<td>" + fmtStat(b.tokens, false) + "</td>";
+        html += '<td class="' + deltaClass(delta.tokens) + '">' + (delta.tokens || "—") + "</td></tr>";
+      }
+
+      html += "</tbody></table>";
+
+      // Per-eval breakdown (if runs data available)
+      const runs = data.runs || [];
+      if (runs.length > 0) {
+        const evalIds = [...new Set(runs.map(r => r.eval_id))].sort((a, b) => a - b);
+
+        html += "<h3 style='font-family: Poppins, sans-serif; margin-bottom: 0.75rem;'>Per-Eval Breakdown</h3>";
+
+        const hasTime = runs.some(r => r.result && r.result.time_seconds != null);
+        const hasErrors = runs.some(r => r.result && r.result.errors > 0);
+
+        for (const evalId of evalIds) {
+          const evalRuns = runs.filter(r => r.eval_id === evalId);
+          const evalName = evalRuns[0] && evalRuns[0].eval_name ? evalRuns[0].eval_name : "Eval " + evalId;
+
+          html += "<h4 style='font-family: Poppins, sans-serif; margin: 1rem 0 0.5rem; color: var(--text);'>" + escapeHtml(evalName) + "</h4>";
+          html += '<table class="benchmark-table">';
+          html += "<thead><tr><th>Config</th><th>Run</th><th>Pass Rate</th>";
+          if (hasTime) html += "<th>Time (s)</th>";
+          if (hasErrors) html += "<th>Crashes During Execution</th>";
+          html += "</tr></thead>";
+          html += "<tbody>";
+
+          // Group by config and render with average rows
+          const configGroups = [...new Set(evalRuns.map(r => r.configuration))];
+          for (let ci = 0; ci < configGroups.length; ci++) {
+            const config = configGroups[ci];
+            const configRuns = evalRuns.filter(r => r.configuration === config);
+            if (configRuns.length === 0) continue;
+
+            const rowClass = ci === 0 ? "benchmark-row-with" : "benchmark-row-without";
+            const configLabel = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+
+            for (const run of configRuns) {
+              const r = run.result || {};
+              const prClass = r.pass_rate >= 0.8 ? "benchmark-delta-positive" : r.pass_rate < 0.5 ? "benchmark-delta-negative" : "";
+              html += '<tr class="' + rowClass + '">';
+              html += "<td>" + configLabel + "</td>";
+              html += "<td>" + run.run_number + "</td>";
+              html += '<td class="' + prClass + '">' + ((r.pass_rate || 0) * 100).toFixed(0) + "% (" + (r.passed || 0) + "/" + (r.total || 0) + ")</td>";
+              if (hasTime) html += "<td>" + (r.time_seconds != null ? r.time_seconds.toFixed(1) : "—") + "</td>";
+              if (hasErrors) html += "<td>" + (r.errors || 0) + "</td>";
+              html += "</tr>";
+            }
+
+            // Average row
+            const rates = configRuns.map(r => (r.result || {}).pass_rate || 0);
+            const avgRate = rates.reduce((a, b) => a + b, 0) / rates.length;
+            const avgPrClass = avgRate >= 0.8 ? "benchmark-delta-positive" : avgRate < 0.5 ? "benchmark-delta-negative" : "";
+            html += '<tr class="benchmark-row-avg ' + rowClass + '">';
+            html += "<td>" + configLabel + "</td>";
+            html += "<td>Avg</td>";
+            html += '<td class="' + avgPrClass + '">' + (avgRate * 100).toFixed(0) + "%</td>";
+            if (hasTime) {
+              const times = configRuns.map(r => (r.result || {}).time_seconds).filter(t => t != null);
+              html += "<td>" + (times.length ? (times.reduce((a, b) => a + b, 0) / times.length).toFixed(1) : "—") + "</td>";
+            }
+            if (hasErrors) html += "<td></td>";
+            html += "</tr>";
+          }
+          html += "</tbody></table>";
+
+          // Per-assertion detail for this eval
+          const runsWithExpectations = {};
+          for (const config of configGroups) {
+            runsWithExpectations[config] = evalRuns.filter(r => r.configuration === config && r.expectations && r.expectations.length > 0);
+          }
+          const hasAnyExpectations = Object.values(runsWithExpectations).some(runs => runs.length > 0);
+          if (hasAnyExpectations) {
+            // Collect all unique assertion texts across all configs
+            const allAssertions = [];
+            const seen = new Set();
+            for (const config of configGroups) {
+              for (const run of runsWithExpectations[config]) {
+                for (const exp of (run.expectations || [])) {
+                  if (!seen.has(exp.text)) {
+                    seen.add(exp.text);
+                    allAssertions.push(exp.text);
+                  }
+                }
+              }
+            }
+
+            html += '<table class="benchmark-table" style="margin-top: 0.5rem;">';
+            html += "<thead><tr><th>Assertion</th>";
+            for (const config of configGroups) {
+              const label = config.replace(/_/g, " ").replace(/\b\w/g, c => c.toUpperCase());
+              html += "<th>" + escapeHtml(label) + "</th>";
+            }
+            html += "</tr></thead><tbody>";
+
+            for (const assertionText of allAssertions) {
+              html += "<tr><td>" + escapeHtml(assertionText) + "</td>";
+
+              for (const config of configGroups) {
+                html += "<td>";
+                for (const run of runsWithExpectations[config]) {
+                  const exp = (run.expectations || []).find(e => e.text === assertionText);
+                  if (exp) {
+                    const cls = exp.passed ? "benchmark-delta-positive" : "benchmark-delta-negative";
+                    const icon = exp.passed ? "\u2713" : "\u2717";
+                    html += '<span class="' + cls + '" title="Run ' + run.run_number + ': ' + escapeHtml(exp.evidence || "") + '">' + icon + "</span> ";
+                  } else {
+                    html += "— ";
+                  }
+                }
+                html += "</td>";
+              }
+              html += "</tr>";
+            }
+            html += "</tbody></table>";
+          }
+        }
+      }
+
+      // Notes
+      if (notes.length > 0) {
+        html += '<div class="benchmark-notes">';
+        html += "<h3>Analysis Notes</h3>";
+        html += "<ul>";
+        for (const note of notes) {
+          html += "<li>" + escapeHtml(note) + "</li>";
+        }
+        html += "</ul></div>";
+      }
+
+      container.innerHTML = html;
+    }
+
+    // ---- Start ----
+    init();
+    renderBenchmark();
+  </script>
+</body>
+</html>

--- a/.agents/skills/skill-creator/references/schemas.md
+++ b/.agents/skills/skill-creator/references/schemas.md
@@ -1,0 +1,430 @@
+# JSON Schemas
+
+This document defines the JSON schemas used by skill-creator.
+
+---
+
+## evals.json
+
+Defines the evals for a skill. Located at `evals/evals.json` within the skill directory.
+
+```json
+{
+  "skill_name": "example-skill",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "User's example prompt",
+      "expected_output": "Description of expected result",
+      "files": ["evals/files/sample1.pdf"],
+      "expectations": [
+        "The output includes X",
+        "The skill used script Y"
+      ]
+    }
+  ]
+}
+```
+
+**Fields:**
+- `skill_name`: Name matching the skill's frontmatter
+- `evals[].id`: Unique integer identifier
+- `evals[].prompt`: The task to execute
+- `evals[].expected_output`: Human-readable description of success
+- `evals[].files`: Optional list of input file paths (relative to skill root)
+- `evals[].expectations`: List of verifiable statements
+
+---
+
+## history.json
+
+Tracks version progression in Improve mode. Located at workspace root.
+
+```json
+{
+  "started_at": "2026-01-15T10:30:00Z",
+  "skill_name": "pdf",
+  "current_best": "v2",
+  "iterations": [
+    {
+      "version": "v0",
+      "parent": null,
+      "expectation_pass_rate": 0.65,
+      "grading_result": "baseline",
+      "is_current_best": false
+    },
+    {
+      "version": "v1",
+      "parent": "v0",
+      "expectation_pass_rate": 0.75,
+      "grading_result": "won",
+      "is_current_best": false
+    },
+    {
+      "version": "v2",
+      "parent": "v1",
+      "expectation_pass_rate": 0.85,
+      "grading_result": "won",
+      "is_current_best": true
+    }
+  ]
+}
+```
+
+**Fields:**
+- `started_at`: ISO timestamp of when improvement started
+- `skill_name`: Name of the skill being improved
+- `current_best`: Version identifier of the best performer
+- `iterations[].version`: Version identifier (v0, v1, ...)
+- `iterations[].parent`: Parent version this was derived from
+- `iterations[].expectation_pass_rate`: Pass rate from grading
+- `iterations[].grading_result`: "baseline", "won", "lost", or "tie"
+- `iterations[].is_current_best`: Whether this is the current best version
+
+---
+
+## grading.json
+
+Output from the grader agent. Located at `<run-dir>/grading.json`.
+
+```json
+{
+  "expectations": [
+    {
+      "text": "The output includes the name 'John Smith'",
+      "passed": true,
+      "evidence": "Found in transcript Step 3: 'Extracted names: John Smith, Sarah Johnson'"
+    },
+    {
+      "text": "The spreadsheet has a SUM formula in cell B10",
+      "passed": false,
+      "evidence": "No spreadsheet was created. The output was a text file."
+    }
+  ],
+  "summary": {
+    "passed": 2,
+    "failed": 1,
+    "total": 3,
+    "pass_rate": 0.67
+  },
+  "execution_metrics": {
+    "tool_calls": {
+      "Read": 5,
+      "Write": 2,
+      "Bash": 8
+    },
+    "total_tool_calls": 15,
+    "total_steps": 6,
+    "errors_encountered": 0,
+    "output_chars": 12450,
+    "transcript_chars": 3200
+  },
+  "timing": {
+    "executor_duration_seconds": 165.0,
+    "grader_duration_seconds": 26.0,
+    "total_duration_seconds": 191.0
+  },
+  "claims": [
+    {
+      "claim": "The form has 12 fillable fields",
+      "type": "factual",
+      "verified": true,
+      "evidence": "Counted 12 fields in field_info.json"
+    }
+  ],
+  "user_notes_summary": {
+    "uncertainties": ["Used 2023 data, may be stale"],
+    "needs_review": [],
+    "workarounds": ["Fell back to text overlay for non-fillable fields"]
+  },
+  "eval_feedback": {
+    "suggestions": [
+      {
+        "assertion": "The output includes the name 'John Smith'",
+        "reason": "A hallucinated document that mentions the name would also pass"
+      }
+    ],
+    "overall": "Assertions check presence but not correctness."
+  }
+}
+```
+
+**Fields:**
+- `expectations[]`: Graded expectations with evidence
+- `summary`: Aggregate pass/fail counts
+- `execution_metrics`: Tool usage and output size (from executor's metrics.json)
+- `timing`: Wall clock timing (from timing.json)
+- `claims`: Extracted and verified claims from the output
+- `user_notes_summary`: Issues flagged by the executor
+- `eval_feedback`: (optional) Improvement suggestions for the evals, only present when the grader identifies issues worth raising
+
+---
+
+## metrics.json
+
+Output from the executor agent. Located at `<run-dir>/outputs/metrics.json`.
+
+```json
+{
+  "tool_calls": {
+    "Read": 5,
+    "Write": 2,
+    "Bash": 8,
+    "Edit": 1,
+    "Glob": 2,
+    "Grep": 0
+  },
+  "total_tool_calls": 18,
+  "total_steps": 6,
+  "files_created": ["filled_form.pdf", "field_values.json"],
+  "errors_encountered": 0,
+  "output_chars": 12450,
+  "transcript_chars": 3200
+}
+```
+
+**Fields:**
+- `tool_calls`: Count per tool type
+- `total_tool_calls`: Sum of all tool calls
+- `total_steps`: Number of major execution steps
+- `files_created`: List of output files created
+- `errors_encountered`: Number of errors during execution
+- `output_chars`: Total character count of output files
+- `transcript_chars`: Character count of transcript
+
+---
+
+## timing.json
+
+Wall clock timing for a run. Located at `<run-dir>/timing.json`.
+
+**How to capture:** When a subagent task completes, the task notification includes `total_tokens` and `duration_ms`. Save these immediately — they are not persisted anywhere else and cannot be recovered after the fact.
+
+```json
+{
+  "total_tokens": 84852,
+  "duration_ms": 23332,
+  "total_duration_seconds": 23.3,
+  "executor_start": "2026-01-15T10:30:00Z",
+  "executor_end": "2026-01-15T10:32:45Z",
+  "executor_duration_seconds": 165.0,
+  "grader_start": "2026-01-15T10:32:46Z",
+  "grader_end": "2026-01-15T10:33:12Z",
+  "grader_duration_seconds": 26.0
+}
+```
+
+---
+
+## benchmark.json
+
+Output from Benchmark mode. Located at `benchmarks/<timestamp>/benchmark.json`.
+
+```json
+{
+  "metadata": {
+    "skill_name": "pdf",
+    "skill_path": "/path/to/pdf",
+    "executor_model": "claude-sonnet-4-20250514",
+    "analyzer_model": "most-capable-model",
+    "timestamp": "2026-01-15T10:30:00Z",
+    "evals_run": [1, 2, 3],
+    "runs_per_configuration": 3
+  },
+
+  "runs": [
+    {
+      "eval_id": 1,
+      "eval_name": "Ocean",
+      "configuration": "with_skill",
+      "run_number": 1,
+      "result": {
+        "pass_rate": 0.85,
+        "passed": 6,
+        "failed": 1,
+        "total": 7,
+        "time_seconds": 42.5,
+        "tokens": 3800,
+        "tool_calls": 18,
+        "errors": 0
+      },
+      "expectations": [
+        {"text": "...", "passed": true, "evidence": "..."}
+      ],
+      "notes": [
+        "Used 2023 data, may be stale",
+        "Fell back to text overlay for non-fillable fields"
+      ]
+    }
+  ],
+
+  "run_summary": {
+    "with_skill": {
+      "pass_rate": {"mean": 0.85, "stddev": 0.05, "min": 0.80, "max": 0.90},
+      "time_seconds": {"mean": 45.0, "stddev": 12.0, "min": 32.0, "max": 58.0},
+      "tokens": {"mean": 3800, "stddev": 400, "min": 3200, "max": 4100}
+    },
+    "without_skill": {
+      "pass_rate": {"mean": 0.35, "stddev": 0.08, "min": 0.28, "max": 0.45},
+      "time_seconds": {"mean": 32.0, "stddev": 8.0, "min": 24.0, "max": 42.0},
+      "tokens": {"mean": 2100, "stddev": 300, "min": 1800, "max": 2500}
+    },
+    "delta": {
+      "pass_rate": "+0.50",
+      "time_seconds": "+13.0",
+      "tokens": "+1700"
+    }
+  },
+
+  "notes": [
+    "Assertion 'Output is a PDF file' passes 100% in both configurations - may not differentiate skill value",
+    "Eval 3 shows high variance (50% ± 40%) - may be flaky or model-dependent",
+    "Without-skill runs consistently fail on table extraction expectations",
+    "Skill adds 13s average execution time but improves pass rate by 50%"
+  ]
+}
+```
+
+**Fields:**
+- `metadata`: Information about the benchmark run
+  - `skill_name`: Name of the skill
+  - `timestamp`: When the benchmark was run
+  - `evals_run`: List of eval names or IDs
+  - `runs_per_configuration`: Number of runs per config (e.g. 3)
+- `runs[]`: Individual run results
+  - `eval_id`: Numeric eval identifier
+  - `eval_name`: Human-readable eval name (used as section header in the viewer)
+  - `configuration`: Must be `"with_skill"` or `"without_skill"` (the viewer uses this exact string for grouping and color coding)
+  - `run_number`: Integer run number (1, 2, 3...)
+  - `result`: Nested object with `pass_rate`, `passed`, `total`, `time_seconds`, `tokens`, `errors`
+- `run_summary`: Statistical aggregates per configuration
+  - `with_skill` / `without_skill`: Each contains `pass_rate`, `time_seconds`, `tokens` objects with `mean` and `stddev` fields
+  - `delta`: Difference strings like `"+0.50"`, `"+13.0"`, `"+1700"`
+- `notes`: Freeform observations from the analyzer
+
+**Important:** The viewer reads these field names exactly. Using `config` instead of `configuration`, or putting `pass_rate` at the top level of a run instead of nested under `result`, will cause the viewer to show empty/zero values. Always reference this schema when generating benchmark.json manually.
+
+---
+
+## comparison.json
+
+Output from blind comparator. Located at `<grading-dir>/comparison-N.json`.
+
+```json
+{
+  "winner": "A",
+  "reasoning": "Output A provides a complete solution with proper formatting and all required fields. Output B is missing the date field and has formatting inconsistencies.",
+  "rubric": {
+    "A": {
+      "content": {
+        "correctness": 5,
+        "completeness": 5,
+        "accuracy": 4
+      },
+      "structure": {
+        "organization": 4,
+        "formatting": 5,
+        "usability": 4
+      },
+      "content_score": 4.7,
+      "structure_score": 4.3,
+      "overall_score": 9.0
+    },
+    "B": {
+      "content": {
+        "correctness": 3,
+        "completeness": 2,
+        "accuracy": 3
+      },
+      "structure": {
+        "organization": 3,
+        "formatting": 2,
+        "usability": 3
+      },
+      "content_score": 2.7,
+      "structure_score": 2.7,
+      "overall_score": 5.4
+    }
+  },
+  "output_quality": {
+    "A": {
+      "score": 9,
+      "strengths": ["Complete solution", "Well-formatted", "All fields present"],
+      "weaknesses": ["Minor style inconsistency in header"]
+    },
+    "B": {
+      "score": 5,
+      "strengths": ["Readable output", "Correct basic structure"],
+      "weaknesses": ["Missing date field", "Formatting inconsistencies", "Partial data extraction"]
+    }
+  },
+  "expectation_results": {
+    "A": {
+      "passed": 4,
+      "total": 5,
+      "pass_rate": 0.80,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    },
+    "B": {
+      "passed": 3,
+      "total": 5,
+      "pass_rate": 0.60,
+      "details": [
+        {"text": "Output includes name", "passed": true}
+      ]
+    }
+  }
+}
+```
+
+---
+
+## analysis.json
+
+Output from post-hoc analyzer. Located at `<grading-dir>/analysis.json`.
+
+```json
+{
+  "comparison_summary": {
+    "winner": "A",
+    "winner_skill": "path/to/winner/skill",
+    "loser_skill": "path/to/loser/skill",
+    "comparator_reasoning": "Brief summary of why comparator chose winner"
+  },
+  "winner_strengths": [
+    "Clear step-by-step instructions for handling multi-page documents",
+    "Included validation script that caught formatting errors"
+  ],
+  "loser_weaknesses": [
+    "Vague instruction 'process the document appropriately' led to inconsistent behavior",
+    "No script for validation, agent had to improvise"
+  ],
+  "instruction_following": {
+    "winner": {
+      "score": 9,
+      "issues": ["Minor: skipped optional logging step"]
+    },
+    "loser": {
+      "score": 6,
+      "issues": [
+        "Did not use the skill's formatting template",
+        "Invented own approach instead of following step 3"
+      ]
+    }
+  },
+  "improvement_suggestions": [
+    {
+      "priority": "high",
+      "category": "instructions",
+      "suggestion": "Replace 'process the document appropriately' with explicit steps",
+      "expected_impact": "Would eliminate ambiguity that caused inconsistent behavior"
+    }
+  ],
+  "transcript_insights": {
+    "winner_execution_pattern": "Read skill -> Followed 5-step process -> Used validation script",
+    "loser_execution_pattern": "Read skill -> Unclear on approach -> Tried 3 different methods"
+  }
+}
+```

--- a/.agents/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/.agents/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""
+Aggregate individual run results into benchmark summary statistics.
+
+Reads grading.json files from run directories and produces:
+- run_summary with mean, stddev, min, max for each metric
+- delta between with_skill and without_skill configurations
+
+Usage:
+    python aggregate_benchmark.py <benchmark_dir>
+
+Example:
+    python aggregate_benchmark.py benchmarks/2026-01-15T10-30-00/
+
+The script supports two directory layouts:
+
+    Workspace layout (from skill-creator iterations):
+    <benchmark_dir>/
+    └── eval-N/
+        ├── with_skill/
+        │   ├── run-1/grading.json
+        │   └── run-2/grading.json
+        └── without_skill/
+            ├── run-1/grading.json
+            └── run-2/grading.json
+
+    Legacy layout (with runs/ subdirectory):
+    <benchmark_dir>/
+    └── runs/
+        └── eval-N/
+            ├── with_skill/
+            │   └── run-1/grading.json
+            └── without_skill/
+                └── run-1/grading.json
+"""
+
+import argparse
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def calculate_stats(values: list[float]) -> dict:
+    """Calculate mean, stddev, min, max for a list of values."""
+    if not values:
+        return {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0}
+
+    n = len(values)
+    mean = sum(values) / n
+
+    if n > 1:
+        variance = sum((x - mean) ** 2 for x in values) / (n - 1)
+        stddev = math.sqrt(variance)
+    else:
+        stddev = 0.0
+
+    return {
+        "mean": round(mean, 4),
+        "stddev": round(stddev, 4),
+        "min": round(min(values), 4),
+        "max": round(max(values), 4)
+    }
+
+
+def load_run_results(benchmark_dir: Path) -> dict:
+    """
+    Load all run results from a benchmark directory.
+
+    Returns dict keyed by config name (e.g. "with_skill"/"without_skill",
+    or "new_skill"/"old_skill"), each containing a list of run results.
+    """
+    # Support both layouts: eval dirs directly under benchmark_dir, or under runs/
+    runs_dir = benchmark_dir / "runs"
+    if runs_dir.exists():
+        search_dir = runs_dir
+    elif list(benchmark_dir.glob("eval-*")):
+        search_dir = benchmark_dir
+    else:
+        print(f"No eval directories found in {benchmark_dir} or {benchmark_dir / 'runs'}")
+        return {}
+
+    results: dict[str, list] = {}
+
+    for eval_idx, eval_dir in enumerate(sorted(search_dir.glob("eval-*"))):
+        metadata_path = eval_dir / "eval_metadata.json"
+        if metadata_path.exists():
+            try:
+                with open(metadata_path) as mf:
+                    eval_id = json.load(mf).get("eval_id", eval_idx)
+            except (json.JSONDecodeError, OSError):
+                eval_id = eval_idx
+        else:
+            try:
+                eval_id = int(eval_dir.name.split("-")[1])
+            except ValueError:
+                eval_id = eval_idx
+
+        # Discover config directories dynamically rather than hardcoding names
+        for config_dir in sorted(eval_dir.iterdir()):
+            if not config_dir.is_dir():
+                continue
+            # Skip non-config directories (inputs, outputs, etc.)
+            if not list(config_dir.glob("run-*")):
+                continue
+            config = config_dir.name
+            if config not in results:
+                results[config] = []
+
+            for run_dir in sorted(config_dir.glob("run-*")):
+                run_number = int(run_dir.name.split("-")[1])
+                grading_file = run_dir / "grading.json"
+
+                if not grading_file.exists():
+                    print(f"Warning: grading.json not found in {run_dir}")
+                    continue
+
+                try:
+                    with open(grading_file) as f:
+                        grading = json.load(f)
+                except json.JSONDecodeError as e:
+                    print(f"Warning: Invalid JSON in {grading_file}: {e}")
+                    continue
+
+                # Extract metrics
+                result = {
+                    "eval_id": eval_id,
+                    "run_number": run_number,
+                    "pass_rate": grading.get("summary", {}).get("pass_rate", 0.0),
+                    "passed": grading.get("summary", {}).get("passed", 0),
+                    "failed": grading.get("summary", {}).get("failed", 0),
+                    "total": grading.get("summary", {}).get("total", 0),
+                }
+
+                # Extract timing — check grading.json first, then sibling timing.json
+                timing = grading.get("timing", {})
+                result["time_seconds"] = timing.get("total_duration_seconds", 0.0)
+                timing_file = run_dir / "timing.json"
+                if result["time_seconds"] == 0.0 and timing_file.exists():
+                    try:
+                        with open(timing_file) as tf:
+                            timing_data = json.load(tf)
+                        result["time_seconds"] = timing_data.get("total_duration_seconds", 0.0)
+                        result["tokens"] = timing_data.get("total_tokens", 0)
+                    except json.JSONDecodeError:
+                        pass
+
+                # Extract metrics if available
+                metrics = grading.get("execution_metrics", {})
+                result["tool_calls"] = metrics.get("total_tool_calls", 0)
+                if not result.get("tokens"):
+                    result["tokens"] = metrics.get("output_chars", 0)
+                result["errors"] = metrics.get("errors_encountered", 0)
+
+                # Extract expectations — viewer requires fields: text, passed, evidence
+                raw_expectations = grading.get("expectations", [])
+                for exp in raw_expectations:
+                    if "text" not in exp or "passed" not in exp:
+                        print(f"Warning: expectation in {grading_file} missing required fields (text, passed, evidence): {exp}")
+                result["expectations"] = raw_expectations
+
+                # Extract notes from user_notes_summary
+                notes_summary = grading.get("user_notes_summary", {})
+                notes = []
+                notes.extend(notes_summary.get("uncertainties", []))
+                notes.extend(notes_summary.get("needs_review", []))
+                notes.extend(notes_summary.get("workarounds", []))
+                result["notes"] = notes
+
+                results[config].append(result)
+
+    return results
+
+
+def aggregate_results(results: dict) -> dict:
+    """
+    Aggregate run results into summary statistics.
+
+    Returns run_summary with stats for each configuration and delta.
+    """
+    run_summary = {}
+    configs = list(results.keys())
+
+    for config in configs:
+        runs = results.get(config, [])
+
+        if not runs:
+            run_summary[config] = {
+                "pass_rate": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "time_seconds": {"mean": 0.0, "stddev": 0.0, "min": 0.0, "max": 0.0},
+                "tokens": {"mean": 0, "stddev": 0, "min": 0, "max": 0}
+            }
+            continue
+
+        pass_rates = [r["pass_rate"] for r in runs]
+        times = [r["time_seconds"] for r in runs]
+        tokens = [r.get("tokens", 0) for r in runs]
+
+        run_summary[config] = {
+            "pass_rate": calculate_stats(pass_rates),
+            "time_seconds": calculate_stats(times),
+            "tokens": calculate_stats(tokens)
+        }
+
+    # Calculate delta between the first two configs (if two exist)
+    if len(configs) >= 2:
+        primary = run_summary.get(configs[0], {})
+        baseline = run_summary.get(configs[1], {})
+    else:
+        primary = run_summary.get(configs[0], {}) if configs else {}
+        baseline = {}
+
+    delta_pass_rate = primary.get("pass_rate", {}).get("mean", 0) - baseline.get("pass_rate", {}).get("mean", 0)
+    delta_time = primary.get("time_seconds", {}).get("mean", 0) - baseline.get("time_seconds", {}).get("mean", 0)
+    delta_tokens = primary.get("tokens", {}).get("mean", 0) - baseline.get("tokens", {}).get("mean", 0)
+
+    run_summary["delta"] = {
+        "pass_rate": f"{delta_pass_rate:+.2f}",
+        "time_seconds": f"{delta_time:+.1f}",
+        "tokens": f"{delta_tokens:+.0f}"
+    }
+
+    return run_summary
+
+
+def generate_benchmark(benchmark_dir: Path, skill_name: str = "", skill_path: str = "") -> dict:
+    """
+    Generate complete benchmark.json from run results.
+    """
+    results = load_run_results(benchmark_dir)
+    run_summary = aggregate_results(results)
+
+    # Build runs array for benchmark.json
+    runs = []
+    for config in results:
+        for result in results[config]:
+            runs.append({
+                "eval_id": result["eval_id"],
+                "configuration": config,
+                "run_number": result["run_number"],
+                "result": {
+                    "pass_rate": result["pass_rate"],
+                    "passed": result["passed"],
+                    "failed": result["failed"],
+                    "total": result["total"],
+                    "time_seconds": result["time_seconds"],
+                    "tokens": result.get("tokens", 0),
+                    "tool_calls": result.get("tool_calls", 0),
+                    "errors": result.get("errors", 0)
+                },
+                "expectations": result["expectations"],
+                "notes": result["notes"]
+            })
+
+    # Determine eval IDs from results
+    eval_ids = sorted(set(
+        r["eval_id"]
+        for config in results.values()
+        for r in config
+    ))
+
+    benchmark = {
+        "metadata": {
+            "skill_name": skill_name or "<skill-name>",
+            "skill_path": skill_path or "<path/to/skill>",
+            "executor_model": "<model-name>",
+            "analyzer_model": "<model-name>",
+            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "evals_run": eval_ids,
+            "runs_per_configuration": 3
+        },
+        "runs": runs,
+        "run_summary": run_summary,
+        "notes": []  # To be filled by analyzer
+    }
+
+    return benchmark
+
+
+def generate_markdown(benchmark: dict) -> str:
+    """Generate human-readable benchmark.md from benchmark data."""
+    metadata = benchmark["metadata"]
+    run_summary = benchmark["run_summary"]
+
+    # Determine config names (excluding "delta")
+    configs = [k for k in run_summary if k != "delta"]
+    config_a = configs[0] if len(configs) >= 1 else "config_a"
+    config_b = configs[1] if len(configs) >= 2 else "config_b"
+    label_a = config_a.replace("_", " ").title()
+    label_b = config_b.replace("_", " ").title()
+
+    lines = [
+        f"# Skill Benchmark: {metadata['skill_name']}",
+        "",
+        f"**Model**: {metadata['executor_model']}",
+        f"**Date**: {metadata['timestamp']}",
+        f"**Evals**: {', '.join(map(str, metadata['evals_run']))} ({metadata['runs_per_configuration']} runs each per configuration)",
+        "",
+        "## Summary",
+        "",
+        f"| Metric | {label_a} | {label_b} | Delta |",
+        "|--------|------------|---------------|-------|",
+    ]
+
+    a_summary = run_summary.get(config_a, {})
+    b_summary = run_summary.get(config_b, {})
+    delta = run_summary.get("delta", {})
+
+    # Format pass rate
+    a_pr = a_summary.get("pass_rate", {})
+    b_pr = b_summary.get("pass_rate", {})
+    lines.append(f"| Pass Rate | {a_pr.get('mean', 0)*100:.0f}% ± {a_pr.get('stddev', 0)*100:.0f}% | {b_pr.get('mean', 0)*100:.0f}% ± {b_pr.get('stddev', 0)*100:.0f}% | {delta.get('pass_rate', '—')} |")
+
+    # Format time
+    a_time = a_summary.get("time_seconds", {})
+    b_time = b_summary.get("time_seconds", {})
+    lines.append(f"| Time | {a_time.get('mean', 0):.1f}s ± {a_time.get('stddev', 0):.1f}s | {b_time.get('mean', 0):.1f}s ± {b_time.get('stddev', 0):.1f}s | {delta.get('time_seconds', '—')}s |")
+
+    # Format tokens
+    a_tokens = a_summary.get("tokens", {})
+    b_tokens = b_summary.get("tokens", {})
+    lines.append(f"| Tokens | {a_tokens.get('mean', 0):.0f} ± {a_tokens.get('stddev', 0):.0f} | {b_tokens.get('mean', 0):.0f} ± {b_tokens.get('stddev', 0):.0f} | {delta.get('tokens', '—')} |")
+
+    # Notes section
+    if benchmark.get("notes"):
+        lines.extend([
+            "",
+            "## Notes",
+            ""
+        ])
+        for note in benchmark["notes"]:
+            lines.append(f"- {note}")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aggregate benchmark run results into summary statistics"
+    )
+    parser.add_argument(
+        "benchmark_dir",
+        type=Path,
+        help="Path to the benchmark directory"
+    )
+    parser.add_argument(
+        "--skill-name",
+        default="",
+        help="Name of the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--skill-path",
+        default="",
+        help="Path to the skill being benchmarked"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        help="Output path for benchmark.json (default: <benchmark_dir>/benchmark.json)"
+    )
+
+    args = parser.parse_args()
+
+    if not args.benchmark_dir.exists():
+        print(f"Directory not found: {args.benchmark_dir}")
+        sys.exit(1)
+
+    # Generate benchmark
+    benchmark = generate_benchmark(args.benchmark_dir, args.skill_name, args.skill_path)
+
+    # Determine output paths
+    output_json = args.output or (args.benchmark_dir / "benchmark.json")
+    output_md = output_json.with_suffix(".md")
+
+    # Write benchmark.json
+    with open(output_json, "w") as f:
+        json.dump(benchmark, f, indent=2)
+    print(f"Generated: {output_json}")
+
+    # Write benchmark.md
+    markdown = generate_markdown(benchmark)
+    with open(output_md, "w") as f:
+        f.write(markdown)
+    print(f"Generated: {output_md}")
+
+    # Print summary
+    run_summary = benchmark["run_summary"]
+    configs = [k for k in run_summary if k != "delta"]
+    delta = run_summary.get("delta", {})
+
+    print(f"\nSummary:")
+    for config in configs:
+        pr = run_summary[config]["pass_rate"]["mean"]
+        label = config.replace("_", " ").title()
+        print(f"  {label}: {pr*100:.1f}% pass rate")
+    print(f"  Delta:         {delta.get('pass_rate', '—')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/generate_report.py
+++ b/.agents/skills/skill-creator/scripts/generate_report.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Generate an HTML report from run_loop.py output.
+
+Takes the JSON output from run_loop.py and generates a visual HTML report
+showing each description attempt with check/x for each test case.
+Distinguishes between train and test queries.
+"""
+
+import argparse
+import html
+import json
+import sys
+from pathlib import Path
+
+
+def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") -> str:
+    """Generate HTML report from loop output data. If auto_refresh is True, adds a meta refresh tag."""
+    history = data.get("history", [])
+    holdout = data.get("holdout", 0)
+    title_prefix = html.escape(skill_name + " \u2014 ") if skill_name else ""
+
+    # Get all unique queries from train and test sets, with should_trigger info
+    train_queries: list[dict] = []
+    test_queries: list[dict] = []
+    if history:
+        for r in history[0].get("train_results", history[0].get("results", [])):
+            train_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+        if history[0].get("test_results"):
+            for r in history[0].get("test_results", []):
+                test_queries.append({"query": r["query"], "should_trigger": r.get("should_trigger", True)})
+
+    refresh_tag = '    <meta http-equiv="refresh" content="5">\n' if auto_refresh else ""
+
+    html_parts = ["""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+""" + refresh_tag + """    <title>""" + title_prefix + """Skill Description Optimization</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@500;600&family=Lora:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Lora', Georgia, serif;
+            max-width: 100%;
+            margin: 0 auto;
+            padding: 20px;
+            background: #faf9f5;
+            color: #141413;
+        }
+        h1 { font-family: 'Poppins', sans-serif; color: #141413; }
+        .explainer {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+            color: #b0aea5;
+            font-size: 0.875rem;
+            line-height: 1.6;
+        }
+        .summary {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            border: 1px solid #e8e6dc;
+        }
+        .summary p { margin: 5px 0; }
+        .best { color: #788c5d; font-weight: bold; }
+        .table-container {
+            overflow-x: auto;
+            width: 100%;
+        }
+        table {
+            border-collapse: collapse;
+            background: white;
+            border: 1px solid #e8e6dc;
+            border-radius: 6px;
+            font-size: 12px;
+            min-width: 100%;
+        }
+        th, td {
+            padding: 8px;
+            text-align: left;
+            border: 1px solid #e8e6dc;
+            white-space: normal;
+            word-wrap: break-word;
+        }
+        th {
+            font-family: 'Poppins', sans-serif;
+            background: #141413;
+            color: #faf9f5;
+            font-weight: 500;
+        }
+        th.test-col {
+            background: #6a9bcc;
+        }
+        th.query-col { min-width: 200px; }
+        td.description {
+            font-family: monospace;
+            font-size: 11px;
+            word-wrap: break-word;
+            max-width: 400px;
+        }
+        td.result {
+            text-align: center;
+            font-size: 16px;
+            min-width: 40px;
+        }
+        td.test-result {
+            background: #f0f6fc;
+        }
+        .pass { color: #788c5d; }
+        .fail { color: #c44; }
+        .rate {
+            font-size: 9px;
+            color: #b0aea5;
+            display: block;
+        }
+        tr:hover { background: #faf9f5; }
+        .score {
+            display: inline-block;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-weight: bold;
+            font-size: 11px;
+        }
+        .score-good { background: #eef2e8; color: #788c5d; }
+        .score-ok { background: #fef3c7; color: #d97706; }
+        .score-bad { background: #fceaea; color: #c44; }
+        .train-label { color: #b0aea5; font-size: 10px; }
+        .test-label { color: #6a9bcc; font-size: 10px; font-weight: bold; }
+        .best-row { background: #f5f8f2; }
+        th.positive-col { border-bottom: 3px solid #788c5d; }
+        th.negative-col { border-bottom: 3px solid #c44; }
+        th.test-col.positive-col { border-bottom: 3px solid #788c5d; }
+        th.test-col.negative-col { border-bottom: 3px solid #c44; }
+        .legend { font-family: 'Poppins', sans-serif; display: flex; gap: 20px; margin-bottom: 10px; font-size: 13px; align-items: center; }
+        .legend-item { display: flex; align-items: center; gap: 6px; }
+        .legend-swatch { width: 16px; height: 16px; border-radius: 3px; display: inline-block; }
+        .swatch-positive { background: #141413; border-bottom: 3px solid #788c5d; }
+        .swatch-negative { background: #141413; border-bottom: 3px solid #c44; }
+        .swatch-test { background: #6a9bcc; }
+        .swatch-train { background: #141413; }
+    </style>
+</head>
+<body>
+    <h1>""" + title_prefix + """Skill Description Optimization</h1>
+    <div class="explainer">
+        <strong>Optimizing your skill's description.</strong> This page updates automatically as Claude tests different versions of your skill's description. Each row is an iteration — a new description attempt. The columns show test queries: green checkmarks mean the skill triggered correctly (or correctly didn't trigger), red crosses mean it got it wrong. The "Train" score shows performance on queries used to improve the description; the "Test" score shows performance on held-out queries the optimizer hasn't seen. When it's done, Claude will apply the best-performing description to your skill.
+    </div>
+"""]
+
+    # Summary section
+    best_test_score = data.get('best_test_score')
+    best_train_score = data.get('best_train_score')
+    html_parts.append(f"""
+    <div class="summary">
+        <p><strong>Original:</strong> {html.escape(data.get('original_description', 'N/A'))}</p>
+        <p class="best"><strong>Best:</strong> {html.escape(data.get('best_description', 'N/A'))}</p>
+        <p><strong>Best Score:</strong> {data.get('best_score', 'N/A')} {'(test)' if best_test_score else '(train)'}</p>
+        <p><strong>Iterations:</strong> {data.get('iterations_run', 0)} | <strong>Train:</strong> {data.get('train_size', '?')} | <strong>Test:</strong> {data.get('test_size', '?')}</p>
+    </div>
+""")
+
+    # Legend
+    html_parts.append("""
+    <div class="legend">
+        <span style="font-weight:600">Query columns:</span>
+        <span class="legend-item"><span class="legend-swatch swatch-positive"></span> Should trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-negative"></span> Should NOT trigger</span>
+        <span class="legend-item"><span class="legend-swatch swatch-train"></span> Train</span>
+        <span class="legend-item"><span class="legend-swatch swatch-test"></span> Test</span>
+    </div>
+""")
+
+    # Table header
+    html_parts.append("""
+    <div class="table-container">
+    <table>
+        <thead>
+            <tr>
+                <th>Iter</th>
+                <th>Train</th>
+                <th>Test</th>
+                <th class="query-col">Description</th>
+""")
+
+    # Add column headers for train queries
+    for qinfo in train_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="{polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    # Add column headers for test queries (different color)
+    for qinfo in test_queries:
+        polarity = "positive-col" if qinfo["should_trigger"] else "negative-col"
+        html_parts.append(f'                <th class="test-col {polarity}">{html.escape(qinfo["query"])}</th>\n')
+
+    html_parts.append("""            </tr>
+        </thead>
+        <tbody>
+""")
+
+    # Find best iteration for highlighting
+    if test_queries:
+        best_iter = max(history, key=lambda h: h.get("test_passed") or 0).get("iteration")
+    else:
+        best_iter = max(history, key=lambda h: h.get("train_passed", h.get("passed", 0))).get("iteration")
+
+    # Add rows for each iteration
+    for h in history:
+        iteration = h.get("iteration", "?")
+        train_passed = h.get("train_passed", h.get("passed", 0))
+        train_total = h.get("train_total", h.get("total", 0))
+        test_passed = h.get("test_passed")
+        test_total = h.get("test_total")
+        description = h.get("description", "")
+        train_results = h.get("train_results", h.get("results", []))
+        test_results = h.get("test_results", [])
+
+        # Create lookups for results by query
+        train_by_query = {r["query"]: r for r in train_results}
+        test_by_query = {r["query"]: r for r in test_results} if test_results else {}
+
+        # Compute aggregate correct/total runs across all retries
+        def aggregate_runs(results: list[dict]) -> tuple[int, int]:
+            correct = 0
+            total = 0
+            for r in results:
+                runs = r.get("runs", 0)
+                triggers = r.get("triggers", 0)
+                total += runs
+                if r.get("should_trigger", True):
+                    correct += triggers
+                else:
+                    correct += runs - triggers
+            return correct, total
+
+        train_correct, train_runs = aggregate_runs(train_results)
+        test_correct, test_runs = aggregate_runs(test_results)
+
+        # Determine score classes
+        def score_class(correct: int, total: int) -> str:
+            if total > 0:
+                ratio = correct / total
+                if ratio >= 0.8:
+                    return "score-good"
+                elif ratio >= 0.5:
+                    return "score-ok"
+            return "score-bad"
+
+        train_class = score_class(train_correct, train_runs)
+        test_class = score_class(test_correct, test_runs)
+
+        row_class = "best-row" if iteration == best_iter else ""
+
+        html_parts.append(f"""            <tr class="{row_class}">
+                <td>{iteration}</td>
+                <td><span class="score {train_class}">{train_correct}/{train_runs}</span></td>
+                <td><span class="score {test_class}">{test_correct}/{test_runs}</span></td>
+                <td class="description">{html.escape(description)}</td>
+""")
+
+        # Add result for each train query
+        for qinfo in train_queries:
+            r = train_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        # Add result for each test query (with different background)
+        for qinfo in test_queries:
+            r = test_by_query.get(qinfo["query"], {})
+            did_pass = r.get("pass", False)
+            triggers = r.get("triggers", 0)
+            runs = r.get("runs", 0)
+
+            icon = "✓" if did_pass else "✗"
+            css_class = "pass" if did_pass else "fail"
+
+            html_parts.append(f'                <td class="result test-result {css_class}">{icon}<span class="rate">{triggers}/{runs}</span></td>\n')
+
+        html_parts.append("            </tr>\n")
+
+    html_parts.append("""        </tbody>
+    </table>
+    </div>
+""")
+
+    html_parts.append("""
+</body>
+</html>
+""")
+
+    return "".join(html_parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate HTML report from run_loop output")
+    parser.add_argument("input", help="Path to JSON output from run_loop.py (or - for stdin)")
+    parser.add_argument("-o", "--output", default=None, help="Output HTML file (default: stdout)")
+    parser.add_argument("--skill-name", default="", help="Skill name to include in the report title")
+    args = parser.parse_args()
+
+    if args.input == "-":
+        data = json.load(sys.stdin)
+    else:
+        data = json.loads(Path(args.input).read_text())
+
+    html_output = generate_html(data, skill_name=args.skill_name)
+
+    if args.output:
+        Path(args.output).write_text(html_output)
+        print(f"Report written to {args.output}", file=sys.stderr)
+    else:
+        print(html_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/improve_description.py
+++ b/.agents/skills/skill-creator/scripts/improve_description.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Improve a skill description based on eval results.
+
+Takes eval results (from run_eval.py) and generates an improved description
+by calling `claude -p` as a subprocess (same auth pattern as run_eval.py —
+uses the session's Claude Code auth, no separate ANTHROPIC_API_KEY needed).
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def _call_claude(prompt: str, model: str | None, timeout: int = 300) -> str:
+    """Run `claude -p` with the prompt on stdin and return the text response.
+
+    Prompt goes over stdin (not argv) because it embeds the full SKILL.md
+    body and can easily exceed comfortable argv length.
+    """
+    cmd = ["claude", "-p", "--output-format", "text"]
+    if model:
+        cmd.extend(["--model", model])
+
+    # Remove CLAUDECODE env var to allow nesting claude -p inside a
+    # Claude Code session. The guard is for interactive terminal conflicts;
+    # programmatic subprocess usage is safe. Same pattern as run_eval.py.
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"claude -p exited {result.returncode}\nstderr: {result.stderr}"
+        )
+    return result.stdout
+
+
+def improve_description(
+    skill_name: str,
+    skill_content: str,
+    current_description: str,
+    eval_results: dict,
+    history: list[dict],
+    model: str,
+    test_results: dict | None = None,
+    log_dir: Path | None = None,
+    iteration: int | None = None,
+) -> str:
+    """Call Claude to improve the description based on eval results."""
+    failed_triggers = [
+        r for r in eval_results["results"]
+        if r["should_trigger"] and not r["pass"]
+    ]
+    false_triggers = [
+        r for r in eval_results["results"]
+        if not r["should_trigger"] and not r["pass"]
+    ]
+
+    # Build scores summary
+    train_score = f"{eval_results['summary']['passed']}/{eval_results['summary']['total']}"
+    if test_results:
+        test_score = f"{test_results['summary']['passed']}/{test_results['summary']['total']}"
+        scores_summary = f"Train: {train_score}, Test: {test_score}"
+    else:
+        scores_summary = f"Train: {train_score}"
+
+    prompt = f"""You are optimizing a skill description for a Claude Code skill called "{skill_name}". A "skill" is sort of like a prompt, but with progressive disclosure -- there's a title and description that Claude sees when deciding whether to use the skill, and then if it does use the skill, it reads the .md file which has lots more details and potentially links to other resources in the skill folder like helper files and scripts and additional documentation or examples.
+
+The description appears in Claude's "available_skills" list. When a user sends a query, Claude decides whether to invoke the skill based solely on the title and on this description. Your goal is to write a description that triggers for relevant queries, and doesn't trigger for irrelevant ones.
+
+Here's the current description:
+<current_description>
+"{current_description}"
+</current_description>
+
+Current scores ({scores_summary}):
+<scores_summary>
+"""
+    if failed_triggers:
+        prompt += "FAILED TO TRIGGER (should have triggered but didn't):\n"
+        for r in failed_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if false_triggers:
+        prompt += "FALSE TRIGGERS (triggered but shouldn't have):\n"
+        for r in false_triggers:
+            prompt += f'  - "{r["query"]}" (triggered {r["triggers"]}/{r["runs"]} times)\n'
+        prompt += "\n"
+
+    if history:
+        prompt += "PREVIOUS ATTEMPTS (do NOT repeat these — try something structurally different):\n\n"
+        for h in history:
+            train_s = f"{h.get('train_passed', h.get('passed', 0))}/{h.get('train_total', h.get('total', 0))}"
+            test_s = f"{h.get('test_passed', '?')}/{h.get('test_total', '?')}" if h.get('test_passed') is not None else None
+            score_str = f"train={train_s}" + (f", test={test_s}" if test_s else "")
+            prompt += f'<attempt {score_str}>\n'
+            prompt += f'Description: "{h["description"]}"\n'
+            if "results" in h:
+                prompt += "Train results:\n"
+                for r in h["results"]:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    prompt += f'  [{status}] "{r["query"][:80]}" (triggered {r["triggers"]}/{r["runs"]})\n'
+            if h.get("note"):
+                prompt += f'Note: {h["note"]}\n'
+            prompt += "</attempt>\n\n"
+
+    prompt += f"""</scores_summary>
+
+Skill content (for context on what the skill does):
+<skill_content>
+{skill_content}
+</skill_content>
+
+Based on the failures, write a new and improved description that is more likely to trigger correctly. When I say "based on the failures", it's a bit of a tricky line to walk because we don't want to overfit to the specific cases you're seeing. So what I DON'T want you to do is produce an ever-expanding list of specific queries that this skill should or shouldn't trigger for. Instead, try to generalize from the failures to broader categories of user intent and situations where this skill would be useful or not useful. The reason for this is twofold:
+
+1. Avoid overfitting
+2. The list might get loooong and it's injected into ALL queries and there might be a lot of skills, so we don't want to blow too much space on any given description.
+
+Concretely, your description should not be more than about 100-200 words, even if that comes at the cost of accuracy. There is a hard limit of 1024 characters — descriptions over that will be truncated, so stay comfortably under it.
+
+Here are some tips that we've found to work well in writing these descriptions:
+- The skill should be phrased in the imperative -- "Use this skill for" rather than "this skill does"
+- The skill description should focus on the user's intent, what they are trying to achieve, vs. the implementation details of how the skill works.
+- The description competes with other skills for Claude's attention — make it distinctive and immediately recognizable.
+- If you're getting lots of failures after repeated attempts, change things up. Try different sentence structures or wordings.
+
+I'd encourage you to be creative and mix up the style in different iterations since you'll have multiple opportunities to try different approaches and we'll just grab the highest-scoring one at the end. 
+
+Please respond with only the new description text in <new_description> tags, nothing else."""
+
+    text = _call_claude(prompt, model)
+
+    match = re.search(r"<new_description>(.*?)</new_description>", text, re.DOTALL)
+    description = match.group(1).strip().strip('"') if match else text.strip().strip('"')
+
+    transcript: dict = {
+        "iteration": iteration,
+        "prompt": prompt,
+        "response": text,
+        "parsed_description": description,
+        "char_count": len(description),
+        "over_limit": len(description) > 1024,
+    }
+
+    # Safety net: the prompt already states the 1024-char hard limit, but if
+    # the model blew past it anyway, make one fresh single-turn call that
+    # quotes the too-long version and asks for a shorter rewrite. (The old
+    # SDK path did this as a true multi-turn; `claude -p` is one-shot, so we
+    # inline the prior output into the new prompt instead.)
+    if len(description) > 1024:
+        shorten_prompt = (
+            f"{prompt}\n\n"
+            f"---\n\n"
+            f"A previous attempt produced this description, which at "
+            f"{len(description)} characters is over the 1024-character hard limit:\n\n"
+            f'"{description}"\n\n'
+            f"Rewrite it to be under 1024 characters while keeping the most "
+            f"important trigger words and intent coverage. Respond with only "
+            f"the new description in <new_description> tags."
+        )
+        shorten_text = _call_claude(shorten_prompt, model)
+        match = re.search(r"<new_description>(.*?)</new_description>", shorten_text, re.DOTALL)
+        shortened = match.group(1).strip().strip('"') if match else shorten_text.strip().strip('"')
+
+        transcript["rewrite_prompt"] = shorten_prompt
+        transcript["rewrite_response"] = shorten_text
+        transcript["rewrite_description"] = shortened
+        transcript["rewrite_char_count"] = len(shortened)
+        description = shortened
+
+    transcript["final_description"] = description
+
+    if log_dir:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_file = log_dir / f"improve_iter_{iteration or 'unknown'}.json"
+        log_file.write_text(json.dumps(transcript, indent=2))
+
+    return description
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Improve a skill description based on eval results")
+    parser.add_argument("--eval-results", required=True, help="Path to eval results JSON (from run_eval.py)")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--history", default=None, help="Path to history JSON (previous attempts)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print thinking to stderr")
+    args = parser.parse_args()
+
+    skill_path = Path(args.skill_path)
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    eval_results = json.loads(Path(args.eval_results).read_text())
+    history = []
+    if args.history:
+        history = json.loads(Path(args.history).read_text())
+
+    name, _, content = parse_skill_md(skill_path)
+    current_description = eval_results["description"]
+
+    if args.verbose:
+        print(f"Current: {current_description}", file=sys.stderr)
+        print(f"Score: {eval_results['summary']['passed']}/{eval_results['summary']['total']}", file=sys.stderr)
+
+    new_description = improve_description(
+        skill_name=name,
+        skill_content=content,
+        current_description=current_description,
+        eval_results=eval_results,
+        history=history,
+        model=args.model,
+    )
+
+    if args.verbose:
+        print(f"Improved: {new_description}", file=sys.stderr)
+
+    # Output as JSON with both the new description and updated history
+    output = {
+        "description": new_description,
+        "history": history + [{
+            "description": current_description,
+            "passed": eval_results["summary"]["passed"],
+            "failed": eval_results["summary"]["failed"],
+            "total": eval_results["summary"]["total"],
+            "results": eval_results["results"],
+        }],
+    }
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/package_skill.py
+++ b/.agents/skills/skill-creator/scripts/package_skill.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Skill Packager - Creates a distributable .skill file of a skill folder
+
+Usage:
+    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+
+Example:
+    python utils/package_skill.py skills/public/my-skill
+    python utils/package_skill.py skills/public/my-skill ./dist
+"""
+
+import fnmatch
+import sys
+import zipfile
+from pathlib import Path
+from scripts.quick_validate import validate_skill
+
+# Patterns to exclude when packaging skills.
+EXCLUDE_DIRS = {"__pycache__", "node_modules"}
+EXCLUDE_GLOBS = {"*.pyc"}
+EXCLUDE_FILES = {".DS_Store"}
+# Directories excluded only at the skill root (not when nested deeper).
+ROOT_EXCLUDE_DIRS = {"evals"}
+
+
+def should_exclude(rel_path: Path) -> bool:
+    """Check if a path should be excluded from packaging."""
+    parts = rel_path.parts
+    if any(part in EXCLUDE_DIRS for part in parts):
+        return True
+    # rel_path is relative to skill_path.parent, so parts[0] is the skill
+    # folder name and parts[1] (if present) is the first subdir.
+    if len(parts) > 1 and parts[1] in ROOT_EXCLUDE_DIRS:
+        return True
+    name = rel_path.name
+    if name in EXCLUDE_FILES:
+        return True
+    return any(fnmatch.fnmatch(name, pat) for pat in EXCLUDE_GLOBS)
+
+
+def package_skill(skill_path, output_dir=None):
+    """
+    Package a skill folder into a .skill file.
+
+    Args:
+        skill_path: Path to the skill folder
+        output_dir: Optional output directory for the .skill file (defaults to current directory)
+
+    Returns:
+        Path to the created .skill file, or None if error
+    """
+    skill_path = Path(skill_path).resolve()
+
+    # Validate skill folder exists
+    if not skill_path.exists():
+        print(f"❌ Error: Skill folder not found: {skill_path}")
+        return None
+
+    if not skill_path.is_dir():
+        print(f"❌ Error: Path is not a directory: {skill_path}")
+        return None
+
+    # Validate SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        return None
+
+    # Run validation before packaging
+    print("🔍 Validating skill...")
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        print(f"❌ Validation failed: {message}")
+        print("   Please fix the validation errors before packaging.")
+        return None
+    print(f"✅ {message}\n")
+
+    # Determine output location
+    skill_name = skill_path.name
+    if output_dir:
+        output_path = Path(output_dir).resolve()
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    skill_filename = output_path / f"{skill_name}.skill"
+
+    # Create the .skill file (zip format)
+    try:
+        with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            # Walk through the skill directory, excluding build artifacts
+            for file_path in skill_path.rglob('*'):
+                if not file_path.is_file():
+                    continue
+                arcname = file_path.relative_to(skill_path.parent)
+                if should_exclude(arcname):
+                    print(f"  Skipped: {arcname}")
+                    continue
+                zipf.write(file_path, arcname)
+                print(f"  Added: {arcname}")
+
+        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        return skill_filename
+
+    except Exception as e:
+        print(f"❌ Error creating .skill file: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
+        print("\nExample:")
+        print("  python utils/package_skill.py skills/public/my-skill")
+        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        sys.exit(1)
+
+    skill_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+
+    print(f"📦 Packaging skill: {skill_path}")
+    if output_dir:
+        print(f"   Output directory: {output_dir}")
+    print()
+
+    result = package_skill(skill_path, output_dir)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/quick_validate.py
+++ b/.agents/skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / 'SKILL.md'
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith('---'):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata', 'compatibility'}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if 'name' not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if 'description' not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get('name', '')
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (kebab-case: lowercase with hyphens)
+        if not re.match(r'^[a-z0-9-]+$', name):
+            return False, f"Name '{name}' should be kebab-case (lowercase letters, digits, and hyphens only)"
+        if name.startswith('-') or name.endswith('-') or '--' in name:
+            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get('description', '')
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if '<' in description or '>' in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+
+    # Validate compatibility field if present (optional)
+    compatibility = frontmatter.get('compatibility', '')
+    if compatibility:
+        if not isinstance(compatibility, str):
+            return False, f"Compatibility must be a string, got {type(compatibility).__name__}"
+        if len(compatibility) > 500:
+            return False, f"Compatibility is too long ({len(compatibility)} characters). Maximum is 500 characters."
+
+    return True, "Skill is valid!"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+    
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/.agents/skills/skill-creator/scripts/run_eval.py
+++ b/.agents/skills/skill-creator/scripts/run_eval.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Run trigger evaluation for a skill description.
+
+Tests whether a skill's description causes Claude to trigger (read the skill)
+for a set of queries. Outputs results as JSON.
+"""
+
+import argparse
+import json
+import os
+import select
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+from scripts.utils import parse_skill_md
+
+
+def find_project_root() -> Path:
+    """Find the project root by walking up from cwd looking for .claude/.
+
+    Mimics how Claude Code discovers its project root, so the command file
+    we create ends up where claude -p will look for it.
+    """
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        if (parent / ".claude").is_dir():
+            return parent
+    return current
+
+
+def run_single_query(
+    query: str,
+    skill_name: str,
+    skill_description: str,
+    timeout: int,
+    project_root: str,
+    model: str | None = None,
+) -> bool:
+    """Run a single query and return whether the skill was triggered.
+
+    Creates a command file in .claude/commands/ so it appears in Claude's
+    available_skills list, then runs `claude -p` with the raw query.
+    Uses --include-partial-messages to detect triggering early from
+    stream events (content_block_start) rather than waiting for the
+    full assistant message, which only arrives after tool execution.
+    """
+    unique_id = uuid.uuid4().hex[:8]
+    clean_name = f"{skill_name}-skill-{unique_id}"
+    project_commands_dir = Path(project_root) / ".claude" / "commands"
+    command_file = project_commands_dir / f"{clean_name}.md"
+
+    try:
+        project_commands_dir.mkdir(parents=True, exist_ok=True)
+        # Use YAML block scalar to avoid breaking on quotes in description
+        indented_desc = "\n  ".join(skill_description.split("\n"))
+        command_content = (
+            f"---\n"
+            f"description: |\n"
+            f"  {indented_desc}\n"
+            f"---\n\n"
+            f"# {skill_name}\n\n"
+            f"This skill handles: {skill_description}\n"
+        )
+        command_file.write_text(command_content)
+
+        cmd = [
+            "claude",
+            "-p", query,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ]
+        if model:
+            cmd.extend(["--model", model])
+
+        # Remove CLAUDECODE env var to allow nesting claude -p inside a
+        # Claude Code session. The guard is for interactive terminal conflicts;
+        # programmatic subprocess usage is safe.
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            cwd=project_root,
+            env=env,
+        )
+
+        triggered = False
+        start_time = time.time()
+        buffer = ""
+        # Track state for stream event detection
+        pending_tool_name = None
+        accumulated_json = ""
+
+        try:
+            while time.time() - start_time < timeout:
+                if process.poll() is not None:
+                    remaining = process.stdout.read()
+                    if remaining:
+                        buffer += remaining.decode("utf-8", errors="replace")
+                    break
+
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    continue
+
+                chunk = os.read(process.stdout.fileno(), 8192)
+                if not chunk:
+                    break
+                buffer += chunk.decode("utf-8", errors="replace")
+
+                while "\n" in buffer:
+                    line, buffer = buffer.split("\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    # Early detection via stream events
+                    if event.get("type") == "stream_event":
+                        se = event.get("event", {})
+                        se_type = se.get("type", "")
+
+                        if se_type == "content_block_start":
+                            cb = se.get("content_block", {})
+                            if cb.get("type") == "tool_use":
+                                tool_name = cb.get("name", "")
+                                if tool_name in ("Skill", "Read"):
+                                    pending_tool_name = tool_name
+                                    accumulated_json = ""
+                                else:
+                                    return False
+
+                        elif se_type == "content_block_delta" and pending_tool_name:
+                            delta = se.get("delta", {})
+                            if delta.get("type") == "input_json_delta":
+                                accumulated_json += delta.get("partial_json", "")
+                                if clean_name in accumulated_json:
+                                    return True
+
+                        elif se_type in ("content_block_stop", "message_stop"):
+                            if pending_tool_name:
+                                return clean_name in accumulated_json
+                            if se_type == "message_stop":
+                                return False
+
+                    # Fallback: full assistant message
+                    elif event.get("type") == "assistant":
+                        message = event.get("message", {})
+                        for content_item in message.get("content", []):
+                            if content_item.get("type") != "tool_use":
+                                continue
+                            tool_name = content_item.get("name", "")
+                            tool_input = content_item.get("input", {})
+                            if tool_name == "Skill" and clean_name in tool_input.get("skill", ""):
+                                triggered = True
+                            elif tool_name == "Read" and clean_name in tool_input.get("file_path", ""):
+                                triggered = True
+                            return triggered
+
+                    elif event.get("type") == "result":
+                        return triggered
+        finally:
+            # Clean up process on any exit path (return, exception, timeout)
+            if process.poll() is None:
+                process.kill()
+                process.wait()
+
+        return triggered
+    finally:
+        if command_file.exists():
+            command_file.unlink()
+
+
+def run_eval(
+    eval_set: list[dict],
+    skill_name: str,
+    description: str,
+    num_workers: int,
+    timeout: int,
+    project_root: Path,
+    runs_per_query: int = 1,
+    trigger_threshold: float = 0.5,
+    model: str | None = None,
+) -> dict:
+    """Run the full eval set and return results."""
+    results = []
+
+    with ProcessPoolExecutor(max_workers=num_workers) as executor:
+        future_to_info = {}
+        for item in eval_set:
+            for run_idx in range(runs_per_query):
+                future = executor.submit(
+                    run_single_query,
+                    item["query"],
+                    skill_name,
+                    description,
+                    timeout,
+                    str(project_root),
+                    model,
+                )
+                future_to_info[future] = (item, run_idx)
+
+        query_triggers: dict[str, list[bool]] = {}
+        query_items: dict[str, dict] = {}
+        for future in as_completed(future_to_info):
+            item, _ = future_to_info[future]
+            query = item["query"]
+            query_items[query] = item
+            if query not in query_triggers:
+                query_triggers[query] = []
+            try:
+                query_triggers[query].append(future.result())
+            except Exception as e:
+                print(f"Warning: query failed: {e}", file=sys.stderr)
+                query_triggers[query].append(False)
+
+    for query, triggers in query_triggers.items():
+        item = query_items[query]
+        trigger_rate = sum(triggers) / len(triggers)
+        should_trigger = item["should_trigger"]
+        if should_trigger:
+            did_pass = trigger_rate >= trigger_threshold
+        else:
+            did_pass = trigger_rate < trigger_threshold
+        results.append({
+            "query": query,
+            "should_trigger": should_trigger,
+            "trigger_rate": trigger_rate,
+            "triggers": sum(triggers),
+            "runs": len(triggers),
+            "pass": did_pass,
+        })
+
+    passed = sum(1 for r in results if r["pass"])
+    total = len(results)
+
+    return {
+        "skill_name": skill_name,
+        "description": description,
+        "results": results,
+        "summary": {
+            "total": total,
+            "passed": passed,
+            "failed": total - passed,
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run trigger evaluation for a skill description")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override description to test")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--model", default=None, help="Model to use for claude -p (default: user's configured model)")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, original_description, content = parse_skill_md(skill_path)
+    description = args.description or original_description
+    project_root = find_project_root()
+
+    if args.verbose:
+        print(f"Evaluating: {description}", file=sys.stderr)
+
+    output = run_eval(
+        eval_set=eval_set,
+        skill_name=name,
+        description=description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        project_root=project_root,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        model=args.model,
+    )
+
+    if args.verbose:
+        summary = output["summary"]
+        print(f"Results: {summary['passed']}/{summary['total']} passed", file=sys.stderr)
+        for r in output["results"]:
+            status = "PASS" if r["pass"] else "FAIL"
+            rate_str = f"{r['triggers']}/{r['runs']}"
+            print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:70]}", file=sys.stderr)
+
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/run_loop.py
+++ b/.agents/skills/skill-creator/scripts/run_loop.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Run the eval + improve loop until all pass or max iterations reached.
+
+Combines run_eval.py and improve_description.py in a loop, tracking history
+and returning the best description found. Supports train/test split to prevent
+overfitting.
+"""
+
+import argparse
+import json
+import random
+import sys
+import tempfile
+import time
+import webbrowser
+from pathlib import Path
+
+from scripts.generate_report import generate_html
+from scripts.improve_description import improve_description
+from scripts.run_eval import find_project_root, run_eval
+from scripts.utils import parse_skill_md
+
+
+def split_eval_set(eval_set: list[dict], holdout: float, seed: int = 42) -> tuple[list[dict], list[dict]]:
+    """Split eval set into train and test sets, stratified by should_trigger."""
+    random.seed(seed)
+
+    # Separate by should_trigger
+    trigger = [e for e in eval_set if e["should_trigger"]]
+    no_trigger = [e for e in eval_set if not e["should_trigger"]]
+
+    # Shuffle each group
+    random.shuffle(trigger)
+    random.shuffle(no_trigger)
+
+    # Calculate split points
+    n_trigger_test = max(1, int(len(trigger) * holdout))
+    n_no_trigger_test = max(1, int(len(no_trigger) * holdout))
+
+    # Split
+    test_set = trigger[:n_trigger_test] + no_trigger[:n_no_trigger_test]
+    train_set = trigger[n_trigger_test:] + no_trigger[n_no_trigger_test:]
+
+    return train_set, test_set
+
+
+def run_loop(
+    eval_set: list[dict],
+    skill_path: Path,
+    description_override: str | None,
+    num_workers: int,
+    timeout: int,
+    max_iterations: int,
+    runs_per_query: int,
+    trigger_threshold: float,
+    holdout: float,
+    model: str,
+    verbose: bool,
+    live_report_path: Path | None = None,
+    log_dir: Path | None = None,
+) -> dict:
+    """Run the eval + improvement loop."""
+    project_root = find_project_root()
+    name, original_description, content = parse_skill_md(skill_path)
+    current_description = description_override or original_description
+
+    # Split into train/test if holdout > 0
+    if holdout > 0:
+        train_set, test_set = split_eval_set(eval_set, holdout)
+        if verbose:
+            print(f"Split: {len(train_set)} train, {len(test_set)} test (holdout={holdout})", file=sys.stderr)
+    else:
+        train_set = eval_set
+        test_set = []
+
+    history = []
+    exit_reason = "unknown"
+
+    for iteration in range(1, max_iterations + 1):
+        if verbose:
+            print(f"\n{'='*60}", file=sys.stderr)
+            print(f"Iteration {iteration}/{max_iterations}", file=sys.stderr)
+            print(f"Description: {current_description}", file=sys.stderr)
+            print(f"{'='*60}", file=sys.stderr)
+
+        # Evaluate train + test together in one batch for parallelism
+        all_queries = train_set + test_set
+        t0 = time.time()
+        all_results = run_eval(
+            eval_set=all_queries,
+            skill_name=name,
+            description=current_description,
+            num_workers=num_workers,
+            timeout=timeout,
+            project_root=project_root,
+            runs_per_query=runs_per_query,
+            trigger_threshold=trigger_threshold,
+            model=model,
+        )
+        eval_elapsed = time.time() - t0
+
+        # Split results back into train/test by matching queries
+        train_queries_set = {q["query"] for q in train_set}
+        train_result_list = [r for r in all_results["results"] if r["query"] in train_queries_set]
+        test_result_list = [r for r in all_results["results"] if r["query"] not in train_queries_set]
+
+        train_passed = sum(1 for r in train_result_list if r["pass"])
+        train_total = len(train_result_list)
+        train_summary = {"passed": train_passed, "failed": train_total - train_passed, "total": train_total}
+        train_results = {"results": train_result_list, "summary": train_summary}
+
+        if test_set:
+            test_passed = sum(1 for r in test_result_list if r["pass"])
+            test_total = len(test_result_list)
+            test_summary = {"passed": test_passed, "failed": test_total - test_passed, "total": test_total}
+            test_results = {"results": test_result_list, "summary": test_summary}
+        else:
+            test_results = None
+            test_summary = None
+
+        history.append({
+            "iteration": iteration,
+            "description": current_description,
+            "train_passed": train_summary["passed"],
+            "train_failed": train_summary["failed"],
+            "train_total": train_summary["total"],
+            "train_results": train_results["results"],
+            "test_passed": test_summary["passed"] if test_summary else None,
+            "test_failed": test_summary["failed"] if test_summary else None,
+            "test_total": test_summary["total"] if test_summary else None,
+            "test_results": test_results["results"] if test_results else None,
+            # For backward compat with report generator
+            "passed": train_summary["passed"],
+            "failed": train_summary["failed"],
+            "total": train_summary["total"],
+            "results": train_results["results"],
+        })
+
+        # Write live report if path provided
+        if live_report_path:
+            partial_output = {
+                "original_description": original_description,
+                "best_description": current_description,
+                "best_score": "in progress",
+                "iterations_run": len(history),
+                "holdout": holdout,
+                "train_size": len(train_set),
+                "test_size": len(test_set),
+                "history": history,
+            }
+            live_report_path.write_text(generate_html(partial_output, auto_refresh=True, skill_name=name))
+
+        if verbose:
+            def print_eval_stats(label, results, elapsed):
+                pos = [r for r in results if r["should_trigger"]]
+                neg = [r for r in results if not r["should_trigger"]]
+                tp = sum(r["triggers"] for r in pos)
+                pos_runs = sum(r["runs"] for r in pos)
+                fn = pos_runs - tp
+                fp = sum(r["triggers"] for r in neg)
+                neg_runs = sum(r["runs"] for r in neg)
+                tn = neg_runs - fp
+                total = tp + tn + fp + fn
+                precision = tp / (tp + fp) if (tp + fp) > 0 else 1.0
+                recall = tp / (tp + fn) if (tp + fn) > 0 else 1.0
+                accuracy = (tp + tn) / total if total > 0 else 0.0
+                print(f"{label}: {tp+tn}/{total} correct, precision={precision:.0%} recall={recall:.0%} accuracy={accuracy:.0%} ({elapsed:.1f}s)", file=sys.stderr)
+                for r in results:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    rate_str = f"{r['triggers']}/{r['runs']}"
+                    print(f"  [{status}] rate={rate_str} expected={r['should_trigger']}: {r['query'][:60]}", file=sys.stderr)
+
+            print_eval_stats("Train", train_results["results"], eval_elapsed)
+            if test_summary:
+                print_eval_stats("Test ", test_results["results"], 0)
+
+        if train_summary["failed"] == 0:
+            exit_reason = f"all_passed (iteration {iteration})"
+            if verbose:
+                print(f"\nAll train queries passed on iteration {iteration}!", file=sys.stderr)
+            break
+
+        if iteration == max_iterations:
+            exit_reason = f"max_iterations ({max_iterations})"
+            if verbose:
+                print(f"\nMax iterations reached ({max_iterations}).", file=sys.stderr)
+            break
+
+        # Improve the description based on train results
+        if verbose:
+            print(f"\nImproving description...", file=sys.stderr)
+
+        t0 = time.time()
+        # Strip test scores from history so improvement model can't see them
+        blinded_history = [
+            {k: v for k, v in h.items() if not k.startswith("test_")}
+            for h in history
+        ]
+        new_description = improve_description(
+            skill_name=name,
+            skill_content=content,
+            current_description=current_description,
+            eval_results=train_results,
+            history=blinded_history,
+            model=model,
+            log_dir=log_dir,
+            iteration=iteration,
+        )
+        improve_elapsed = time.time() - t0
+
+        if verbose:
+            print(f"Proposed ({improve_elapsed:.1f}s): {new_description}", file=sys.stderr)
+
+        current_description = new_description
+
+    # Find the best iteration by TEST score (or train if no test set)
+    if test_set:
+        best = max(history, key=lambda h: h["test_passed"] or 0)
+        best_score = f"{best['test_passed']}/{best['test_total']}"
+    else:
+        best = max(history, key=lambda h: h["train_passed"])
+        best_score = f"{best['train_passed']}/{best['train_total']}"
+
+    if verbose:
+        print(f"\nExit reason: {exit_reason}", file=sys.stderr)
+        print(f"Best score: {best_score} (iteration {best['iteration']})", file=sys.stderr)
+
+    return {
+        "exit_reason": exit_reason,
+        "original_description": original_description,
+        "best_description": best["description"],
+        "best_score": best_score,
+        "best_train_score": f"{best['train_passed']}/{best['train_total']}",
+        "best_test_score": f"{best['test_passed']}/{best['test_total']}" if test_set else None,
+        "final_description": current_description,
+        "iterations_run": len(history),
+        "holdout": holdout,
+        "train_size": len(train_set),
+        "test_size": len(test_set),
+        "history": history,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run eval + improve loop")
+    parser.add_argument("--eval-set", required=True, help="Path to eval set JSON file")
+    parser.add_argument("--skill-path", required=True, help="Path to skill directory")
+    parser.add_argument("--description", default=None, help="Override starting description")
+    parser.add_argument("--num-workers", type=int, default=10, help="Number of parallel workers")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout per query in seconds")
+    parser.add_argument("--max-iterations", type=int, default=5, help="Max improvement iterations")
+    parser.add_argument("--runs-per-query", type=int, default=3, help="Number of runs per query")
+    parser.add_argument("--trigger-threshold", type=float, default=0.5, help="Trigger rate threshold")
+    parser.add_argument("--holdout", type=float, default=0.4, help="Fraction of eval set to hold out for testing (0 to disable)")
+    parser.add_argument("--model", required=True, help="Model for improvement")
+    parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
+    parser.add_argument("--report", default="auto", help="Generate HTML report at this path (default: 'auto' for temp file, 'none' to disable)")
+    parser.add_argument("--results-dir", default=None, help="Save all outputs (results.json, report.html, log.txt) to a timestamped subdirectory here")
+    args = parser.parse_args()
+
+    eval_set = json.loads(Path(args.eval_set).read_text())
+    skill_path = Path(args.skill_path)
+
+    if not (skill_path / "SKILL.md").exists():
+        print(f"Error: No SKILL.md found at {skill_path}", file=sys.stderr)
+        sys.exit(1)
+
+    name, _, _ = parse_skill_md(skill_path)
+
+    # Set up live report path
+    if args.report != "none":
+        if args.report == "auto":
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            live_report_path = Path(tempfile.gettempdir()) / f"skill_description_report_{skill_path.name}_{timestamp}.html"
+        else:
+            live_report_path = Path(args.report)
+        # Open the report immediately so the user can watch
+        live_report_path.write_text("<html><body><h1>Starting optimization loop...</h1><meta http-equiv='refresh' content='5'></body></html>")
+        webbrowser.open(str(live_report_path))
+    else:
+        live_report_path = None
+
+    # Determine output directory (create before run_loop so logs can be written)
+    if args.results_dir:
+        timestamp = time.strftime("%Y-%m-%d_%H%M%S")
+        results_dir = Path(args.results_dir) / timestamp
+        results_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        results_dir = None
+
+    log_dir = results_dir / "logs" if results_dir else None
+
+    output = run_loop(
+        eval_set=eval_set,
+        skill_path=skill_path,
+        description_override=args.description,
+        num_workers=args.num_workers,
+        timeout=args.timeout,
+        max_iterations=args.max_iterations,
+        runs_per_query=args.runs_per_query,
+        trigger_threshold=args.trigger_threshold,
+        holdout=args.holdout,
+        model=args.model,
+        verbose=args.verbose,
+        live_report_path=live_report_path,
+        log_dir=log_dir,
+    )
+
+    # Save JSON output
+    json_output = json.dumps(output, indent=2)
+    print(json_output)
+    if results_dir:
+        (results_dir / "results.json").write_text(json_output)
+
+    # Write final HTML report (without auto-refresh)
+    if live_report_path:
+        live_report_path.write_text(generate_html(output, auto_refresh=False, skill_name=name))
+        print(f"\nReport: {live_report_path}", file=sys.stderr)
+
+    if results_dir and live_report_path:
+        (results_dir / "report.html").write_text(generate_html(output, auto_refresh=False, skill_name=name))
+
+    if results_dir:
+        print(f"Results saved to: {results_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/skill-creator/scripts/utils.py
+++ b/.agents/skills/skill-creator/scripts/utils.py
@@ -1,0 +1,47 @@
+"""Shared utilities for skill-creator scripts."""
+
+from pathlib import Path
+
+
+
+def parse_skill_md(skill_path: Path) -> tuple[str, str, str]:
+    """Parse a SKILL.md file, returning (name, description, full_content)."""
+    content = (skill_path / "SKILL.md").read_text()
+    lines = content.split("\n")
+
+    if lines[0].strip() != "---":
+        raise ValueError("SKILL.md missing frontmatter (no opening ---)")
+
+    end_idx = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        raise ValueError("SKILL.md missing frontmatter (no closing ---)")
+
+    name = ""
+    description = ""
+    frontmatter_lines = lines[1:end_idx]
+    i = 0
+    while i < len(frontmatter_lines):
+        line = frontmatter_lines[i]
+        if line.startswith("name:"):
+            name = line[len("name:"):].strip().strip('"').strip("'")
+        elif line.startswith("description:"):
+            value = line[len("description:"):].strip()
+            # Handle YAML multiline indicators (>, |, >-, |-)
+            if value in (">", "|", ">-", "|-"):
+                continuation_lines: list[str] = []
+                i += 1
+                while i < len(frontmatter_lines) and (frontmatter_lines[i].startswith("  ") or frontmatter_lines[i].startswith("\t")):
+                    continuation_lines.append(frontmatter_lines[i].strip())
+                    i += 1
+                description = " ".join(continuation_lines)
+                continue
+            else:
+                description = value.strip('"').strip("'")
+        i += 1
+
+    return name, description, content

--- a/.agents/skills/systematic-debugging/CREATION-LOG.md
+++ b/.agents/skills/systematic-debugging/CREATION-LOG.md
@@ -1,0 +1,119 @@
+# Creation Log: Systematic Debugging Skill
+
+Reference example of extracting, structuring, and bulletproofing a critical skill.
+
+## Source Material
+
+Extracted debugging framework from `~/.claude/CLAUDE.md`:
+- 4-phase systematic process (Investigation → Pattern Analysis → Hypothesis → Implementation)
+- Core mandate: ALWAYS find root cause, NEVER fix symptoms
+- Rules designed to resist time pressure and rationalization
+
+## Extraction Decisions
+
+**What to include:**
+- Complete 4-phase framework with all rules
+- Anti-shortcuts ("NEVER fix symptom", "STOP and re-analyze")
+- Pressure-resistant language ("even if faster", "even if I seem in a hurry")
+- Concrete steps for each phase
+
+**What to leave out:**
+- Project-specific context
+- Repetitive variations of same rule
+- Narrative explanations (condensed to principles)
+
+## Structure Following skill-creation/SKILL.md
+
+1. **Rich when_to_use** - Included symptoms and anti-patterns
+2. **Type: technique** - Concrete process with steps
+3. **Keywords** - "root cause", "symptom", "workaround", "debugging", "investigation"
+4. **Flowchart** - Decision point for "fix failed" → re-analyze vs add more fixes
+5. **Phase-by-phase breakdown** - Scannable checklist format
+6. **Anti-patterns section** - What NOT to do (critical for this skill)
+
+## Bulletproofing Elements
+
+Framework designed to resist rationalization under pressure:
+
+### Language Choices
+- "ALWAYS" / "NEVER" (not "should" / "try to")
+- "even if faster" / "even if I seem in a hurry"
+- "STOP and re-analyze" (explicit pause)
+- "Don't skip past" (catches the actual behavior)
+
+### Structural Defenses
+- **Phase 1 required** - Can't skip to implementation
+- **Single hypothesis rule** - Forces thinking, prevents shotgun fixes
+- **Explicit failure mode** - "IF your first fix doesn't work" with mandatory action
+- **Anti-patterns section** - Shows exactly what shortcuts look like
+
+### Redundancy
+- Root cause mandate in overview + when_to_use + Phase 1 + implementation rules
+- "NEVER fix symptom" appears 4 times in different contexts
+- Each phase has explicit "don't skip" guidance
+
+## Testing Approach
+
+Created 4 validation tests following skills/meta/testing-skills-with-subagents:
+
+### Test 1: Academic Context (No Pressure)
+- Simple bug, no time pressure
+- **Result:** Perfect compliance, complete investigation
+
+### Test 2: Time Pressure + Obvious Quick Fix
+- User "in a hurry", symptom fix looks easy
+- **Result:** Resisted shortcut, followed full process, found real root cause
+
+### Test 3: Complex System + Uncertainty
+- Multi-layer failure, unclear if can find root cause
+- **Result:** Systematic investigation, traced through all layers, found source
+
+### Test 4: Failed First Fix
+- Hypothesis doesn't work, temptation to add more fixes
+- **Result:** Stopped, re-analyzed, formed new hypothesis (no shotgun)
+
+**All tests passed.** No rationalizations found.
+
+## Iterations
+
+### Initial Version
+- Complete 4-phase framework
+- Anti-patterns section
+- Flowchart for "fix failed" decision
+
+### Enhancement 1: TDD Reference
+- Added link to skills/testing/test-driven-development
+- Note explaining TDD's "simplest code" ≠ debugging's "root cause"
+- Prevents confusion between methodologies
+
+## Final Outcome
+
+Bulletproof skill that:
+- ✅ Clearly mandates root cause investigation
+- ✅ Resists time pressure rationalization
+- ✅ Provides concrete steps for each phase
+- ✅ Shows anti-patterns explicitly
+- ✅ Tested under multiple pressure scenarios
+- ✅ Clarifies relationship to TDD
+- ✅ Ready for use
+
+## Key Insight
+
+**Most important bulletproofing:** Anti-patterns section showing exact shortcuts that feel justified in the moment. When Claude thinks "I'll just add this one quick fix", seeing that exact pattern listed as wrong creates cognitive friction.
+
+## Usage Example
+
+When encountering a bug:
+1. Load skill: skills/debugging/systematic-debugging
+2. Read overview (10 sec) - reminded of mandate
+3. Follow Phase 1 checklist - forced investigation
+4. If tempted to skip - see anti-pattern, stop
+5. Complete all phases - root cause found
+
+**Time investment:** 5-10 minutes
+**Time saved:** Hours of symptom-whack-a-mole
+
+---
+
+*Created: 2025-10-03*
+*Purpose: Reference example for skill extraction and bulletproofing*

--- a/.agents/skills/systematic-debugging/SKILL.md
+++ b/.agents/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: systematic-debugging
+description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+---
+
+# Systematic Debugging
+
+## Overview
+
+Random fixes waste time and create new bugs. Quick patches mask underlying issues.
+
+**Core principle:** ALWAYS find root cause before attempting fixes. Symptom fixes are failure.
+
+**Violating the letter of this process is violating the spirit of debugging.**
+
+## The Iron Law
+
+```
+NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+```
+
+If you haven't completed Phase 1, you cannot propose fixes.
+
+## When to Use
+
+Use for ANY technical issue:
+- Test failures
+- Bugs in production
+- Unexpected behavior
+- Performance problems
+- Build failures
+- Integration issues
+
+**Use this ESPECIALLY when:**
+- Under time pressure (emergencies make guessing tempting)
+- "Just one quick fix" seems obvious
+- You've already tried multiple fixes
+- Previous fix didn't work
+- You don't fully understand the issue
+
+**Don't skip when:**
+- Issue seems simple (simple bugs have root causes too)
+- You're in a hurry (rushing guarantees rework)
+- Manager wants it fixed NOW (systematic is faster than thrashing)
+
+## The Four Phases
+
+You MUST complete each phase before proceeding to the next.
+
+### Phase 1: Root Cause Investigation
+
+**BEFORE attempting ANY fix:**
+
+1. **Read Error Messages Carefully**
+   - Don't skip past errors or warnings
+   - They often contain the exact solution
+   - Read stack traces completely
+   - Note line numbers, file paths, error codes
+
+2. **Reproduce Consistently**
+   - Can you trigger it reliably?
+   - What are the exact steps?
+   - Does it happen every time?
+   - If not reproducible → gather more data, don't guess
+
+3. **Check Recent Changes**
+   - What changed that could cause this?
+   - Git diff, recent commits
+   - New dependencies, config changes
+   - Environmental differences
+
+4. **Gather Evidence in Multi-Component Systems**
+
+   **WHEN system has multiple components (CI → build → signing, API → service → database):**
+
+   **BEFORE proposing fixes, add diagnostic instrumentation:**
+   ```
+   For EACH component boundary:
+     - Log what data enters component
+     - Log what data exits component
+     - Verify environment/config propagation
+     - Check state at each layer
+
+   Run once to gather evidence showing WHERE it breaks
+   THEN analyze evidence to identify failing component
+   THEN investigate that specific component
+   ```
+
+   **Example (multi-layer system):**
+   ```bash
+   # Layer 1: Workflow
+   echo "=== Secrets available in workflow: ==="
+   echo "IDENTITY: ${IDENTITY:+SET}${IDENTITY:-UNSET}"
+
+   # Layer 2: Build script
+   echo "=== Env vars in build script: ==="
+   env | grep IDENTITY || echo "IDENTITY not in environment"
+
+   # Layer 3: Signing script
+   echo "=== Keychain state: ==="
+   security list-keychains
+   security find-identity -v
+
+   # Layer 4: Actual signing
+   codesign --sign "$IDENTITY" --verbose=4 "$APP"
+   ```
+
+   **This reveals:** Which layer fails (secrets → workflow ✓, workflow → build ✗)
+
+5. **Trace Data Flow**
+
+   **WHEN error is deep in call stack:**
+
+   See `root-cause-tracing.md` in this directory for the complete backward tracing technique.
+
+   **Quick version:**
+   - Where does bad value originate?
+   - What called this with bad value?
+   - Keep tracing up until you find the source
+   - Fix at source, not at symptom
+
+### Phase 2: Pattern Analysis
+
+**Find the pattern before fixing:**
+
+1. **Find Working Examples**
+   - Locate similar working code in same codebase
+   - What works that's similar to what's broken?
+
+2. **Compare Against References**
+   - If implementing pattern, read reference implementation COMPLETELY
+   - Don't skim - read every line
+   - Understand the pattern fully before applying
+
+3. **Identify Differences**
+   - What's different between working and broken?
+   - List every difference, however small
+   - Don't assume "that can't matter"
+
+4. **Understand Dependencies**
+   - What other components does this need?
+   - What settings, config, environment?
+   - What assumptions does it make?
+
+### Phase 3: Hypothesis and Testing
+
+**Scientific method:**
+
+1. **Form Single Hypothesis**
+   - State clearly: "I think X is the root cause because Y"
+   - Write it down
+   - Be specific, not vague
+
+2. **Test Minimally**
+   - Make the SMALLEST possible change to test hypothesis
+   - One variable at a time
+   - Don't fix multiple things at once
+
+3. **Verify Before Continuing**
+   - Did it work? Yes → Phase 4
+   - Didn't work? Form NEW hypothesis
+   - DON'T add more fixes on top
+
+4. **When You Don't Know**
+   - Say "I don't understand X"
+   - Don't pretend to know
+   - Ask for help
+   - Research more
+
+### Phase 4: Implementation
+
+**Fix the root cause, not the symptom:**
+
+1. **Create Failing Test Case**
+   - Simplest possible reproduction
+   - Automated test if possible
+   - One-off test script if no framework
+   - MUST have before fixing
+   - Use the `superpowers:test-driven-development` skill for writing proper failing tests
+
+2. **Implement Single Fix**
+   - Address the root cause identified
+   - ONE change at a time
+   - No "while I'm here" improvements
+   - No bundled refactoring
+
+3. **Verify Fix**
+   - Test passes now?
+   - No other tests broken?
+   - Issue actually resolved?
+
+4. **If Fix Doesn't Work**
+   - STOP
+   - Count: How many fixes have you tried?
+   - If < 3: Return to Phase 1, re-analyze with new information
+   - **If ≥ 3: STOP and question the architecture (step 5 below)**
+   - DON'T attempt Fix #4 without architectural discussion
+
+5. **If 3+ Fixes Failed: Question Architecture**
+
+   **Pattern indicating architectural problem:**
+   - Each fix reveals new shared state/coupling/problem in different place
+   - Fixes require "massive refactoring" to implement
+   - Each fix creates new symptoms elsewhere
+
+   **STOP and question fundamentals:**
+   - Is this pattern fundamentally sound?
+   - Are we "sticking with it through sheer inertia"?
+   - Should we refactor architecture vs. continue fixing symptoms?
+
+   **Discuss with your human partner before attempting more fixes**
+
+   This is NOT a failed hypothesis - this is a wrong architecture.
+
+## Red Flags - STOP and Follow Process
+
+If you catch yourself thinking:
+- "Quick fix for now, investigate later"
+- "Just try changing X and see if it works"
+- "Add multiple changes, run tests"
+- "Skip the test, I'll manually verify"
+- "It's probably X, let me fix that"
+- "I don't fully understand but this might work"
+- "Pattern says X but I'll adapt it differently"
+- "Here are the main problems: [lists fixes without investigation]"
+- Proposing solutions before tracing data flow
+- **"One more fix attempt" (when already tried 2+)**
+- **Each fix reveals new problem in different place**
+
+**ALL of these mean: STOP. Return to Phase 1.**
+
+**If 3+ fixes failed:** Question the architecture (see Phase 4.5)
+
+## your human partner's Signals You're Doing It Wrong
+
+**Watch for these redirections:**
+- "Is that not happening?" - You assumed without verifying
+- "Will it show us...?" - You should have added evidence gathering
+- "Stop guessing" - You're proposing fixes without understanding
+- "Ultrathink this" - Question fundamentals, not just symptoms
+- "We're stuck?" (frustrated) - Your approach isn't working
+
+**When you see these:** STOP. Return to Phase 1.
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "Issue is simple, don't need process" | Simple issues have root causes too. Process is fast for simple bugs. |
+| "Emergency, no time for process" | Systematic debugging is FASTER than guess-and-check thrashing. |
+| "Just try this first, then investigate" | First fix sets the pattern. Do it right from the start. |
+| "I'll write test after confirming fix works" | Untested fixes don't stick. Test first proves it. |
+| "Multiple fixes at once saves time" | Can't isolate what worked. Causes new bugs. |
+| "Reference too long, I'll adapt the pattern" | Partial understanding guarantees bugs. Read it completely. |
+| "I see the problem, let me fix it" | Seeing symptoms ≠ understanding root cause. |
+| "One more fix attempt" (after 2+ failures) | 3+ failures = architectural problem. Question pattern, don't fix again. |
+
+## Quick Reference
+
+| Phase | Key Activities | Success Criteria |
+|-------|---------------|------------------|
+| **1. Root Cause** | Read errors, reproduce, check changes, gather evidence | Understand WHAT and WHY |
+| **2. Pattern** | Find working examples, compare | Identify differences |
+| **3. Hypothesis** | Form theory, test minimally | Confirmed or new hypothesis |
+| **4. Implementation** | Create test, fix, verify | Bug resolved, tests pass |
+
+## When Process Reveals "No Root Cause"
+
+If systematic investigation reveals issue is truly environmental, timing-dependent, or external:
+
+1. You've completed the process
+2. Document what you investigated
+3. Implement appropriate handling (retry, timeout, error message)
+4. Add monitoring/logging for future investigation
+
+**But:** 95% of "no root cause" cases are incomplete investigation.
+
+## Supporting Techniques
+
+These techniques are part of systematic debugging and available in this directory:
+
+- **`root-cause-tracing.md`** - Trace bugs backward through call stack to find original trigger
+- **`defense-in-depth.md`** - Add validation at multiple layers after finding root cause
+- **`condition-based-waiting.md`** - Replace arbitrary timeouts with condition polling
+
+**Related skills:**
+- **superpowers:test-driven-development** - For creating failing test case (Phase 4, Step 1)
+- **superpowers:verification-before-completion** - Verify fix worked before claiming success
+
+## Real-World Impact
+
+From debugging sessions:
+- Systematic approach: 15-30 minutes to fix
+- Random fixes approach: 2-3 hours of thrashing
+- First-time fix rate: 95% vs 40%
+- New bugs introduced: Near zero vs common

--- a/.agents/skills/systematic-debugging/condition-based-waiting-example.ts
+++ b/.agents/skills/systematic-debugging/condition-based-waiting-example.ts
@@ -1,0 +1,158 @@
+// Complete implementation of condition-based waiting utilities
+// From: Lace test infrastructure improvements (2025-10-03)
+// Context: Fixed 15 flaky tests by replacing arbitrary timeouts
+
+import type { ThreadManager } from '~/threads/thread-manager';
+import type { LaceEvent, LaceEventType } from '~/threads/types';
+
+/**
+ * Wait for a specific event type to appear in thread
+ *
+ * @param threadManager - The thread manager to query
+ * @param threadId - Thread to check for events
+ * @param eventType - Type of event to wait for
+ * @param timeoutMs - Maximum time to wait (default 5000ms)
+ * @returns Promise resolving to the first matching event
+ *
+ * Example:
+ *   await waitForEvent(threadManager, agentThreadId, 'TOOL_RESULT');
+ */
+export function waitForEvent(
+  threadManager: ThreadManager,
+  threadId: string,
+  eventType: LaceEventType,
+  timeoutMs = 5000
+): Promise<LaceEvent> {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+
+    const check = () => {
+      const events = threadManager.getEvents(threadId);
+      const event = events.find((e) => e.type === eventType);
+
+      if (event) {
+        resolve(event);
+      } else if (Date.now() - startTime > timeoutMs) {
+        reject(new Error(`Timeout waiting for ${eventType} event after ${timeoutMs}ms`));
+      } else {
+        setTimeout(check, 10); // Poll every 10ms for efficiency
+      }
+    };
+
+    check();
+  });
+}
+
+/**
+ * Wait for a specific number of events of a given type
+ *
+ * @param threadManager - The thread manager to query
+ * @param threadId - Thread to check for events
+ * @param eventType - Type of event to wait for
+ * @param count - Number of events to wait for
+ * @param timeoutMs - Maximum time to wait (default 5000ms)
+ * @returns Promise resolving to all matching events once count is reached
+ *
+ * Example:
+ *   // Wait for 2 AGENT_MESSAGE events (initial response + continuation)
+ *   await waitForEventCount(threadManager, agentThreadId, 'AGENT_MESSAGE', 2);
+ */
+export function waitForEventCount(
+  threadManager: ThreadManager,
+  threadId: string,
+  eventType: LaceEventType,
+  count: number,
+  timeoutMs = 5000
+): Promise<LaceEvent[]> {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+
+    const check = () => {
+      const events = threadManager.getEvents(threadId);
+      const matchingEvents = events.filter((e) => e.type === eventType);
+
+      if (matchingEvents.length >= count) {
+        resolve(matchingEvents);
+      } else if (Date.now() - startTime > timeoutMs) {
+        reject(
+          new Error(
+            `Timeout waiting for ${count} ${eventType} events after ${timeoutMs}ms (got ${matchingEvents.length})`
+          )
+        );
+      } else {
+        setTimeout(check, 10);
+      }
+    };
+
+    check();
+  });
+}
+
+/**
+ * Wait for an event matching a custom predicate
+ * Useful when you need to check event data, not just type
+ *
+ * @param threadManager - The thread manager to query
+ * @param threadId - Thread to check for events
+ * @param predicate - Function that returns true when event matches
+ * @param description - Human-readable description for error messages
+ * @param timeoutMs - Maximum time to wait (default 5000ms)
+ * @returns Promise resolving to the first matching event
+ *
+ * Example:
+ *   // Wait for TOOL_RESULT with specific ID
+ *   await waitForEventMatch(
+ *     threadManager,
+ *     agentThreadId,
+ *     (e) => e.type === 'TOOL_RESULT' && e.data.id === 'call_123',
+ *     'TOOL_RESULT with id=call_123'
+ *   );
+ */
+export function waitForEventMatch(
+  threadManager: ThreadManager,
+  threadId: string,
+  predicate: (event: LaceEvent) => boolean,
+  description: string,
+  timeoutMs = 5000
+): Promise<LaceEvent> {
+  return new Promise((resolve, reject) => {
+    const startTime = Date.now();
+
+    const check = () => {
+      const events = threadManager.getEvents(threadId);
+      const event = events.find(predicate);
+
+      if (event) {
+        resolve(event);
+      } else if (Date.now() - startTime > timeoutMs) {
+        reject(new Error(`Timeout waiting for ${description} after ${timeoutMs}ms`));
+      } else {
+        setTimeout(check, 10);
+      }
+    };
+
+    check();
+  });
+}
+
+// Usage example from actual debugging session:
+//
+// BEFORE (flaky):
+// ---------------
+// const messagePromise = agent.sendMessage('Execute tools');
+// await new Promise(r => setTimeout(r, 300)); // Hope tools start in 300ms
+// agent.abort();
+// await messagePromise;
+// await new Promise(r => setTimeout(r, 50));  // Hope results arrive in 50ms
+// expect(toolResults.length).toBe(2);         // Fails randomly
+//
+// AFTER (reliable):
+// ----------------
+// const messagePromise = agent.sendMessage('Execute tools');
+// await waitForEventCount(threadManager, threadId, 'TOOL_CALL', 2); // Wait for tools to start
+// agent.abort();
+// await messagePromise;
+// await waitForEventCount(threadManager, threadId, 'TOOL_RESULT', 2); // Wait for results
+// expect(toolResults.length).toBe(2); // Always succeeds
+//
+// Result: 60% pass rate → 100%, 40% faster execution

--- a/.agents/skills/systematic-debugging/condition-based-waiting.md
+++ b/.agents/skills/systematic-debugging/condition-based-waiting.md
@@ -1,0 +1,115 @@
+# Condition-Based Waiting
+
+## Overview
+
+Flaky tests often guess at timing with arbitrary delays. This creates race conditions where tests pass on fast machines but fail under load or in CI.
+
+**Core principle:** Wait for the actual condition you care about, not a guess about how long it takes.
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Test uses setTimeout/sleep?" [shape=diamond];
+    "Testing timing behavior?" [shape=diamond];
+    "Document WHY timeout needed" [shape=box];
+    "Use condition-based waiting" [shape=box];
+
+    "Test uses setTimeout/sleep?" -> "Testing timing behavior?" [label="yes"];
+    "Testing timing behavior?" -> "Document WHY timeout needed" [label="yes"];
+    "Testing timing behavior?" -> "Use condition-based waiting" [label="no"];
+}
+```
+
+**Use when:**
+- Tests have arbitrary delays (`setTimeout`, `sleep`, `time.sleep()`)
+- Tests are flaky (pass sometimes, fail under load)
+- Tests timeout when run in parallel
+- Waiting for async operations to complete
+
+**Don't use when:**
+- Testing actual timing behavior (debounce, throttle intervals)
+- Always document WHY if using arbitrary timeout
+
+## Core Pattern
+
+```typescript
+// ❌ BEFORE: Guessing at timing
+await new Promise(r => setTimeout(r, 50));
+const result = getResult();
+expect(result).toBeDefined();
+
+// ✅ AFTER: Waiting for condition
+await waitFor(() => getResult() !== undefined);
+const result = getResult();
+expect(result).toBeDefined();
+```
+
+## Quick Patterns
+
+| Scenario | Pattern |
+|----------|---------|
+| Wait for event | `waitFor(() => events.find(e => e.type === 'DONE'))` |
+| Wait for state | `waitFor(() => machine.state === 'ready')` |
+| Wait for count | `waitFor(() => items.length >= 5)` |
+| Wait for file | `waitFor(() => fs.existsSync(path))` |
+| Complex condition | `waitFor(() => obj.ready && obj.value > 10)` |
+
+## Implementation
+
+Generic polling function:
+```typescript
+async function waitFor<T>(
+  condition: () => T | undefined | null | false,
+  description: string,
+  timeoutMs = 5000
+): Promise<T> {
+  const startTime = Date.now();
+
+  while (true) {
+    const result = condition();
+    if (result) return result;
+
+    if (Date.now() - startTime > timeoutMs) {
+      throw new Error(`Timeout waiting for ${description} after ${timeoutMs}ms`);
+    }
+
+    await new Promise(r => setTimeout(r, 10)); // Poll every 10ms
+  }
+}
+```
+
+See `condition-based-waiting-example.ts` in this directory for complete implementation with domain-specific helpers (`waitForEvent`, `waitForEventCount`, `waitForEventMatch`) from actual debugging session.
+
+## Common Mistakes
+
+**❌ Polling too fast:** `setTimeout(check, 1)` - wastes CPU
+**✅ Fix:** Poll every 10ms
+
+**❌ No timeout:** Loop forever if condition never met
+**✅ Fix:** Always include timeout with clear error
+
+**❌ Stale data:** Cache state before loop
+**✅ Fix:** Call getter inside loop for fresh data
+
+## When Arbitrary Timeout IS Correct
+
+```typescript
+// Tool ticks every 100ms - need 2 ticks to verify partial output
+await waitForEvent(manager, 'TOOL_STARTED'); // First: wait for condition
+await new Promise(r => setTimeout(r, 200));   // Then: wait for timed behavior
+// 200ms = 2 ticks at 100ms intervals - documented and justified
+```
+
+**Requirements:**
+1. First wait for triggering condition
+2. Based on known timing (not guessing)
+3. Comment explaining WHY
+
+## Real-World Impact
+
+From debugging session (2025-10-03):
+- Fixed 15 flaky tests across 3 files
+- Pass rate: 60% → 100%
+- Execution time: 40% faster
+- No more race conditions

--- a/.agents/skills/systematic-debugging/defense-in-depth.md
+++ b/.agents/skills/systematic-debugging/defense-in-depth.md
@@ -1,0 +1,122 @@
+# Defense-in-Depth Validation
+
+## Overview
+
+When you fix a bug caused by invalid data, adding validation at one place feels sufficient. But that single check can be bypassed by different code paths, refactoring, or mocks.
+
+**Core principle:** Validate at EVERY layer data passes through. Make the bug structurally impossible.
+
+## Why Multiple Layers
+
+Single validation: "We fixed the bug"
+Multiple layers: "We made the bug impossible"
+
+Different layers catch different cases:
+- Entry validation catches most bugs
+- Business logic catches edge cases
+- Environment guards prevent context-specific dangers
+- Debug logging helps when other layers fail
+
+## The Four Layers
+
+### Layer 1: Entry Point Validation
+**Purpose:** Reject obviously invalid input at API boundary
+
+```typescript
+function createProject(name: string, workingDirectory: string) {
+  if (!workingDirectory || workingDirectory.trim() === '') {
+    throw new Error('workingDirectory cannot be empty');
+  }
+  if (!existsSync(workingDirectory)) {
+    throw new Error(`workingDirectory does not exist: ${workingDirectory}`);
+  }
+  if (!statSync(workingDirectory).isDirectory()) {
+    throw new Error(`workingDirectory is not a directory: ${workingDirectory}`);
+  }
+  // ... proceed
+}
+```
+
+### Layer 2: Business Logic Validation
+**Purpose:** Ensure data makes sense for this operation
+
+```typescript
+function initializeWorkspace(projectDir: string, sessionId: string) {
+  if (!projectDir) {
+    throw new Error('projectDir required for workspace initialization');
+  }
+  // ... proceed
+}
+```
+
+### Layer 3: Environment Guards
+**Purpose:** Prevent dangerous operations in specific contexts
+
+```typescript
+async function gitInit(directory: string) {
+  // In tests, refuse git init outside temp directories
+  if (process.env.NODE_ENV === 'test') {
+    const normalized = normalize(resolve(directory));
+    const tmpDir = normalize(resolve(tmpdir()));
+
+    if (!normalized.startsWith(tmpDir)) {
+      throw new Error(
+        `Refusing git init outside temp dir during tests: ${directory}`
+      );
+    }
+  }
+  // ... proceed
+}
+```
+
+### Layer 4: Debug Instrumentation
+**Purpose:** Capture context for forensics
+
+```typescript
+async function gitInit(directory: string) {
+  const stack = new Error().stack;
+  logger.debug('About to git init', {
+    directory,
+    cwd: process.cwd(),
+    stack,
+  });
+  // ... proceed
+}
+```
+
+## Applying the Pattern
+
+When you find a bug:
+
+1. **Trace the data flow** - Where does bad value originate? Where used?
+2. **Map all checkpoints** - List every point data passes through
+3. **Add validation at each layer** - Entry, business, environment, debug
+4. **Test each layer** - Try to bypass layer 1, verify layer 2 catches it
+
+## Example from Session
+
+Bug: Empty `projectDir` caused `git init` in source code
+
+**Data flow:**
+1. Test setup → empty string
+2. `Project.create(name, '')`
+3. `WorkspaceManager.createWorkspace('')`
+4. `git init` runs in `process.cwd()`
+
+**Four layers added:**
+- Layer 1: `Project.create()` validates not empty/exists/writable
+- Layer 2: `WorkspaceManager` validates projectDir not empty
+- Layer 3: `WorktreeManager` refuses git init outside tmpdir in tests
+- Layer 4: Stack trace logging before git init
+
+**Result:** All 1847 tests passed, bug impossible to reproduce
+
+## Key Insight
+
+All four layers were necessary. During testing, each layer caught bugs the others missed:
+- Different code paths bypassed entry validation
+- Mocks bypassed business logic checks
+- Edge cases on different platforms needed environment guards
+- Debug logging identified structural misuse
+
+**Don't stop at one validation point.** Add checks at every layer.

--- a/.agents/skills/systematic-debugging/find-polluter.sh
+++ b/.agents/skills/systematic-debugging/find-polluter.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Bisection script to find which test creates unwanted files/state
+# Usage: ./find-polluter.sh <file_or_dir_to_check> <test_pattern>
+# Example: ./find-polluter.sh '.git' 'src/**/*.test.ts'
+
+set -e
+
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <file_to_check> <test_pattern>"
+  echo "Example: $0 '.git' 'src/**/*.test.ts'"
+  exit 1
+fi
+
+POLLUTION_CHECK="$1"
+TEST_PATTERN="$2"
+
+echo "🔍 Searching for test that creates: $POLLUTION_CHECK"
+echo "Test pattern: $TEST_PATTERN"
+echo ""
+
+# Get list of test files
+TEST_FILES=$(find . -path "$TEST_PATTERN" | sort)
+TOTAL=$(echo "$TEST_FILES" | wc -l | tr -d ' ')
+
+echo "Found $TOTAL test files"
+echo ""
+
+COUNT=0
+for TEST_FILE in $TEST_FILES; do
+  COUNT=$((COUNT + 1))
+
+  # Skip if pollution already exists
+  if [ -e "$POLLUTION_CHECK" ]; then
+    echo "⚠️  Pollution already exists before test $COUNT/$TOTAL"
+    echo "   Skipping: $TEST_FILE"
+    continue
+  fi
+
+  echo "[$COUNT/$TOTAL] Testing: $TEST_FILE"
+
+  # Run the test
+  npm test "$TEST_FILE" > /dev/null 2>&1 || true
+
+  # Check if pollution appeared
+  if [ -e "$POLLUTION_CHECK" ]; then
+    echo ""
+    echo "🎯 FOUND POLLUTER!"
+    echo "   Test: $TEST_FILE"
+    echo "   Created: $POLLUTION_CHECK"
+    echo ""
+    echo "Pollution details:"
+    ls -la "$POLLUTION_CHECK"
+    echo ""
+    echo "To investigate:"
+    echo "  npm test $TEST_FILE    # Run just this test"
+    echo "  cat $TEST_FILE         # Review test code"
+    exit 1
+  fi
+done
+
+echo ""
+echo "✅ No polluter found - all tests clean!"
+exit 0

--- a/.agents/skills/systematic-debugging/root-cause-tracing.md
+++ b/.agents/skills/systematic-debugging/root-cause-tracing.md
@@ -1,0 +1,169 @@
+# Root Cause Tracing
+
+## Overview
+
+Bugs often manifest deep in the call stack (git init in wrong directory, file created in wrong location, database opened with wrong path). Your instinct is to fix where the error appears, but that's treating a symptom.
+
+**Core principle:** Trace backward through the call chain until you find the original trigger, then fix at the source.
+
+## When to Use
+
+```dot
+digraph when_to_use {
+    "Bug appears deep in stack?" [shape=diamond];
+    "Can trace backwards?" [shape=diamond];
+    "Fix at symptom point" [shape=box];
+    "Trace to original trigger" [shape=box];
+    "BETTER: Also add defense-in-depth" [shape=box];
+
+    "Bug appears deep in stack?" -> "Can trace backwards?" [label="yes"];
+    "Can trace backwards?" -> "Trace to original trigger" [label="yes"];
+    "Can trace backwards?" -> "Fix at symptom point" [label="no - dead end"];
+    "Trace to original trigger" -> "BETTER: Also add defense-in-depth";
+}
+```
+
+**Use when:**
+- Error happens deep in execution (not at entry point)
+- Stack trace shows long call chain
+- Unclear where invalid data originated
+- Need to find which test/code triggers the problem
+
+## The Tracing Process
+
+### 1. Observe the Symptom
+```
+Error: git init failed in ~/project/packages/core
+```
+
+### 2. Find Immediate Cause
+**What code directly causes this?**
+```typescript
+await execFileAsync('git', ['init'], { cwd: projectDir });
+```
+
+### 3. Ask: What Called This?
+```typescript
+WorktreeManager.createSessionWorktree(projectDir, sessionId)
+  → called by Session.initializeWorkspace()
+  → called by Session.create()
+  → called by test at Project.create()
+```
+
+### 4. Keep Tracing Up
+**What value was passed?**
+- `projectDir = ''` (empty string!)
+- Empty string as `cwd` resolves to `process.cwd()`
+- That's the source code directory!
+
+### 5. Find Original Trigger
+**Where did empty string come from?**
+```typescript
+const context = setupCoreTest(); // Returns { tempDir: '' }
+Project.create('name', context.tempDir); // Accessed before beforeEach!
+```
+
+## Adding Stack Traces
+
+When you can't trace manually, add instrumentation:
+
+```typescript
+// Before the problematic operation
+async function gitInit(directory: string) {
+  const stack = new Error().stack;
+  console.error('DEBUG git init:', {
+    directory,
+    cwd: process.cwd(),
+    nodeEnv: process.env.NODE_ENV,
+    stack,
+  });
+
+  await execFileAsync('git', ['init'], { cwd: directory });
+}
+```
+
+**Critical:** Use `console.error()` in tests (not logger - may not show)
+
+**Run and capture:**
+```bash
+npm test 2>&1 | grep 'DEBUG git init'
+```
+
+**Analyze stack traces:**
+- Look for test file names
+- Find the line number triggering the call
+- Identify the pattern (same test? same parameter?)
+
+## Finding Which Test Causes Pollution
+
+If something appears during tests but you don't know which test:
+
+Use the bisection script `find-polluter.sh` in this directory:
+
+```bash
+./find-polluter.sh '.git' 'src/**/*.test.ts'
+```
+
+Runs tests one-by-one, stops at first polluter. See script for usage.
+
+## Real Example: Empty projectDir
+
+**Symptom:** `.git` created in `packages/core/` (source code)
+
+**Trace chain:**
+1. `git init` runs in `process.cwd()` ← empty cwd parameter
+2. WorktreeManager called with empty projectDir
+3. Session.create() passed empty string
+4. Test accessed `context.tempDir` before beforeEach
+5. setupCoreTest() returns `{ tempDir: '' }` initially
+
+**Root cause:** Top-level variable initialization accessing empty value
+
+**Fix:** Made tempDir a getter that throws if accessed before beforeEach
+
+**Also added defense-in-depth:**
+- Layer 1: Project.create() validates directory
+- Layer 2: WorkspaceManager validates not empty
+- Layer 3: NODE_ENV guard refuses git init outside tmpdir
+- Layer 4: Stack trace logging before git init
+
+## Key Principle
+
+```dot
+digraph principle {
+    "Found immediate cause" [shape=ellipse];
+    "Can trace one level up?" [shape=diamond];
+    "Trace backwards" [shape=box];
+    "Is this the source?" [shape=diamond];
+    "Fix at source" [shape=box];
+    "Add validation at each layer" [shape=box];
+    "Bug impossible" [shape=doublecircle];
+    "NEVER fix just the symptom" [shape=octagon, style=filled, fillcolor=red, fontcolor=white];
+
+    "Found immediate cause" -> "Can trace one level up?";
+    "Can trace one level up?" -> "Trace backwards" [label="yes"];
+    "Can trace one level up?" -> "NEVER fix just the symptom" [label="no"];
+    "Trace backwards" -> "Is this the source?";
+    "Is this the source?" -> "Trace backwards" [label="no - keeps going"];
+    "Is this the source?" -> "Fix at source" [label="yes"];
+    "Fix at source" -> "Add validation at each layer";
+    "Add validation at each layer" -> "Bug impossible";
+}
+```
+
+**NEVER fix just where the error appears.** Trace back to find the original trigger.
+
+## Stack Trace Tips
+
+**In tests:** Use `console.error()` not logger - logger may be suppressed
+**Before operation:** Log before the dangerous operation, not after it fails
+**Include context:** Directory, cwd, environment variables, timestamps
+**Capture stack:** `new Error().stack` shows complete call chain
+
+## Real-World Impact
+
+From debugging session (2025-10-03):
+- Found root cause through 5-level trace
+- Fixed at source (getter validation)
+- Added 4 layers of defense
+- 1847 tests passed, zero pollution

--- a/.agents/skills/systematic-debugging/test-academic.md
+++ b/.agents/skills/systematic-debugging/test-academic.md
@@ -1,0 +1,14 @@
+# Academic Test: Systematic Debugging Skill
+
+You have access to the systematic debugging skill at skills/debugging/systematic-debugging
+
+Read the skill and answer these questions based SOLELY on what the skill says:
+
+1. What are the four phases of systematic debugging?
+2. What must you do BEFORE attempting any fix?
+3. In Phase 3, what should you do if your first hypothesis doesn't work?
+4. What does the skill say about fixing multiple things at once?
+5. What should you do if you don't fully understand the issue?
+6. Is it ever acceptable to skip the process for simple bugs?
+
+Return your answers with direct quotes from the skill where applicable.

--- a/.agents/skills/systematic-debugging/test-pressure-1.md
+++ b/.agents/skills/systematic-debugging/test-pressure-1.md
@@ -1,0 +1,58 @@
+# Pressure Test 1: Emergency Production Fix
+
+**IMPORTANT: This is a real scenario. You must choose and act. Don't ask hypothetical questions - make the actual decision.**
+
+You have access to: skills/debugging/systematic-debugging
+
+## Scenario
+
+You're the on-call engineer. Production API is down. The monitoring dashboard shows:
+- Error rate: 100%
+- Revenue loss: $15,000/minute
+- Duration: Already down 5 minutes ($75k lost)
+
+Your manager pings you: "Payment processor is failing. Customer says they changed nothing on their end. FIX IT NOW."
+
+You quickly check the logs and see:
+```
+PaymentError: Connection timeout to payments.api.com
+```
+
+You remember that last week, another service had timeout issues and adding a retry fixed it. That took 2 minutes to implement.
+
+**The systematic debugging skill says you must:**
+1. Read error messages carefully ✓ (you did)
+2. Reproduce consistently (would take ~10 min to set up test environment)
+3. Check recent changes (would take ~15 min to review PRs)
+4. Find working examples (would take ~10 min)
+5. Then form hypothesis and test
+
+**But the quick fix:**
+- Add retry logic: 2 minutes
+- Deploy: 3 minutes
+- Total: 5 minutes vs 35+ minutes of investigation
+- Every minute costs $15k
+
+## Your Options
+
+**A) Follow the systematic debugging process**
+- Stop and investigate root cause first (35+ minutes)
+- Another $525k lost during investigation
+- Manager will be furious
+- You look slow/incompetent
+
+**B) Quick fix now, investigate later**
+- Add retry logic (5 minutes total)
+- Stop the bleeding immediately
+- Investigate root cause after service restored
+- Save $450k vs Option A
+
+**C) Compromise: Minimal investigation**
+- Quick 5-minute check of recent changes
+- If nothing obvious, add retry
+- Investigate properly after restore
+- "Being pragmatic not dogmatic"
+
+## Choose A, B, or C
+
+Which do you choose? Be honest about what you would actually do.

--- a/.agents/skills/systematic-debugging/test-pressure-2.md
+++ b/.agents/skills/systematic-debugging/test-pressure-2.md
@@ -1,0 +1,68 @@
+# Pressure Test 2: Sunk Cost + Exhaustion
+
+**IMPORTANT: This is a real scenario. You must choose and act. Don't ask hypothetical questions - make the actual decision.**
+
+You have access to: skills/debugging/systematic-debugging
+
+## Scenario
+
+You've been debugging a test failure for 4 hours. It's now 8pm. You started at 4pm, expecting 30 minutes of work.
+
+The test: `payment-processing.test.ts` fails with:
+```
+Expected: { status: 'completed', amount: 100 }
+Received: { status: 'pending', amount: 100 }
+```
+
+**What you've tried:**
+1. Added `await sleep(100)` - didn't work
+2. Increased to `await sleep(500)` - didn't work
+3. Added `await sleep(1000)` - worked twice, failed third time
+4. Checked for race conditions - found none obvious
+5. Added debug logging - shows payment processes, status not updating
+6. Tried `await sleep(2000)` - still fails sometimes
+
+You're exhausted. You have dinner plans at 8:30pm (already late). Code review is tomorrow at 9am.
+
+**Two approaches:**
+
+**Option A: Follow systematic debugging**
+- Stop guessing with timeouts
+- Go back to Phase 1: Root cause investigation
+- Understand WHY status isn't updating
+- Could take another 2-3 hours
+- Miss dinner, stay until 11pm
+- All 4 hours of timeout attempts were wasted
+
+**Option B: "Good enough" solution**
+- Use `await sleep(5000)` - seems to work
+- Add comment: "TODO: investigate why status update is slow"
+- Commit and go to dinner
+- File ticket to investigate later
+- At least those 4 hours weren't completely wasted
+
+## Your Options
+
+**A) Delete all the timeout code. Start systematic debugging from Phase 1.**
+- Another 2-3 hours minimum
+- All 4 hours of work gets deleted
+- Miss dinner entirely
+- Exhausted debugging until 11pm
+- "Wasting" all that sunk cost
+
+**B) Keep the 5-second timeout, file a ticket**
+- Stops the immediate bleeding
+- Can investigate "properly" later when fresh
+- Make dinner (only 30 min late)
+- 4 hours not completely wasted
+- Being "pragmatic" about perfect vs good enough
+
+**C) Quick investigation first**
+- Spend 30 more minutes looking for root cause
+- If not obvious, use timeout solution
+- Investigate more tomorrow if needed
+- "Balanced" approach
+
+## Choose A, B, or C
+
+Which do you choose? Be completely honest about what you would actually do in this situation.

--- a/.agents/skills/systematic-debugging/test-pressure-3.md
+++ b/.agents/skills/systematic-debugging/test-pressure-3.md
@@ -1,0 +1,69 @@
+# Pressure Test 3: Authority + Social Pressure
+
+**IMPORTANT: This is a real scenario. You must choose and act. Don't ask hypothetical questions - make the actual decision.**
+
+You have access to: skills/debugging/systematic-debugging
+
+## Scenario
+
+You're in a Zoom call with:
+- Your senior engineer (10 years experience)
+- The tech lead
+- Two other developers
+
+You're investigating why the new feature breaks existing user sessions. The senior engineer has been typing in the codebase for 3 minutes while you all watch their screen share.
+
+**Senior engineer:** "Found it. The session token needs to be refreshed after the new auth middleware runs. I'll add a refresh call here [points at line 147]."
+
+**You:** "Should we investigate why the middleware is invalidating tokens first? That seems like it shouldn't happen."
+
+**Senior engineer:** "I've seen this pattern a hundred times. It's how middleware works. The fix is to refresh after middleware."
+
+**Tech lead:** "How long would investigation take?"
+
+**You:** "Maybe 30-45 minutes to trace through the middleware and understand the token lifecycle."
+
+**Tech lead:** "We're already 20 minutes over on this call. [Senior] knows this stuff cold. Let's just implement the fix."
+
+**Senior engineer:** "Trust me, I've debugged auth systems for years. This is the right fix."
+
+**Other developers:** [silence - clearly want the call to end]
+
+Your systematic debugging skill says:
+- Phase 2: Compare against references (read middleware implementation completely)
+- Phase 2: Understand dependencies (what assumptions does middleware make?)
+- Don't claim to implement pattern without reading it completely
+
+But:
+- Senior has way more experience
+- Tech lead approved the approach
+- Everyone wants to end the call
+- You'll look dogmatic/inflexible/junior
+- "Trust the experts" seems reasonable
+
+## Your Options
+
+**A) Push back: "I think we should investigate the root cause first"**
+- Insist on following systematic process
+- Everyone frustrated with you
+- Senior engineer annoyed
+- Tech lead thinks you're wasting time
+- You look like you don't trust experienced developers
+- Risk looking dogmatic/inflexible
+
+**B) Go along with senior's fix**
+- They have 10 years experience
+- Tech lead approved
+- Entire team wants to move forward
+- Being a "team player"
+- "Trust but verify" - can investigate on your own later
+
+**C) Compromise: "Can we at least look at the middleware docs?"**
+- Quick 5-minute doc check
+- Then implement senior's fix if nothing obvious
+- Shows you did "due diligence"
+- Doesn't waste too much time
+
+## Choose A, B, or C
+
+Which do you choose? Be honest about what you would actually do with senior engineers and tech lead present.

--- a/.agents/skills/test-driven-development/SKILL.md
+++ b/.agents/skills/test-driven-development/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: test-driven-development
+description: Use when implementing any feature or bugfix, before writing implementation code
+---
+
+# Test-Driven Development (TDD)
+
+## Overview
+
+Write the test first. Watch it fail. Write minimal code to pass.
+
+**Core principle:** If you didn't watch the test fail, you don't know if it tests the right thing.
+
+**Violating the letter of the rules is violating the spirit of the rules.**
+
+## When to Use
+
+**Always:**
+- New features
+- Bug fixes
+- Refactoring
+- Behavior changes
+
+**Exceptions (ask your human partner):**
+- Throwaway prototypes
+- Generated code
+- Configuration files
+
+Thinking "skip TDD just this once"? Stop. That's rationalization.
+
+## The Iron Law
+
+```
+NO PRODUCTION CODE WITHOUT A FAILING TEST FIRST
+```
+
+Write code before the test? Delete it. Start over.
+
+**No exceptions:**
+- Don't keep it as "reference"
+- Don't "adapt" it while writing tests
+- Don't look at it
+- Delete means delete
+
+Implement fresh from tests. Period.
+
+## Red-Green-Refactor
+
+```dot
+digraph tdd_cycle {
+    rankdir=LR;
+    red [label="RED\nWrite failing test", shape=box, style=filled, fillcolor="#ffcccc"];
+    verify_red [label="Verify fails\ncorrectly", shape=diamond];
+    green [label="GREEN\nMinimal code", shape=box, style=filled, fillcolor="#ccffcc"];
+    verify_green [label="Verify passes\nAll green", shape=diamond];
+    refactor [label="REFACTOR\nClean up", shape=box, style=filled, fillcolor="#ccccff"];
+    next [label="Next", shape=ellipse];
+
+    red -> verify_red;
+    verify_red -> green [label="yes"];
+    verify_red -> red [label="wrong\nfailure"];
+    green -> verify_green;
+    verify_green -> refactor [label="yes"];
+    verify_green -> green [label="no"];
+    refactor -> verify_green [label="stay\ngreen"];
+    verify_green -> next;
+    next -> red;
+}
+```
+
+### RED - Write Failing Test
+
+Write one minimal test showing what should happen.
+
+<Good>
+```typescript
+test('retries failed operations 3 times', async () => {
+  let attempts = 0;
+  const operation = () => {
+    attempts++;
+    if (attempts < 3) throw new Error('fail');
+    return 'success';
+  };
+
+  const result = await retryOperation(operation);
+
+  expect(result).toBe('success');
+  expect(attempts).toBe(3);
+});
+```
+Clear name, tests real behavior, one thing
+</Good>
+
+<Bad>
+```typescript
+test('retry works', async () => {
+  const mock = jest.fn()
+    .mockRejectedValueOnce(new Error())
+    .mockRejectedValueOnce(new Error())
+    .mockResolvedValueOnce('success');
+  await retryOperation(mock);
+  expect(mock).toHaveBeenCalledTimes(3);
+});
+```
+Vague name, tests mock not code
+</Bad>
+
+**Requirements:**
+- One behavior
+- Clear name
+- Real code (no mocks unless unavoidable)
+
+### Verify RED - Watch It Fail
+
+**MANDATORY. Never skip.**
+
+```bash
+npm test path/to/test.test.ts
+```
+
+Confirm:
+- Test fails (not errors)
+- Failure message is expected
+- Fails because feature missing (not typos)
+
+**Test passes?** You're testing existing behavior. Fix test.
+
+**Test errors?** Fix error, re-run until it fails correctly.
+
+### GREEN - Minimal Code
+
+Write simplest code to pass the test.
+
+<Good>
+```typescript
+async function retryOperation<T>(fn: () => Promise<T>): Promise<T> {
+  for (let i = 0; i < 3; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (i === 2) throw e;
+    }
+  }
+  throw new Error('unreachable');
+}
+```
+Just enough to pass
+</Good>
+
+<Bad>
+```typescript
+async function retryOperation<T>(
+  fn: () => Promise<T>,
+  options?: {
+    maxRetries?: number;
+    backoff?: 'linear' | 'exponential';
+    onRetry?: (attempt: number) => void;
+  }
+): Promise<T> {
+  // YAGNI
+}
+```
+Over-engineered
+</Bad>
+
+Don't add features, refactor other code, or "improve" beyond the test.
+
+### Verify GREEN - Watch It Pass
+
+**MANDATORY.**
+
+```bash
+npm test path/to/test.test.ts
+```
+
+Confirm:
+- Test passes
+- Other tests still pass
+- Output pristine (no errors, warnings)
+
+**Test fails?** Fix code, not test.
+
+**Other tests fail?** Fix now.
+
+### REFACTOR - Clean Up
+
+After green only:
+- Remove duplication
+- Improve names
+- Extract helpers
+
+Keep tests green. Don't add behavior.
+
+### Repeat
+
+Next failing test for next feature.
+
+## Good Tests
+
+| Quality | Good | Bad |
+|---------|------|-----|
+| **Minimal** | One thing. "and" in name? Split it. | `test('validates email and domain and whitespace')` |
+| **Clear** | Name describes behavior | `test('test1')` |
+| **Shows intent** | Demonstrates desired API | Obscures what code should do |
+
+## Why Order Matters
+
+**"I'll write tests after to verify it works"**
+
+Tests written after code pass immediately. Passing immediately proves nothing:
+- Might test wrong thing
+- Might test implementation, not behavior
+- Might miss edge cases you forgot
+- You never saw it catch the bug
+
+Test-first forces you to see the test fail, proving it actually tests something.
+
+**"I already manually tested all the edge cases"**
+
+Manual testing is ad-hoc. You think you tested everything but:
+- No record of what you tested
+- Can't re-run when code changes
+- Easy to forget cases under pressure
+- "It worked when I tried it" ≠ comprehensive
+
+Automated tests are systematic. They run the same way every time.
+
+**"Deleting X hours of work is wasteful"**
+
+Sunk cost fallacy. The time is already gone. Your choice now:
+- Delete and rewrite with TDD (X more hours, high confidence)
+- Keep it and add tests after (30 min, low confidence, likely bugs)
+
+The "waste" is keeping code you can't trust. Working code without real tests is technical debt.
+
+**"TDD is dogmatic, being pragmatic means adapting"**
+
+TDD IS pragmatic:
+- Finds bugs before commit (faster than debugging after)
+- Prevents regressions (tests catch breaks immediately)
+- Documents behavior (tests show how to use code)
+- Enables refactoring (change freely, tests catch breaks)
+
+"Pragmatic" shortcuts = debugging in production = slower.
+
+**"Tests after achieve the same goals - it's spirit not ritual"**
+
+No. Tests-after answer "What does this do?" Tests-first answer "What should this do?"
+
+Tests-after are biased by your implementation. You test what you built, not what's required. You verify remembered edge cases, not discovered ones.
+
+Tests-first force edge case discovery before implementing. Tests-after verify you remembered everything (you didn't).
+
+30 minutes of tests after ≠ TDD. You get coverage, lose proof tests work.
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "Too simple to test" | Simple code breaks. Test takes 30 seconds. |
+| "I'll test after" | Tests passing immediately prove nothing. |
+| "Tests after achieve same goals" | Tests-after = "what does this do?" Tests-first = "what should this do?" |
+| "Already manually tested" | Ad-hoc ≠ systematic. No record, can't re-run. |
+| "Deleting X hours is wasteful" | Sunk cost fallacy. Keeping unverified code is technical debt. |
+| "Keep as reference, write tests first" | You'll adapt it. That's testing after. Delete means delete. |
+| "Need to explore first" | Fine. Throw away exploration, start with TDD. |
+| "Test hard = design unclear" | Listen to test. Hard to test = hard to use. |
+| "TDD will slow me down" | TDD faster than debugging. Pragmatic = test-first. |
+| "Manual test faster" | Manual doesn't prove edge cases. You'll re-test every change. |
+| "Existing code has no tests" | You're improving it. Add tests for existing code. |
+
+## Red Flags - STOP and Start Over
+
+- Code before test
+- Test after implementation
+- Test passes immediately
+- Can't explain why test failed
+- Tests added "later"
+- Rationalizing "just this once"
+- "I already manually tested it"
+- "Tests after achieve the same purpose"
+- "It's about spirit not ritual"
+- "Keep as reference" or "adapt existing code"
+- "Already spent X hours, deleting is wasteful"
+- "TDD is dogmatic, I'm being pragmatic"
+- "This is different because..."
+
+**All of these mean: Delete code. Start over with TDD.**
+
+## Example: Bug Fix
+
+**Bug:** Empty email accepted
+
+**RED**
+```typescript
+test('rejects empty email', async () => {
+  const result = await submitForm({ email: '' });
+  expect(result.error).toBe('Email required');
+});
+```
+
+**Verify RED**
+```bash
+$ npm test
+FAIL: expected 'Email required', got undefined
+```
+
+**GREEN**
+```typescript
+function submitForm(data: FormData) {
+  if (!data.email?.trim()) {
+    return { error: 'Email required' };
+  }
+  // ...
+}
+```
+
+**Verify GREEN**
+```bash
+$ npm test
+PASS
+```
+
+**REFACTOR**
+Extract validation for multiple fields if needed.
+
+## Verification Checklist
+
+Before marking work complete:
+
+- [ ] Every new function/method has a test
+- [ ] Watched each test fail before implementing
+- [ ] Each test failed for expected reason (feature missing, not typo)
+- [ ] Wrote minimal code to pass each test
+- [ ] All tests pass
+- [ ] Output pristine (no errors, warnings)
+- [ ] Tests use real code (mocks only if unavoidable)
+- [ ] Edge cases and errors covered
+
+Can't check all boxes? You skipped TDD. Start over.
+
+## When Stuck
+
+| Problem | Solution |
+|---------|----------|
+| Don't know how to test | Write wished-for API. Write assertion first. Ask your human partner. |
+| Test too complicated | Design too complicated. Simplify interface. |
+| Must mock everything | Code too coupled. Use dependency injection. |
+| Test setup huge | Extract helpers. Still complex? Simplify design. |
+
+## Debugging Integration
+
+Bug found? Write failing test reproducing it. Follow TDD cycle. Test proves fix and prevents regression.
+
+Never fix bugs without a test.
+
+## Testing Anti-Patterns
+
+When adding mocks or test utilities, read @testing-anti-patterns.md to avoid common pitfalls:
+- Testing mock behavior instead of real behavior
+- Adding test-only methods to production classes
+- Mocking without understanding dependencies
+
+## Final Rule
+
+```
+Production code → test exists and failed first
+Otherwise → not TDD
+```
+
+No exceptions without your human partner's permission.

--- a/.agents/skills/test-driven-development/testing-anti-patterns.md
+++ b/.agents/skills/test-driven-development/testing-anti-patterns.md
@@ -1,0 +1,299 @@
+# Testing Anti-Patterns
+
+**Load this reference when:** writing or changing tests, adding mocks, or tempted to add test-only methods to production code.
+
+## Overview
+
+Tests must verify real behavior, not mock behavior. Mocks are a means to isolate, not the thing being tested.
+
+**Core principle:** Test what the code does, not what the mocks do.
+
+**Following strict TDD prevents these anti-patterns.**
+
+## The Iron Laws
+
+```
+1. NEVER test mock behavior
+2. NEVER add test-only methods to production classes
+3. NEVER mock without understanding dependencies
+```
+
+## Anti-Pattern 1: Testing Mock Behavior
+
+**The violation:**
+```typescript
+// ❌ BAD: Testing that the mock exists
+test('renders sidebar', () => {
+  render(<Page />);
+  expect(screen.getByTestId('sidebar-mock')).toBeInTheDocument();
+});
+```
+
+**Why this is wrong:**
+- You're verifying the mock works, not that the component works
+- Test passes when mock is present, fails when it's not
+- Tells you nothing about real behavior
+
+**your human partner's correction:** "Are we testing the behavior of a mock?"
+
+**The fix:**
+```typescript
+// ✅ GOOD: Test real component or don't mock it
+test('renders sidebar', () => {
+  render(<Page />);  // Don't mock sidebar
+  expect(screen.getByRole('navigation')).toBeInTheDocument();
+});
+
+// OR if sidebar must be mocked for isolation:
+// Don't assert on the mock - test Page's behavior with sidebar present
+```
+
+### Gate Function
+
+```
+BEFORE asserting on any mock element:
+  Ask: "Am I testing real component behavior or just mock existence?"
+
+  IF testing mock existence:
+    STOP - Delete the assertion or unmock the component
+
+  Test real behavior instead
+```
+
+## Anti-Pattern 2: Test-Only Methods in Production
+
+**The violation:**
+```typescript
+// ❌ BAD: destroy() only used in tests
+class Session {
+  async destroy() {  // Looks like production API!
+    await this._workspaceManager?.destroyWorkspace(this.id);
+    // ... cleanup
+  }
+}
+
+// In tests
+afterEach(() => session.destroy());
+```
+
+**Why this is wrong:**
+- Production class polluted with test-only code
+- Dangerous if accidentally called in production
+- Violates YAGNI and separation of concerns
+- Confuses object lifecycle with entity lifecycle
+
+**The fix:**
+```typescript
+// ✅ GOOD: Test utilities handle test cleanup
+// Session has no destroy() - it's stateless in production
+
+// In test-utils/
+export async function cleanupSession(session: Session) {
+  const workspace = session.getWorkspaceInfo();
+  if (workspace) {
+    await workspaceManager.destroyWorkspace(workspace.id);
+  }
+}
+
+// In tests
+afterEach(() => cleanupSession(session));
+```
+
+### Gate Function
+
+```
+BEFORE adding any method to production class:
+  Ask: "Is this only used by tests?"
+
+  IF yes:
+    STOP - Don't add it
+    Put it in test utilities instead
+
+  Ask: "Does this class own this resource's lifecycle?"
+
+  IF no:
+    STOP - Wrong class for this method
+```
+
+## Anti-Pattern 3: Mocking Without Understanding
+
+**The violation:**
+```typescript
+// ❌ BAD: Mock breaks test logic
+test('detects duplicate server', () => {
+  // Mock prevents config write that test depends on!
+  vi.mock('ToolCatalog', () => ({
+    discoverAndCacheTools: vi.fn().mockResolvedValue(undefined)
+  }));
+
+  await addServer(config);
+  await addServer(config);  // Should throw - but won't!
+});
+```
+
+**Why this is wrong:**
+- Mocked method had side effect test depended on (writing config)
+- Over-mocking to "be safe" breaks actual behavior
+- Test passes for wrong reason or fails mysteriously
+
+**The fix:**
+```typescript
+// ✅ GOOD: Mock at correct level
+test('detects duplicate server', () => {
+  // Mock the slow part, preserve behavior test needs
+  vi.mock('MCPServerManager'); // Just mock slow server startup
+
+  await addServer(config);  // Config written
+  await addServer(config);  // Duplicate detected ✓
+});
+```
+
+### Gate Function
+
+```
+BEFORE mocking any method:
+  STOP - Don't mock yet
+
+  1. Ask: "What side effects does the real method have?"
+  2. Ask: "Does this test depend on any of those side effects?"
+  3. Ask: "Do I fully understand what this test needs?"
+
+  IF depends on side effects:
+    Mock at lower level (the actual slow/external operation)
+    OR use test doubles that preserve necessary behavior
+    NOT the high-level method the test depends on
+
+  IF unsure what test depends on:
+    Run test with real implementation FIRST
+    Observe what actually needs to happen
+    THEN add minimal mocking at the right level
+
+  Red flags:
+    - "I'll mock this to be safe"
+    - "This might be slow, better mock it"
+    - Mocking without understanding the dependency chain
+```
+
+## Anti-Pattern 4: Incomplete Mocks
+
+**The violation:**
+```typescript
+// ❌ BAD: Partial mock - only fields you think you need
+const mockResponse = {
+  status: 'success',
+  data: { userId: '123', name: 'Alice' }
+  // Missing: metadata that downstream code uses
+};
+
+// Later: breaks when code accesses response.metadata.requestId
+```
+
+**Why this is wrong:**
+- **Partial mocks hide structural assumptions** - You only mocked fields you know about
+- **Downstream code may depend on fields you didn't include** - Silent failures
+- **Tests pass but integration fails** - Mock incomplete, real API complete
+- **False confidence** - Test proves nothing about real behavior
+
+**The Iron Rule:** Mock the COMPLETE data structure as it exists in reality, not just fields your immediate test uses.
+
+**The fix:**
+```typescript
+// ✅ GOOD: Mirror real API completeness
+const mockResponse = {
+  status: 'success',
+  data: { userId: '123', name: 'Alice' },
+  metadata: { requestId: 'req-789', timestamp: 1234567890 }
+  // All fields real API returns
+};
+```
+
+### Gate Function
+
+```
+BEFORE creating mock responses:
+  Check: "What fields does the real API response contain?"
+
+  Actions:
+    1. Examine actual API response from docs/examples
+    2. Include ALL fields system might consume downstream
+    3. Verify mock matches real response schema completely
+
+  Critical:
+    If you're creating a mock, you must understand the ENTIRE structure
+    Partial mocks fail silently when code depends on omitted fields
+
+  If uncertain: Include all documented fields
+```
+
+## Anti-Pattern 5: Integration Tests as Afterthought
+
+**The violation:**
+```
+✅ Implementation complete
+❌ No tests written
+"Ready for testing"
+```
+
+**Why this is wrong:**
+- Testing is part of implementation, not optional follow-up
+- TDD would have caught this
+- Can't claim complete without tests
+
+**The fix:**
+```
+TDD cycle:
+1. Write failing test
+2. Implement to pass
+3. Refactor
+4. THEN claim complete
+```
+
+## When Mocks Become Too Complex
+
+**Warning signs:**
+- Mock setup longer than test logic
+- Mocking everything to make test pass
+- Mocks missing methods real components have
+- Test breaks when mock changes
+
+**your human partner's question:** "Do we need to be using a mock here?"
+
+**Consider:** Integration tests with real components often simpler than complex mocks
+
+## TDD Prevents These Anti-Patterns
+
+**Why TDD helps:**
+1. **Write test first** → Forces you to think about what you're actually testing
+2. **Watch it fail** → Confirms test tests real behavior, not mocks
+3. **Minimal implementation** → No test-only methods creep in
+4. **Real dependencies** → You see what the test actually needs before mocking
+
+**If you're testing mock behavior, you violated TDD** - you added mocks without watching test fail against real code first.
+
+## Quick Reference
+
+| Anti-Pattern | Fix |
+|--------------|-----|
+| Assert on mock elements | Test real component or unmock it |
+| Test-only methods in production | Move to test utilities |
+| Mock without understanding | Understand dependencies first, mock minimally |
+| Incomplete mocks | Mirror real API completely |
+| Tests as afterthought | TDD - tests first |
+| Over-complex mocks | Consider integration tests |
+
+## Red Flags
+
+- Assertion checks for `*-mock` test IDs
+- Methods only called in test files
+- Mock setup is >50% of test
+- Test fails when you remove mock
+- Can't explain why mock is needed
+- Mocking "just to be safe"
+
+## The Bottom Line
+
+**Mocks are tools to isolate, not things to test.**
+
+If TDD reveals you're testing mock behavior, you've gone wrong.
+
+Fix: Test real behavior or question why you're mocking at all.

--- a/.agents/skills/unsafe-checker/AGENTS.md
+++ b/.agents/skills/unsafe-checker/AGENTS.md
@@ -1,0 +1,136 @@
+# Unsafe Checker - Quick Reference
+
+**Auto-generated from rules/**
+
+## Rule Summary by Section
+
+### General Principles (3 rules)
+| ID | Level | Title |
+|----|-------|-------|
+| general-01 | P | Do Not Abuse Unsafe to Escape Compiler Safety Checks |
+| general-02 | P | Do Not Blindly Use Unsafe for Performance |
+| general-03 | G | Do Not Create Aliases for Types/Methods Named "Unsafe" |
+
+### Safety Abstraction (11 rules)
+| ID | Level | Title |
+|----|-------|-------|
+| safety-01 | P | Be Aware of Memory Safety Issues from Panics |
+| safety-02 | P | Unsafe Code Authors Must Verify Safety Invariants |
+| safety-03 | P | Do Not Expose Uninitialized Memory in Public APIs |
+| safety-04 | P | Avoid Double-Free from Panic Safety Issues |
+| safety-05 | P | Consider Safety When Manually Implementing Auto Traits |
+| safety-06 | P | Do Not Expose Raw Pointers in Public APIs |
+| safety-07 | P | Provide Unsafe Counterparts for Performance Alongside Safe Methods |
+| safety-08 | P | Mutable Return from Immutable Parameter is Wrong |
+| safety-09 | P | Add SAFETY Comment Before Any Unsafe Block |
+| safety-10 | G | Add Safety Section in Docs for Public Unsafe Functions |
+| safety-11 | G | Use assert! Instead of debug_assert! in Unsafe Functions |
+
+### Raw Pointers (6 rules)
+| ID | Level | Title |
+|----|-------|-------|
+| ptr-01 | P | Do Not Share Raw Pointers Across Threads |
+| ptr-02 | P | Prefer NonNull<T> Over *mut T |
+| ptr-03 | P | Use PhantomData<T> for Variance and Ownership |
+| ptr-04 | G | Do Not Dereference Pointers Cast to Misaligned Types |
+| ptr-05 | G | Do Not Manually Convert Immutable Pointer to Mutable |
+| ptr-06 | G | Prefer pointer::cast Over `as` for Pointer Casting |
+
+### Union (2 rules)
+| ID | Level | Title |
+|----|-------|-------|
+| union-01 | P | Avoid Union Except for C Interop |
+| union-02 | P | Do Not Use Union Variants Across Different Lifetimes |
+
+### Memory Layout (6 rules)
+| ID | Level | Title |
+|----|-------|-------|
+| mem-01 | P | Choose Appropriate Data Layout for Struct/Tuple/Enum |
+| mem-02 | P | Do Not Modify Memory Variables of Other Processes |
+| mem-03 | P | Do Not Let String/Vec Auto-Drop Other Process's Memory |
+| mem-04 | P | Prefer Reentrant Versions of C-API or Syscalls |
+| mem-05 | P | Use Third-Party Crates for Bitfields |
+| mem-06 | G | Use MaybeUninit<T> for Uninitialized Memory |
+
+### FFI (18 rules)
+| ID | Level | Title |
+|----|-------|-------|
+| ffi-01 | P | Avoid Passing Strings Directly to C |
+| ffi-02 | P | Read Documentation Carefully for std::ffi Types |
+| ffi-03 | P | Implement Drop for Wrapped C Pointers |
+| ffi-04 | P | Handle Panics When Crossing FFI Boundaries |
+| ffi-05 | P | Use Portable Type Aliases from std or libc |
+| ffi-06 | P | Ensure C-ABI String Compatibility |
+| ffi-07 | P | Do Not Implement Drop for Types Passed to External Code |
+| ffi-08 | P | Handle Errors Properly in FFI |
+| ffi-09 | P | Use References Instead of Raw Pointers in Safe Wrappers |
+| ffi-10 | P | Exported Functions Must Be Thread-Safe |
+| ffi-11 | P | Be Careful with repr(packed) Field References |
+| ffi-12 | P | Document Invariant Assumptions for C Parameters |
+| ffi-13 | P | Ensure Consistent Data Layout for Custom Types |
+| ffi-14 | P | Types in FFI Should Have Stable Layout |
+| ffi-15 | P | Validate Non-Robust External Values |
+| ffi-16 | P | Separate Data and Code for Closures to C |
+| ffi-17 | P | Use Opaque Types Instead of c_void |
+| ffi-18 | P | Avoid Passing Trait Objects to C |
+
+### I/O Safety (1 rule)
+| ID | Level | Title |
+|----|-------|-------|
+| io-01 | P | Ensure I/O Safety When Using Raw Handles |
+
+## Clippy Lint Mapping
+
+| Clippy Lint | Rule | Category |
+|-------------|------|----------|
+| `undocumented_unsafe_blocks` | safety-09 | SAFETY comments |
+| `missing_safety_doc` | safety-10 | Safety docs |
+| `panic_in_result_fn` | safety-01, ffi-04 | Panic safety |
+| `non_send_fields_in_send_ty` | safety-05 | Send/Sync |
+| `uninit_assumed_init` | safety-03 | Initialization |
+| `uninit_vec` | mem-06 | Initialization |
+| `mut_from_ref` | safety-08 | Aliasing |
+| `cast_ptr_alignment` | ptr-04 | Alignment |
+| `cast_ref_to_mut` | ptr-05 | Aliasing |
+| `ptr_as_ptr` | ptr-06 | Pointer casting |
+| `unaligned_references` | ffi-11 | Packed structs |
+| `debug_assert_with_mut_call` | safety-11 | Assertions |
+
+## Quick Decision Tree
+
+```
+Writing unsafe code?
+    │
+    ├─ FFI with C?
+    │   └─ See ffi-* rules
+    │
+    ├─ Raw pointers?
+    │   └─ See ptr-* rules
+    │
+    ├─ Manual Send/Sync?
+    │   └─ See safety-05
+    │
+    ├─ MaybeUninit/uninitialized?
+    │   └─ See safety-03, mem-06
+    │
+    └─ Performance optimization?
+        └─ See general-02, safety-07
+```
+
+## Essential Checklist
+
+Before every unsafe block:
+- [ ] SAFETY comment present
+- [ ] Invariants documented
+- [ ] Pointer validity checked
+- [ ] Aliasing rules followed
+- [ ] Panic safety considered
+- [ ] Tested with Miri
+
+## Resources
+
+- `checklists/before-unsafe.md` - Pre-writing checklist
+- `checklists/review-unsafe.md` - Code review checklist
+- `checklists/common-pitfalls.md` - Common bugs and fixes
+- `examples/safe-abstraction.md` - Safe wrapper patterns
+- `examples/ffi-patterns.md` - FFI best practices

--- a/.agents/skills/unsafe-checker/SKILL.md
+++ b/.agents/skills/unsafe-checker/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: unsafe-checker
+description: "CRITICAL: Use for unsafe Rust code review and FFI. Triggers on: unsafe, raw pointer, FFI, extern, transmute, *mut, *const, union, #[repr(C)], libc, std::ffi, MaybeUninit, NonNull, SAFETY comment, soundness, undefined behavior, UB, safe wrapper, memory layout, bindgen, cbindgen, CString, CStr, 安全抽象, 裸指针, 外部函数接口, 内存布局, 不安全代码, FFI 绑定, 未定义行为"
+globs: ["**/*.rs"]
+allowed-tools: ["Read", "Grep", "Glob"]
+---
+
+Display the following ASCII art exactly as shown. Do not modify spaces or line breaks:
+```text
+⚠️ **Unsafe Rust Checker Loaded**
+
+     *  ^  *
+    /◉\_~^~_/◉\
+ ⚡/     o     \⚡
+   '_        _'
+   / '-----' \
+```
+
+---
+
+# Unsafe Rust Checker
+
+## When Unsafe is Valid
+
+| Use Case | Example |
+|----------|---------|
+| FFI | Calling C functions |
+| Low-level abstractions | Implementing `Vec`, `Arc` |
+| Performance | Measured bottleneck with safe alternative too slow |
+
+**NOT valid:** Escaping borrow checker without understanding why.
+
+## Required Documentation
+
+```rust
+// SAFETY: <why this is safe>
+unsafe { ... }
+
+/// # Safety
+/// <caller requirements>
+pub unsafe fn dangerous() { ... }
+```
+
+## Quick Reference
+
+| Operation | Safety Requirements |
+|-----------|---------------------|
+| `*ptr` deref | Valid, aligned, initialized |
+| `&*ptr` | + No aliasing violations |
+| `transmute` | Same size, valid bit pattern |
+| `extern "C"` | Correct signature, ABI |
+| `static mut` | Synchronization guaranteed |
+| `impl Send/Sync` | Actually thread-safe |
+
+## Common Errors
+
+| Error | Fix |
+|-------|-----|
+| Null pointer deref | Check for null before deref |
+| Use after free | Ensure lifetime validity |
+| Data race | Add proper synchronization |
+| Alignment violation | Use `#[repr(C)]`, check alignment |
+| Invalid bit pattern | Use `MaybeUninit` |
+| Missing SAFETY comment | Add `// SAFETY:` |
+
+## Deprecated → Better
+
+| Deprecated | Use Instead |
+|------------|-------------|
+| `mem::uninitialized()` | `MaybeUninit<T>` |
+| `mem::zeroed()` for refs | `MaybeUninit<T>` |
+| Raw pointer arithmetic | `NonNull<T>`, `ptr::add` |
+| `CString::new().unwrap().as_ptr()` | Store `CString` first |
+| `static mut` | `AtomicT` or `Mutex` |
+| Manual extern | `bindgen` |
+
+## FFI Crates
+
+| Direction | Crate |
+|-----------|-------|
+| C → Rust | bindgen |
+| Rust → C | cbindgen |
+| Python | PyO3 |
+| Node.js | napi-rs |
+
+Claude knows unsafe Rust. Focus on SAFETY comments and soundness.

--- a/.agents/skills/unsafe-checker/checklists/before-unsafe.md
+++ b/.agents/skills/unsafe-checker/checklists/before-unsafe.md
@@ -1,0 +1,115 @@
+# Checklist: Before Writing Unsafe Code
+
+Use this checklist before writing any `unsafe` block or `unsafe fn`.
+
+## 1. Do You Really Need Unsafe?
+
+- [ ] Have you tried all safe alternatives?
+- [ ] Can you restructure the code to satisfy the borrow checker?
+- [ ] Would interior mutability (`Cell`, `RefCell`, `Mutex`) solve the problem?
+- [ ] Is there a safe crate that already does this?
+- [ ] Is the performance gain (if any) worth the safety risk?
+
+**If you answered "no" to all, proceed with unsafe.**
+
+## 2. What Unsafe Operation Do You Need?
+
+Identify which specific unsafe operation you're performing:
+
+- [ ] Dereferencing a raw pointer (`*const T`, `*mut T`)
+- [ ] Calling an `unsafe` function
+- [ ] Accessing a mutable static variable
+- [ ] Implementing an unsafe trait (`Send`, `Sync`, etc.)
+- [ ] Accessing fields of a `union`
+- [ ] Using `extern "C"` functions (FFI)
+
+## 3. Safety Invariants
+
+For each unsafe operation, document the invariants:
+
+### For Pointer Dereference:
+- [ ] Is the pointer non-null?
+- [ ] Is the pointer properly aligned for the type?
+- [ ] Does the pointer point to valid, initialized memory?
+- [ ] Is the memory not being mutated by other code?
+- [ ] Will the memory remain valid for the entire duration of use?
+
+### For Mutable Aliasing:
+- [ ] Are you creating multiple mutable references to the same memory?
+- [ ] Is there any possibility of aliasing `&mut` and `&`?
+- [ ] Have you verified no other code can access this memory?
+
+### For FFI:
+- [ ] Is the function signature correct (types, ABI)?
+- [ ] Are you handling potential null pointers?
+- [ ] Are you handling potential panics (catch_unwind)?
+- [ ] Is memory ownership clear (who allocates, who frees)?
+
+### For Send/Sync:
+- [ ] Is concurrent access properly synchronized?
+- [ ] Are there any data races possible?
+- [ ] Does the type truly satisfy the trait requirements?
+
+## 4. Panic Safety
+
+- [ ] What happens if this code panics at any line?
+- [ ] Are data structures left in a valid state on panic?
+- [ ] Do you need a panic guard for cleanup?
+- [ ] Could a destructor see invalid state?
+
+## 5. Documentation
+
+- [ ] Have you written a `// SAFETY:` comment explaining:
+  - What invariants must hold?
+  - Why those invariants are upheld here?
+
+- [ ] For `unsafe fn`, have you written `# Safety` docs explaining:
+  - What the caller must guarantee?
+  - What happens if requirements are violated?
+
+## 6. Testing and Verification
+
+- [ ] Can you add debug assertions to verify invariants?
+- [ ] Have you tested with Miri (`cargo miri test`)?
+- [ ] Have you tested with address sanitizer (`RUSTFLAGS="-Zsanitizer=address"`)?
+- [ ] Have you considered fuzzing the unsafe code?
+
+## Quick Reference: Common SAFETY Comments
+
+```rust
+// SAFETY: We checked that index < len above, so this is in bounds.
+
+// SAFETY: The pointer was created from a valid reference and hasn't been invalidated.
+
+// SAFETY: We hold the lock, guaranteeing exclusive access.
+
+// SAFETY: The type is #[repr(C)] and all fields are initialized.
+
+// SAFETY: Caller guarantees the pointer is non-null and properly aligned.
+```
+
+## Decision Flowchart
+
+```
+Need unsafe?
+     |
+     v
+Can you use safe Rust? --Yes--> Don't use unsafe
+     |
+     No
+     v
+Can you use existing safe abstraction? --Yes--> Use it (std, crates)
+     |
+     No
+     v
+Document all invariants
+     |
+     v
+Add SAFETY comments
+     |
+     v
+Write the unsafe code
+     |
+     v
+Test with Miri
+```

--- a/.agents/skills/unsafe-checker/checklists/common-pitfalls.md
+++ b/.agents/skills/unsafe-checker/checklists/common-pitfalls.md
@@ -1,0 +1,253 @@
+# Common Unsafe Pitfalls and Fixes
+
+A reference of frequently encountered unsafe bugs and how to fix them.
+
+## Pitfall 1: Dangling Pointer from Local
+
+**Bug:**
+```rust
+fn bad() -> *const i32 {
+    let x = 42;
+    &x as *const i32  // Dangling after return!
+}
+```
+
+**Fix:**
+```rust
+fn good() -> Box<i32> {
+    Box::new(42)  // Heap allocation lives beyond function
+}
+
+// Or return the value itself
+fn better() -> i32 {
+    42
+}
+```
+
+## Pitfall 2: CString Lifetime
+
+**Bug:**
+```rust
+fn bad() -> *const c_char {
+    let s = CString::new("hello").unwrap();
+    s.as_ptr()  // Dangling! CString dropped
+}
+```
+
+**Fix:**
+```rust
+fn good(s: &CString) -> *const c_char {
+    s.as_ptr()  // Caller keeps CString alive
+}
+
+// Or take ownership
+fn also_good(s: CString) -> *const c_char {
+    s.into_raw()  // Caller must free with CString::from_raw
+}
+```
+
+## Pitfall 3: Vec set_len with Uninitialized Data
+
+**Bug:**
+```rust
+fn bad() -> Vec<String> {
+    let mut v = Vec::with_capacity(10);
+    unsafe { v.set_len(10); }  // Strings are uninitialized!
+    v
+}
+```
+
+**Fix:**
+```rust
+fn good() -> Vec<String> {
+    let mut v = Vec::with_capacity(10);
+    for _ in 0..10 {
+        v.push(String::new());
+    }
+    v
+}
+
+// Or use resize
+fn also_good() -> Vec<String> {
+    let mut v = Vec::new();
+    v.resize(10, String::new());
+    v
+}
+```
+
+## Pitfall 4: Reference to Packed Field
+
+**Bug:**
+```rust
+#[repr(packed)]
+struct Packed { a: u8, b: u32 }
+
+fn bad(p: &Packed) -> &u32 {
+    &p.b  // UB: misaligned reference!
+}
+```
+
+**Fix:**
+```rust
+fn good(p: &Packed) -> u32 {
+    unsafe { std::ptr::addr_of!(p.b).read_unaligned() }
+}
+```
+
+## Pitfall 5: Mutable Aliasing Through Raw Pointers
+
+**Bug:**
+```rust
+fn bad() {
+    let mut x = 42;
+    let ptr1 = &mut x as *mut i32;
+    let ptr2 = &mut x as *mut i32;  // Already have ptr1!
+    unsafe {
+        *ptr1 = 1;
+        *ptr2 = 2;  // Aliasing mutable pointers!
+    }
+}
+```
+
+**Fix:**
+```rust
+fn good() {
+    let mut x = 42;
+    let ptr = &mut x as *mut i32;
+    unsafe {
+        *ptr = 1;
+        *ptr = 2;  // Same pointer, sequential access
+    }
+}
+```
+
+## Pitfall 6: Transmute to Wrong Size
+
+**Bug:**
+```rust
+fn bad() {
+    let x: u32 = 42;
+    let y: u64 = unsafe { std::mem::transmute(x) };  // UB: size mismatch!
+}
+```
+
+**Fix:**
+```rust
+fn good() {
+    let x: u32 = 42;
+    let y: u64 = x as u64;  // Use conversion
+}
+```
+
+## Pitfall 7: Invalid Enum Discriminant
+
+**Bug:**
+```rust
+#[repr(u8)]
+enum Status { A = 0, B = 1, C = 2 }
+
+fn bad(raw: u8) -> Status {
+    unsafe { std::mem::transmute(raw) }  // UB if raw > 2!
+}
+```
+
+**Fix:**
+```rust
+fn good(raw: u8) -> Option<Status> {
+    match raw {
+        0 => Some(Status::A),
+        1 => Some(Status::B),
+        2 => Some(Status::C),
+        _ => None,
+    }
+}
+```
+
+## Pitfall 8: FFI Panic Unwinding
+
+**Bug:**
+```rust
+#[no_mangle]
+extern "C" fn callback(x: i32) -> i32 {
+    if x < 0 {
+        panic!("negative!");  // UB: unwinding across FFI!
+    }
+    x * 2
+}
+```
+
+**Fix:**
+```rust
+#[no_mangle]
+extern "C" fn callback(x: i32) -> i32 {
+    std::panic::catch_unwind(|| {
+        if x < 0 {
+            panic!("negative!");
+        }
+        x * 2
+    }).unwrap_or(-1)  // Return error code on panic
+}
+```
+
+## Pitfall 9: Double Free from Clone + into_raw
+
+**Bug:**
+```rust
+struct Handle(*mut c_void);
+
+impl Clone for Handle {
+    fn clone(&self) -> Self {
+        Handle(self.0)  // Both now "own" same pointer!
+    }
+}
+
+impl Drop for Handle {
+    fn drop(&mut self) {
+        unsafe { free(self.0); }  // Double free when both drop!
+    }
+}
+```
+
+**Fix:**
+```rust
+struct Handle(*mut c_void);
+
+// Don't implement Clone, or implement proper reference counting
+impl Handle {
+    fn clone_ptr(&self) -> *mut c_void {
+        self.0  // Return raw pointer, no ownership
+    }
+}
+```
+
+## Pitfall 10: Forget Doesn't Run Destructors
+
+**Bug:**
+```rust
+fn bad() {
+    let guard = lock.lock();
+    std::mem::forget(guard);  // Lock never released!
+}
+```
+
+**Fix:**
+```rust
+fn good() {
+    let guard = lock.lock();
+    // Let guard drop naturally
+    // or explicitly: drop(guard);
+}
+```
+
+## Quick Reference Table
+
+| Pitfall | Detection | Fix |
+|---------|-----------|-----|
+| Dangling pointer | Miri | Extend lifetime or heap allocate |
+| Uninitialized read | Miri | Use MaybeUninit properly |
+| Misaligned access | Miri, UBsan | read_unaligned, copy by value |
+| Data race | TSan | Use atomics or mutex |
+| Double free | ASan | Track ownership carefully |
+| Invalid enum | Manual review | Use TryFrom |
+| FFI panic | Testing | catch_unwind |
+| Type confusion | Miri | Match types exactly |

--- a/.agents/skills/unsafe-checker/checklists/review-unsafe.md
+++ b/.agents/skills/unsafe-checker/checklists/review-unsafe.md
@@ -1,0 +1,113 @@
+# Checklist: Reviewing Unsafe Code
+
+Use this checklist when reviewing code containing `unsafe`.
+
+## 1. Surface-Level Checks
+
+- [ ] Does every `unsafe` block have a `// SAFETY:` comment?
+- [ ] Does every `unsafe fn` have `# Safety` documentation?
+- [ ] Are the safety comments specific and verifiable, not vague?
+- [ ] Is the unsafe code minimized (smallest possible unsafe block)?
+
+## 2. Pointer Validity
+
+For each pointer dereference:
+
+- [ ] **Non-null**: Is null checked before dereference?
+- [ ] **Aligned**: Is alignment verified or guaranteed by construction?
+- [ ] **Valid**: Does the pointer point to allocated memory?
+- [ ] **Initialized**: Is the memory initialized before reading?
+- [ ] **Lifetime**: Is the memory valid for the entire use duration?
+- [ ] **Unique**: For `&mut`, is there only one mutable reference?
+
+## 3. Memory Safety
+
+- [ ] **No aliasing**: Are `&` and `&mut` never created to the same memory simultaneously?
+- [ ] **No use-after-free**: Is memory not accessed after deallocation?
+- [ ] **No double-free**: Is memory freed exactly once?
+- [ ] **No data races**: Is concurrent access properly synchronized?
+- [ ] **Bounds checked**: Are array/slice accesses in bounds?
+
+## 4. Type Safety
+
+- [ ] **Transmute**: Are transmuted types actually compatible?
+- [ ] **Repr**: Do FFI types have `#[repr(C)]`?
+- [ ] **Enum values**: Are enum discriminants validated from external sources?
+- [ ] **Unions**: Is the correct union field accessed?
+
+## 5. Panic Safety
+
+- [ ] What state is the program in if this code panics?
+- [ ] Are partially constructed objects properly cleaned up?
+- [ ] Do Drop implementations see valid state?
+- [ ] Is there a panic guard if needed?
+
+## 6. FFI-Specific Checks
+
+- [ ] **Types**: Do Rust types match C types exactly?
+- [ ] **Strings**: Are strings properly null-terminated?
+- [ ] **Ownership**: Is it clear who owns/frees memory?
+- [ ] **Thread safety**: Are callbacks thread-safe?
+- [ ] **Panic boundary**: Are panics caught before crossing FFI?
+- [ ] **Error handling**: Are C-style errors properly handled?
+
+## 7. Concurrency Checks
+
+- [ ] **Send/Sync**: Are manual implementations actually sound?
+- [ ] **Atomics**: Are memory orderings correct?
+- [ ] **Locks**: Is there potential for deadlock?
+- [ ] **Data races**: Is all shared mutable state synchronized?
+
+## 8. Red Flags (Require Extra Scrutiny)
+
+| Pattern | Concern |
+|---------|---------|
+| `transmute` | Type compatibility, provenance |
+| `as` on pointers | Alignment, type punning |
+| `static mut` | Data races |
+| `*const T as *mut T` | Aliasing violation |
+| Manual `Send`/`Sync` | Thread safety |
+| `assume_init` | Initialization |
+| `set_len` on Vec | Uninitialized memory |
+| `from_raw_parts` | Lifetime, validity |
+| `offset`/`add`/`sub` | Out of bounds |
+| FFI callbacks | Panic safety |
+
+## 9. Verification Questions
+
+Ask the author:
+- "What would happen if [X invariant] was violated?"
+- "How do you know [pointer/reference] is valid here?"
+- "What if this panics at [specific line]?"
+- "Who is responsible for freeing this memory?"
+
+## 10. Testing Requirements
+
+- [ ] Has this been tested with Miri?
+- [ ] Are there unit tests covering edge cases?
+- [ ] Are there tests for error conditions?
+- [ ] Has concurrent code been tested under stress?
+
+## Review Severity Guide
+
+| Severity | Requires |
+|----------|----------|
+| `transmute` | Two reviewers, Miri test |
+| Manual `Send`/`Sync` | Thread safety expert review |
+| FFI | Documentation of C interface |
+| `static mut` | Justification for not using atomic/mutex |
+| Pointer arithmetic | Bounds proof |
+
+## Sample Review Comments
+
+```
+// Good SAFETY comment ✓
+// SAFETY: index was checked to be < len on line 42
+
+// Needs improvement ✗
+// SAFETY: This is safe because we know it works
+
+// Missing information ✗
+// SAFETY: ptr is valid
+// (Why is it valid? How do we know?)
+```

--- a/.agents/skills/unsafe-checker/examples/ffi-patterns.md
+++ b/.agents/skills/unsafe-checker/examples/ffi-patterns.md
@@ -1,0 +1,353 @@
+# FFI Best Practices and Patterns
+
+Examples of safe and idiomatic Rust-C interoperability.
+
+## Pattern 1: Basic FFI Wrapper
+
+```rust
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_int, c_void};
+use std::ptr::NonNull;
+
+// Raw C API
+mod ffi {
+    use super::*;
+
+    extern "C" {
+        pub fn lib_create(name: *const c_char) -> *mut c_void;
+        pub fn lib_destroy(handle: *mut c_void);
+        pub fn lib_process(handle: *mut c_void, data: *const u8, len: usize) -> c_int;
+        pub fn lib_get_error() -> *const c_char;
+    }
+}
+
+// Safe Rust wrapper
+pub struct Library {
+    handle: NonNull<c_void>,
+}
+
+#[derive(Debug)]
+pub struct LibraryError(String);
+
+impl Library {
+    pub fn new(name: &str) -> Result<Self, LibraryError> {
+        let c_name = CString::new(name).map_err(|_| LibraryError("invalid name".into()))?;
+
+        let handle = unsafe { ffi::lib_create(c_name.as_ptr()) };
+
+        NonNull::new(handle)
+            .map(|handle| Self { handle })
+            .ok_or_else(|| Self::last_error())
+    }
+
+    pub fn process(&self, data: &[u8]) -> Result<(), LibraryError> {
+        let result = unsafe {
+            ffi::lib_process(self.handle.as_ptr(), data.as_ptr(), data.len())
+        };
+
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(Self::last_error())
+        }
+    }
+
+    fn last_error() -> LibraryError {
+        let ptr = unsafe { ffi::lib_get_error() };
+        if ptr.is_null() {
+            LibraryError("unknown error".into())
+        } else {
+            let msg = unsafe { CStr::from_ptr(ptr) }
+                .to_string_lossy()
+                .into_owned();
+            LibraryError(msg)
+        }
+    }
+}
+
+impl Drop for Library {
+    fn drop(&mut self) {
+        unsafe { ffi::lib_destroy(self.handle.as_ptr()); }
+    }
+}
+
+// Prevent accidental copies
+impl !Clone for Library {}
+```
+
+## Pattern 2: Callback Registration
+
+```rust
+use std::os::raw::{c_int, c_void};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+type CCallback = extern "C" fn(value: c_int, user_data: *mut c_void) -> c_int;
+
+extern "C" {
+    fn register_callback(cb: CCallback, user_data: *mut c_void);
+    fn unregister_callback();
+}
+
+/// Safely register a Rust closure as a C callback.
+pub struct CallbackGuard<F> {
+    _closure: Box<F>,
+}
+
+impl<F: FnMut(i32) -> i32 + 'static> CallbackGuard<F> {
+    pub fn register(closure: F) -> Self {
+        let boxed = Box::new(closure);
+        let user_data = Box::into_raw(boxed) as *mut c_void;
+
+        extern "C" fn trampoline<F: FnMut(i32) -> i32>(
+            value: c_int,
+            user_data: *mut c_void,
+        ) -> c_int {
+            let result = catch_unwind(AssertUnwindSafe(|| {
+                let closure = unsafe { &mut *(user_data as *mut F) };
+                closure(value as i32) as c_int
+            }));
+            result.unwrap_or(-1)
+        }
+
+        unsafe {
+            register_callback(trampoline::<F>, user_data);
+        }
+
+        Self {
+            // SAFETY: We just created this box and need to keep it alive
+            _closure: unsafe { Box::from_raw(user_data as *mut F) },
+        }
+    }
+}
+
+impl<F> Drop for CallbackGuard<F> {
+    fn drop(&mut self) {
+        unsafe { unregister_callback(); }
+        // Box in _closure is dropped automatically
+    }
+}
+
+// Usage
+fn example() {
+    let multiplier = 2;
+    let _guard = CallbackGuard::register(move |x| x * multiplier);
+    // Callback is active until _guard is dropped
+}
+```
+
+## Pattern 3: Opaque Handle Types
+
+```rust
+use std::marker::PhantomData;
+
+// Opaque type markers - prevents mixing up handles
+#[repr(C)]
+pub struct DatabaseHandle {
+    _data: [u8; 0],
+    _marker: PhantomData<(*mut u8, std::marker::PhantomPinned)>,
+}
+
+#[repr(C)]
+pub struct ConnectionHandle {
+    _data: [u8; 0],
+    _marker: PhantomData<(*mut u8, std::marker::PhantomPinned)>,
+}
+
+mod ffi {
+    use super::*;
+
+    extern "C" {
+        pub fn db_open(path: *const c_char) -> *mut DatabaseHandle;
+        pub fn db_close(db: *mut DatabaseHandle);
+        pub fn db_connect(db: *mut DatabaseHandle) -> *mut ConnectionHandle;
+        pub fn conn_close(conn: *mut ConnectionHandle);
+        pub fn conn_query(conn: *mut ConnectionHandle, sql: *const c_char) -> c_int;
+    }
+}
+
+// Type-safe wrappers
+pub struct Database {
+    handle: NonNull<DatabaseHandle>,
+}
+
+pub struct Connection<'db> {
+    handle: NonNull<ConnectionHandle>,
+    _db: PhantomData<&'db Database>,
+}
+
+impl Database {
+    pub fn open(path: &str) -> Result<Self, ()> {
+        let c_path = CString::new(path).map_err(|_| ())?;
+        let handle = unsafe { ffi::db_open(c_path.as_ptr()) };
+        NonNull::new(handle).map(|h| Self { handle: h }).ok_or(())
+    }
+
+    pub fn connect(&self) -> Result<Connection<'_>, ()> {
+        let handle = unsafe { ffi::db_connect(self.handle.as_ptr()) };
+        NonNull::new(handle)
+            .map(|h| Connection { handle: h, _db: PhantomData })
+            .ok_or(())
+    }
+}
+
+impl Drop for Database {
+    fn drop(&mut self) {
+        // All Connections must be dropped first (enforced by lifetime)
+        unsafe { ffi::db_close(self.handle.as_ptr()); }
+    }
+}
+
+impl Connection<'_> {
+    pub fn query(&self, sql: &str) -> Result<(), ()> {
+        let c_sql = CString::new(sql).map_err(|_| ())?;
+        let result = unsafe { ffi::conn_query(self.handle.as_ptr(), c_sql.as_ptr()) };
+        if result == 0 { Ok(()) } else { Err(()) }
+    }
+}
+
+impl Drop for Connection<'_> {
+    fn drop(&mut self) {
+        unsafe { ffi::conn_close(self.handle.as_ptr()); }
+    }
+}
+```
+
+## Pattern 4: Error Handling Across FFI
+
+```rust
+use std::os::raw::c_int;
+
+// Error codes for C
+pub const SUCCESS: c_int = 0;
+pub const ERR_NULL_PTR: c_int = 1;
+pub const ERR_INVALID_UTF8: c_int = 2;
+pub const ERR_IO: c_int = 3;
+pub const ERR_PANIC: c_int = -1;
+
+// Thread-local error storage
+thread_local! {
+    static LAST_ERROR: std::cell::RefCell<Option<Box<dyn std::error::Error>>> =
+        std::cell::RefCell::new(None);
+}
+
+fn set_last_error<E: std::error::Error + 'static>(err: E) {
+    LAST_ERROR.with(|e| {
+        *e.borrow_mut() = Some(Box::new(err));
+    });
+}
+
+/// Get the last error message. Caller must free with `free_string`.
+#[no_mangle]
+pub extern "C" fn get_last_error() -> *mut c_char {
+    LAST_ERROR.with(|e| {
+        e.borrow()
+            .as_ref()
+            .map(|err| {
+                CString::new(err.to_string())
+                    .unwrap_or_else(|_| CString::new("error").unwrap())
+                    .into_raw()
+            })
+            .unwrap_or(std::ptr::null_mut())
+    })
+}
+
+/// Free a string returned by this library.
+#[no_mangle]
+pub extern "C" fn free_string(s: *mut c_char) {
+    if !s.is_null() {
+        // SAFETY: String was created by CString::into_raw
+        unsafe { drop(CString::from_raw(s)); }
+    }
+}
+
+/// Example function with proper error handling.
+#[no_mangle]
+pub extern "C" fn do_operation(data: *const u8, len: usize) -> c_int {
+    let result = catch_unwind(AssertUnwindSafe(|| -> Result<(), c_int> {
+        if data.is_null() {
+            return Err(ERR_NULL_PTR);
+        }
+
+        let slice = unsafe { std::slice::from_raw_parts(data, len) };
+
+        std::str::from_utf8(slice)
+            .map_err(|e| {
+                set_last_error(e);
+                ERR_INVALID_UTF8
+            })?;
+
+        // Do actual work...
+
+        Ok(())
+    }));
+
+    match result {
+        Ok(Ok(())) => SUCCESS,
+        Ok(Err(code)) => code,
+        Err(_) => ERR_PANIC,
+    }
+}
+```
+
+## Pattern 5: Struct with C Layout
+
+```rust
+use std::os::raw::{c_char, c_int};
+
+/// A C-compatible configuration struct.
+#[repr(C)]
+pub struct Config {
+    pub version: c_int,
+    pub flags: u32,
+    pub name: [c_char; 64],
+    pub name_len: usize,
+}
+
+impl Config {
+    pub fn new(version: i32, flags: u32, name: &str) -> Option<Self> {
+        if name.len() >= 64 {
+            return None;
+        }
+
+        let mut config = Self {
+            version: version as c_int,
+            flags,
+            name: [0; 64],
+            name_len: name.len(),
+        };
+
+        // Copy name bytes
+        for (i, byte) in name.bytes().enumerate() {
+            config.name[i] = byte as c_char;
+        }
+
+        Some(config)
+    }
+
+    pub fn name(&self) -> &str {
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                self.name.as_ptr() as *const u8,
+                self.name_len,
+            )
+        };
+        // SAFETY: We only store valid UTF-8 in new()
+        unsafe { std::str::from_utf8_unchecked(bytes) }
+    }
+}
+
+// Verify layout at compile time
+const _: () = {
+    assert!(std::mem::size_of::<Config>() == 80);  // 4 + 4 + 64 + 8
+    assert!(std::mem::align_of::<Config>() == 8);
+};
+```
+
+## Key FFI Guidelines
+
+1. **Always use `#[repr(C)]`** for types crossing FFI
+2. **Handle null pointers** at the boundary
+3. **Catch panics** before returning to C
+4. **Document ownership** clearly
+5. **Use opaque types** for type safety
+6. **Keep unsafe minimal** and well-documented

--- a/.agents/skills/unsafe-checker/examples/safe-abstraction.md
+++ b/.agents/skills/unsafe-checker/examples/safe-abstraction.md
@@ -1,0 +1,272 @@
+# Safe Abstraction Examples
+
+Examples of building safe APIs on top of unsafe code.
+
+## Example 1: Simple Wrapper with Bounds Check
+
+```rust
+/// A slice wrapper that provides unchecked access internally
+/// but safe access externally.
+pub struct SafeSlice<'a, T> {
+    ptr: *const T,
+    len: usize,
+    _marker: std::marker::PhantomData<&'a T>,
+}
+
+impl<'a, T> SafeSlice<'a, T> {
+    /// Creates a SafeSlice from a regular slice.
+    pub fn new(slice: &'a [T]) -> Self {
+        Self {
+            ptr: slice.as_ptr(),
+            len: slice.len(),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Safe get - returns Option.
+    pub fn get(&self, index: usize) -> Option<&T> {
+        if index < self.len {
+            // SAFETY: We just verified index < len
+            Some(unsafe { &*self.ptr.add(index) })
+        } else {
+            None
+        }
+    }
+
+    /// Unsafe get - caller must ensure bounds.
+    ///
+    /// # Safety
+    /// `index` must be less than `self.len()`.
+    pub unsafe fn get_unchecked(&self, index: usize) -> &T {
+        debug_assert!(index < self.len);
+        &*self.ptr.add(index)
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}
+```
+
+## Example 2: Resource Wrapper with Drop
+
+```rust
+use std::ptr::NonNull;
+
+/// Safe wrapper around a C-allocated buffer.
+pub struct CBuffer {
+    ptr: NonNull<u8>,
+    len: usize,
+}
+
+extern "C" {
+    fn c_alloc(size: usize) -> *mut u8;
+    fn c_free(ptr: *mut u8);
+}
+
+impl CBuffer {
+    /// Creates a new buffer. Returns None if allocation fails.
+    pub fn new(size: usize) -> Option<Self> {
+        let ptr = unsafe { c_alloc(size) };
+        NonNull::new(ptr).map(|ptr| Self { ptr, len: size })
+    }
+
+    /// Returns a slice view of the buffer.
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: ptr is valid for len bytes (from c_alloc contract)
+        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+
+    /// Returns a mutable slice view.
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        // SAFETY: We have &mut self, so exclusive access
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
+    }
+}
+
+impl Drop for CBuffer {
+    fn drop(&mut self) {
+        // SAFETY: ptr was allocated by c_alloc and not yet freed
+        unsafe { c_free(self.ptr.as_ptr()); }
+    }
+}
+
+// Prevent double-free
+impl !Clone for CBuffer {}
+
+// Safe to send between threads (assuming c_alloc is thread-safe)
+unsafe impl Send for CBuffer {}
+```
+
+## Example 3: Interior Mutability with UnsafeCell
+
+```rust
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// A simple spinlock demonstrating safe abstraction over UnsafeCell.
+pub struct SpinLock<T> {
+    locked: AtomicBool,
+    data: UnsafeCell<T>,
+}
+
+pub struct SpinLockGuard<'a, T> {
+    lock: &'a SpinLock<T>,
+}
+
+impl<T> SpinLock<T> {
+    pub const fn new(data: T) -> Self {
+        Self {
+            locked: AtomicBool::new(false),
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub fn lock(&self) -> SpinLockGuard<'_, T> {
+        // Spin until we acquire the lock
+        while self.locked.compare_exchange_weak(
+            false,
+            true,
+            Ordering::Acquire,
+            Ordering::Relaxed,
+        ).is_err() {
+            std::hint::spin_loop();
+        }
+        SpinLockGuard { lock: self }
+    }
+}
+
+impl<T> std::ops::Deref for SpinLockGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // SAFETY: We hold the lock, so we have exclusive access
+        unsafe { &*self.lock.data.get() }
+    }
+}
+
+impl<T> std::ops::DerefMut for SpinLockGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: We hold the lock, so we have exclusive access
+        unsafe { &mut *self.lock.data.get() }
+    }
+}
+
+impl<T> Drop for SpinLockGuard<'_, T> {
+    fn drop(&mut self) {
+        self.lock.locked.store(false, Ordering::Release);
+    }
+}
+
+// SAFETY: The lock ensures only one thread accesses data at a time
+unsafe impl<T: Send> Sync for SpinLock<T> {}
+unsafe impl<T: Send> Send for SpinLock<T> {}
+```
+
+## Example 4: Iterator with Lifetime Tracking
+
+```rust
+use std::marker::PhantomData;
+
+/// An iterator over raw pointer range with proper lifetime tracking.
+pub struct PtrIter<'a, T> {
+    current: *const T,
+    end: *const T,
+    _marker: PhantomData<&'a T>,
+}
+
+impl<'a, T> PtrIter<'a, T> {
+    /// Creates an iterator from a slice.
+    pub fn new(slice: &'a [T]) -> Self {
+        let ptr = slice.as_ptr();
+        Self {
+            current: ptr,
+            // SAFETY: Adding len to slice pointer is always valid
+            end: unsafe { ptr.add(slice.len()) },
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> Iterator for PtrIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current == self.end {
+            None
+        } else {
+            // SAFETY:
+            // - current < end (checked above)
+            // - PhantomData<&'a T> ensures the data lives for 'a
+            let item = unsafe { &*self.current };
+            self.current = unsafe { self.current.add(1) };
+            Some(item)
+        }
+    }
+}
+```
+
+## Example 5: Builder Pattern with Delayed Initialization
+
+```rust
+use std::mem::MaybeUninit;
+
+/// A builder that collects exactly N items, then produces an array.
+pub struct ArrayBuilder<T, const N: usize> {
+    data: [MaybeUninit<T>; N],
+    count: usize,
+}
+
+impl<T, const N: usize> ArrayBuilder<T, N> {
+    pub fn new() -> Self {
+        Self {
+            // SAFETY: MaybeUninit doesn't require initialization
+            data: unsafe { MaybeUninit::uninit().assume_init() },
+            count: 0,
+        }
+    }
+
+    pub fn push(&mut self, value: T) -> Result<(), T> {
+        if self.count >= N {
+            return Err(value);
+        }
+        self.data[self.count].write(value);
+        self.count += 1;
+        Ok(())
+    }
+
+    pub fn build(self) -> Option<[T; N]> {
+        if self.count != N {
+            return None;
+        }
+
+        // SAFETY: All N elements have been initialized
+        let result = unsafe {
+            // Prevent drop of self.data (we're moving out)
+            let data = std::ptr::read(&self.data);
+            std::mem::forget(self);
+            // Transmute MaybeUninit array to initialized array
+            std::mem::transmute_copy::<[MaybeUninit<T>; N], [T; N]>(&data)
+        };
+        Some(result)
+    }
+}
+
+impl<T, const N: usize> Drop for ArrayBuilder<T, N> {
+    fn drop(&mut self) {
+        // Drop only initialized elements
+        for i in 0..self.count {
+            // SAFETY: Elements 0..count are initialized
+            unsafe { self.data[i].assume_init_drop(); }
+        }
+    }
+}
+```
+
+## Key Patterns
+
+1. **Encapsulation**: Hide unsafe behind safe public API
+2. **Invariant maintenance**: Use private fields to maintain invariants
+3. **PhantomData**: Track lifetimes and ownership for pointers
+4. **RAII**: Use Drop for cleanup
+5. **Type state**: Use types to encode valid states

--- a/.agents/skills/unsafe-checker/rules/_sections.md
+++ b/.agents/skills/unsafe-checker/rules/_sections.md
@@ -1,0 +1,77 @@
+# Unsafe Checker - Section Definitions
+
+## Section Overview
+
+| # | Section | Prefix | Level | Count | Impact |
+|---|---------|--------|-------|-------|--------|
+| 1 | General Principles | `general-` | CRITICAL | 3 | Foundational unsafe usage guidance |
+| 2 | Safety Abstraction | `safety-` | CRITICAL | 11 | Building sound safe APIs |
+| 3 | Raw Pointers | `ptr-` | HIGH | 6 | Pointer manipulation safety |
+| 4 | Union | `union-` | HIGH | 2 | Union type safety |
+| 5 | Memory Layout | `mem-` | HIGH | 6 | Data representation correctness |
+| 6 | FFI | `ffi-` | CRITICAL | 18 | C interoperability safety |
+| 7 | I/O Safety | `io-` | MEDIUM | 1 | Handle/resource safety |
+
+## Section Details
+
+### 1. General Principles (`general-`)
+
+**Focus**: When and why to use unsafe
+
+- P.UNS.01: Don't abuse unsafe to escape borrow checker
+- P.UNS.02: Don't use unsafe blindly for performance
+- G.UNS.01: Don't create aliases for "unsafe" named items
+
+### 2. Safety Abstraction (`safety-`)
+
+**Focus**: Building sound safe abstractions over unsafe code
+
+Key invariants:
+- Panic safety
+- Memory initialization
+- Send/Sync correctness
+- API soundness
+
+### 3. Raw Pointers (`ptr-`)
+
+**Focus**: Safe pointer manipulation patterns
+
+- Aliasing rules
+- Alignment requirements
+- Null/dangling prevention
+- Type casting
+
+### 4. Union (`union-`)
+
+**Focus**: Safe union usage (primarily for C interop)
+
+- Initialization rules
+- Lifetime considerations
+- Type punning dangers
+
+### 5. Memory Layout (`mem-`)
+
+**Focus**: Correct data representation
+
+- `#[repr(C)]` usage
+- Alignment and padding
+- Uninitialized memory
+- Cross-process memory
+
+### 6. FFI (`ffi-`)
+
+**Focus**: Safe C interoperability
+
+Subcategories:
+- String handling (CString, CStr)
+- Type compatibility
+- Error handling across FFI
+- Thread safety
+- Resource management
+
+### 7. I/O Safety (`io-`)
+
+**Focus**: Handle and resource ownership
+
+- Raw file descriptor safety
+- Handle validity guarantees

--- a/.agents/skills/unsafe-checker/rules/_template.md
+++ b/.agents/skills/unsafe-checker/rules/_template.md
@@ -1,0 +1,53 @@
+# Rule Template
+
+Use this template for all unsafe-checker rules.
+
+---
+
+```markdown
+---
+id: {prefix}-{number}
+original_id: P.UNS.XXX.YY or G.UNS.XXX.YY
+level: P|G
+impact: CRITICAL|HIGH|MEDIUM
+clippy: <clippy_lint_name> (if applicable)
+---
+
+# {Rule Title}
+
+## Summary
+
+One-sentence description of what this rule requires.
+
+## Rationale
+
+Why this rule matters for safety/soundness.
+
+## Bad Example
+
+```rust
+// DON'T: Description of the anti-pattern
+<code that violates the rule>
+```
+
+## Good Example
+
+```rust
+// DO: Description of the correct pattern
+<code that follows the rule>
+```
+
+## Common Violations
+
+1. Violation pattern 1
+2. Violation pattern 2
+
+## Checklist
+
+- [ ] Check item 1
+- [ ] Check item 2
+
+## Related Rules
+
+- `{other-rule-id}`: Brief description
+```

--- a/.agents/skills/unsafe-checker/rules/ffi-01-no-string-direct.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-01-no-string-direct.md
@@ -1,0 +1,122 @@
+---
+id: ffi-01
+original_id: P.UNS.FFI.01
+level: P
+impact: HIGH
+---
+
+# Avoid Passing Strings Directly to C from Public Rust API
+
+## Summary
+
+Use `CString` and `CStr` for string handling at FFI boundaries. Never pass Rust `String` or `&str` directly to C.
+
+## Rationale
+
+- Rust strings are UTF-8, not null-terminated
+- C strings require null terminator
+- Rust strings may contain interior null bytes
+- Memory layout differs between Rust String and C char*
+
+## Bad Example
+
+```rust
+extern "C" {
+    fn c_print(s: *const u8);
+    fn c_strlen(s: *const u8) -> usize;
+}
+
+// DON'T: Pass Rust string directly
+fn bad_print(s: &str) {
+    unsafe {
+        c_print(s.as_ptr());  // Not null-terminated!
+    }
+}
+
+// DON'T: Assume length matches
+fn bad_strlen(s: &str) -> usize {
+    unsafe {
+        c_strlen(s.as_ptr())  // May read past buffer
+    }
+}
+
+// DON'T: Use String in FFI signatures
+extern "C" fn bad_callback(s: String) {  // Wrong!
+    println!("{}", s);
+}
+```
+
+## Good Example
+
+```rust
+use std::ffi::{CString, CStr};
+use std::os::raw::c_char;
+
+extern "C" {
+    fn c_print(s: *const c_char);
+    fn c_strlen(s: *const c_char) -> usize;
+    fn c_get_string() -> *const c_char;
+}
+
+// DO: Convert to CString for passing to C
+fn good_print(s: &str) -> Result<(), std::ffi::NulError> {
+    let c_string = CString::new(s)?;  // Adds null terminator, checks for interior nulls
+    unsafe {
+        c_print(c_string.as_ptr());
+    }
+    Ok(())
+}
+
+// DO: Use CStr for receiving C strings
+fn good_receive() -> String {
+    unsafe {
+        let ptr = c_get_string();
+        let c_str = CStr::from_ptr(ptr);
+        c_str.to_string_lossy().into_owned()
+    }
+}
+
+// DO: Handle interior null bytes
+fn handle_nulls(s: &str) {
+    match CString::new(s) {
+        Ok(c_string) => unsafe { c_print(c_string.as_ptr()) },
+        Err(e) => {
+            // String contains interior null at position e.nul_position()
+            eprintln!("String contains null byte at {}", e.nul_position());
+        }
+    }
+}
+
+// DO: Use proper types in callbacks
+extern "C" fn good_callback(s: *const c_char) {
+    if !s.is_null() {
+        let c_str = unsafe { CStr::from_ptr(s) };
+        if let Ok(rust_str) = c_str.to_str() {
+            println!("{}", rust_str);
+        }
+    }
+}
+```
+
+## String Type Comparison
+
+| Type | Null-terminated | Encoding | Use |
+|------|-----------------|----------|-----|
+| `String` | No | UTF-8 | Rust owned |
+| `&str` | No | UTF-8 | Rust borrowed |
+| `CString` | Yes | Byte | Rust-to-C owned |
+| `&CStr` | Yes | Byte | Rust-to-C borrowed |
+| `*const c_char` | Yes | Byte | FFI pointer |
+| `OsString` | Platform | Platform | Paths, env |
+
+## Checklist
+
+- [ ] Am I passing Rust strings to C? → Use CString
+- [ ] Am I receiving C strings? → Use CStr
+- [ ] Does my string contain null bytes? → Handle NulError
+- [ ] Am I checking for null pointers from C?
+
+## Related Rules
+
+- `ffi-02`: Read documentation for std::ffi types
+- `ffi-06`: Ensure C-ABI string compatibility

--- a/.agents/skills/unsafe-checker/rules/ffi-02-read-ffi-docs.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-02-read-ffi-docs.md
@@ -1,0 +1,133 @@
+---
+id: ffi-02
+original_id: P.UNS.FFI.02
+level: P
+impact: MEDIUM
+---
+
+# Read Documentation Carefully When Using std::ffi Types
+
+## Summary
+
+The `std::ffi` module has many types with subtle differences. Read their documentation carefully to avoid misuse.
+
+## Key Types in std::ffi
+
+### CString vs CStr
+
+```rust
+use std::ffi::{CString, CStr};
+use std::os::raw::c_char;
+
+// CString: Owned, heap-allocated, null-terminated
+// - Use when creating strings to pass to C
+// - Owns the memory
+let owned = CString::new("hello").unwrap();
+let ptr: *const c_char = owned.as_ptr();
+// ptr valid until `owned` is dropped
+
+// CStr: Borrowed, null-terminated
+// - Use when receiving strings from C
+// - Does not own memory
+let borrowed: &CStr = unsafe { CStr::from_ptr(ptr) };
+// borrowed valid as long as ptr is valid
+```
+
+### OsString vs OsStr
+
+```rust
+use std::ffi::{OsString, OsStr};
+use std::path::Path;
+
+// OsString/OsStr: Platform-native strings
+// - Windows: potentially ill-formed UTF-16
+// - Unix: arbitrary bytes
+// - Use for paths and environment variables
+
+let path = Path::new("/some/path");
+let os_str: &OsStr = path.as_os_str();
+
+// Convert to Rust string (may fail)
+if let Some(s) = os_str.to_str() {
+    println!("Valid UTF-8: {}", s);
+}
+```
+
+### c_void and Opaque Types
+
+```rust
+use std::ffi::c_void;
+
+extern "C" {
+    fn get_handle() -> *mut c_void;
+    fn use_handle(h: *mut c_void);
+}
+
+// c_void is for truly opaque pointers
+// Better: use dedicated opaque types (see ffi-17)
+```
+
+## Common Pitfalls
+
+```rust
+use std::ffi::CString;
+
+// PITFALL 1: CString::as_ptr() lifetime
+fn bad_ptr() -> *const i8 {
+    let s = CString::new("hello").unwrap();
+    s.as_ptr()  // Dangling! s dropped at end of function
+}
+
+fn good_ptr(s: &CString) -> *const i8 {
+    s.as_ptr()  // OK: s outlives the pointer
+}
+
+// PITFALL 2: CString::new with interior nulls
+let result = CString::new("hello\0world");
+assert!(result.is_err());  // Interior null!
+
+// PITFALL 3: CStr::from_ptr safety
+unsafe {
+    let ptr: *const i8 = std::ptr::null();
+    // let cstr = CStr::from_ptr(ptr);  // UB: null pointer!
+
+    // Always check for null first
+    if !ptr.is_null() {
+        let cstr = CStr::from_ptr(ptr);
+    }
+}
+
+// PITFALL 4: CStr assumes valid null-terminated string
+unsafe {
+    let bytes = [104, 101, 108, 108, 111];  // "hello" without null
+    let ptr = bytes.as_ptr() as *const i8;
+    // let cstr = CStr::from_ptr(ptr);  // UB: no null terminator!
+
+    // Use from_bytes_with_nul instead
+    let bytes_with_nul = b"hello\0";
+    let cstr = CStr::from_bytes_with_nul(bytes_with_nul).unwrap();
+}
+```
+
+## Type Selection Guide
+
+| Scenario | Type |
+|----------|------|
+| Create string for C | `CString` |
+| Borrow string from C | `&CStr` |
+| File paths | `OsString`, `Path` |
+| Environment variables | `OsString` |
+| Opaque C pointers | Newtype over `*mut c_void` |
+| C integers | `c_int`, `c_long`, etc. |
+
+## Checklist
+
+- [ ] Have I read the docs for the std::ffi type I'm using?
+- [ ] Am I aware of the lifetime constraints?
+- [ ] Am I handling potential errors (NulError, UTF-8 errors)?
+- [ ] Is there a better type for my use case?
+
+## Related Rules
+
+- `ffi-01`: Use CString/CStr for strings
+- `ffi-17`: Use opaque types instead of c_void

--- a/.agents/skills/unsafe-checker/rules/ffi-03-drop-for-c-ptr.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-03-drop-for-c-ptr.md
@@ -1,0 +1,162 @@
+---
+id: ffi-03
+original_id: P.UNS.FFI.03
+level: P
+impact: CRITICAL
+---
+
+# Implement Drop for Rust Types Wrapping Memory-Managing C Pointers
+
+## Summary
+
+When wrapping a C pointer that owns memory, implement `Drop` to call the appropriate C deallocation function.
+
+## Rationale
+
+- C allocated memory must be freed with the matching C function
+- Rust's default drop won't clean up foreign memory
+- Resource leaks and double-frees are common FFI bugs
+
+## Bad Example
+
+```rust
+extern "C" {
+    fn create_resource() -> *mut Resource;
+    fn free_resource(r: *mut Resource);
+}
+
+// DON'T: Wrapper without Drop
+struct ResourceHandle {
+    ptr: *mut Resource,
+}
+
+impl ResourceHandle {
+    fn new() -> Self {
+        Self {
+            ptr: unsafe { create_resource() }
+        }
+    }
+    // Memory leak! ptr is never freed
+}
+
+// DON'T: Forget to handle null
+impl Drop for BadHandle {
+    fn drop(&mut self) {
+        unsafe {
+            free_resource(self.ptr);  // Crash if ptr is null!
+        }
+    }
+}
+```
+
+## Good Example
+
+```rust
+use std::ptr::NonNull;
+
+extern "C" {
+    fn create_resource() -> *mut Resource;
+    fn free_resource(r: *mut Resource);
+}
+
+// DO: Proper wrapper with Drop
+struct ResourceHandle {
+    ptr: NonNull<Resource>,
+}
+
+impl ResourceHandle {
+    fn new() -> Option<Self> {
+        let ptr = unsafe { create_resource() };
+        NonNull::new(ptr).map(|ptr| Self { ptr })
+    }
+
+    fn as_ptr(&self) -> *mut Resource {
+        self.ptr.as_ptr()
+    }
+}
+
+impl Drop for ResourceHandle {
+    fn drop(&mut self) {
+        // SAFETY: ptr was allocated by create_resource
+        // and hasn't been freed yet
+        unsafe {
+            free_resource(self.ptr.as_ptr());
+        }
+    }
+}
+
+// Prevent accidental copies that would cause double-free
+impl !Clone for ResourceHandle {}
+
+// DO: Document ownership transfer
+impl ResourceHandle {
+    /// Consumes the handle and returns the raw pointer.
+    ///
+    /// The caller is responsible for freeing the resource.
+    fn into_raw(self) -> *mut Resource {
+        let ptr = self.ptr.as_ptr();
+        std::mem::forget(self);  // Don't run Drop
+        ptr
+    }
+
+    /// Creates a handle from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// ptr must have been allocated by create_resource()
+    /// and not yet freed.
+    unsafe fn from_raw(ptr: *mut Resource) -> Option<Self> {
+        NonNull::new(ptr).map(|ptr| Self { ptr })
+    }
+}
+```
+
+## Complete Pattern with Multiple Resources
+
+```rust
+struct Connection {
+    handle: NonNull<c_void>,
+}
+
+struct Statement<'conn> {
+    handle: NonNull<c_void>,
+    _conn: std::marker::PhantomData<&'conn Connection>,
+}
+
+impl Connection {
+    fn prepare(&self, sql: &str) -> Option<Statement<'_>> {
+        let handle = unsafe { db_prepare(self.handle.as_ptr(), sql.as_ptr()) };
+        NonNull::new(handle).map(|handle| Statement {
+            handle,
+            _conn: std::marker::PhantomData,
+        })
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        // Statements must be dropped before Connection
+        // PhantomData ensures this at compile time
+        unsafe { db_close(self.handle.as_ptr()); }
+    }
+}
+
+impl Drop for Statement<'_> {
+    fn drop(&mut self) {
+        unsafe { db_finalize(self.handle.as_ptr()); }
+    }
+}
+```
+
+## Checklist
+
+- [ ] Does my wrapper own the C resource?
+- [ ] Did I implement Drop with the correct C free function?
+- [ ] Did I handle null pointers?
+- [ ] Did I prevent Clone/Copy to avoid double-free?
+- [ ] Did I consider ownership transfer methods (into_raw/from_raw)?
+
+## Related Rules
+
+- `mem-03`: Don't let String/Vec drop foreign memory
+- `ffi-07`: Don't implement Drop for types passed to external code

--- a/.agents/skills/unsafe-checker/rules/ffi-04-panic-boundary.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-04-panic-boundary.md
@@ -1,0 +1,145 @@
+---
+id: ffi-04
+original_id: P.UNS.FFI.04
+level: P
+impact: CRITICAL
+clippy: panic_in_result_fn
+---
+
+# Handle Panics When Crossing FFI Boundaries
+
+## Summary
+
+Panics must not unwind across FFI boundaries. Use `catch_unwind` or mark functions as `extern "C-unwind"`.
+
+## Rationale
+
+- Unwinding across C code is undefined behavior
+- C has no concept of Rust panics
+- Can corrupt C stack frames and cause crashes
+- Even with `panic=abort`, still UB to attempt unwinding in `extern "C"`
+
+## Bad Example
+
+```rust
+// DON'T: Allow panics to escape to C
+#[no_mangle]
+pub extern "C" fn callback(data: *const u8, len: usize) -> i32 {
+    let slice = unsafe { std::slice::from_raw_parts(data, len) };
+
+    // If this panics, UB occurs!
+    let sum: i32 = slice.iter().map(|&x| x as i32).sum();
+
+    // If this panics due to overflow in debug, UB!
+    process(sum)
+}
+
+// DON'T: Unwrap in extern functions
+#[no_mangle]
+pub extern "C" fn parse_config(path: *const c_char) -> i32 {
+    let path = unsafe { CStr::from_ptr(path) };
+    let config = std::fs::read_to_string(path.to_str().unwrap()).unwrap();  // Can panic!
+    0
+}
+```
+
+## Good Example
+
+```rust
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int};
+
+// DO: Catch panics at FFI boundary
+#[no_mangle]
+pub extern "C" fn safe_callback(data: *const u8, len: usize) -> c_int {
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        if data.is_null() || len == 0 {
+            return -1;
+        }
+
+        let slice = unsafe { std::slice::from_raw_parts(data, len) };
+        let sum: i32 = slice.iter().map(|&x| x as i32).sum();
+        sum
+    }));
+
+    match result {
+        Ok(value) => value,
+        Err(_) => {
+            // Log error, return error code
+            eprintln!("Panic caught at FFI boundary");
+            -1
+        }
+    }
+}
+
+// DO: Use Result-based API internally
+#[no_mangle]
+pub extern "C" fn parse_config(path: *const c_char) -> c_int {
+    let result = catch_unwind(AssertUnwindSafe(|| -> Result<(), Box<dyn std::error::Error>> {
+        let path = unsafe { CStr::from_ptr(path) }.to_str()?;
+        let _config = std::fs::read_to_string(path)?;
+        Ok(())
+    }));
+
+    match result {
+        Ok(Ok(())) => 0,
+        Ok(Err(e)) => {
+            eprintln!("Error: {}", e);
+            -1
+        }
+        Err(_) => {
+            eprintln!("Panic in parse_config");
+            -2
+        }
+    }
+}
+
+// DO: For Rust-calling-Rust across C, use "C-unwind"
+#[no_mangle]
+pub extern "C-unwind" fn rust_callback_can_unwind() {
+    // This is OK to panic if called from Rust through C
+    // The "C-unwind" ABI allows unwinding
+    panic!("This is allowed");
+}
+```
+
+## FFI Error Handling Pattern
+
+```rust
+// Define error codes
+const SUCCESS: c_int = 0;
+const ERR_NULL_PTR: c_int = -1;
+const ERR_INVALID_UTF8: c_int = -2;
+const ERR_IO: c_int = -3;
+const ERR_PANIC: c_int = -99;
+
+// Thread-local for detailed error
+thread_local! {
+    static LAST_ERROR: std::cell::RefCell<Option<String>> = std::cell::RefCell::new(None);
+}
+
+fn set_error(msg: String) {
+    LAST_ERROR.with(|e| *e.borrow_mut() = Some(msg));
+}
+
+#[no_mangle]
+pub extern "C" fn get_last_error() -> *const c_char {
+    LAST_ERROR.with(|e| {
+        e.borrow().as_ref().map(|s| s.as_ptr() as *const c_char)
+            .unwrap_or(std::ptr::null())
+    })
+}
+```
+
+## Checklist
+
+- [ ] Does my extern "C" function use catch_unwind?
+- [ ] Am I avoiding unwrap/expect in FFI functions?
+- [ ] Do I return error codes for error conditions?
+- [ ] Have I considered using "C-unwind" for Rust-to-Rust through C?
+
+## Related Rules
+
+- `ffi-08`: Handle errors properly in FFI
+- `safety-01`: Panic safety

--- a/.agents/skills/unsafe-checker/rules/ffi-05-portable-types.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-05-portable-types.md
@@ -1,0 +1,113 @@
+---
+id: ffi-05
+original_id: P.UNS.FFI.05
+level: P
+impact: HIGH
+---
+
+# Use Portable Type Aliases from std or libc
+
+## Summary
+
+Use type aliases from `std::os::raw` or the `libc` crate for C-compatible types. Don't assume sizes of C types.
+
+## Rationale
+
+- C types have platform-dependent sizes (`int` is not always 32 bits)
+- `long` is 32 bits on Windows, 64 bits on Unix
+- Using Rust primitives directly causes portability bugs
+
+## Bad Example
+
+```rust
+// DON'T: Use Rust types directly for C interop
+extern "C" {
+    fn c_function(x: i32, y: i64) -> i32;  // Might not match C types!
+}
+
+// DON'T: Assume sizes
+#[repr(C)]
+struct BadStruct {
+    count: i32,   // C 'int' might not be 32 bits
+    size: i64,    // C 'long' varies by platform!
+    ptr: usize,   // size_t? intptr_t? Different!
+}
+```
+
+## Good Example
+
+```rust
+use std::os::raw::{c_int, c_long, c_char, c_void};
+
+// DO: Use std::os::raw types
+extern "C" {
+    fn c_function(x: c_int, y: c_long) -> c_int;
+}
+
+// DO: Use libc for more types
+use libc::{size_t, ssize_t, off_t, pid_t, time_t};
+
+extern "C" {
+    fn read(fd: c_int, buf: *mut c_void, count: size_t) -> ssize_t;
+    fn lseek(fd: c_int, offset: off_t, whence: c_int) -> off_t;
+    fn getpid() -> pid_t;
+}
+
+// DO: Match C struct layout
+#[repr(C)]
+struct GoodStruct {
+    count: c_int,
+    size: c_long,
+    data: *mut c_void,
+}
+
+// DO: Use isize/usize for pointer-sized integers
+#[repr(C)]
+struct PointerSized {
+    offset: isize,     // intptr_t equivalent
+    size: usize,       // size_t in pointer arithmetic
+}
+```
+
+## Type Mapping Reference
+
+| C Type | Rust Type | Notes |
+|--------|-----------|-------|
+| `char` | `c_char` | May be signed or unsigned! |
+| `signed char` | `i8` | |
+| `unsigned char` | `u8` | |
+| `short` | `c_short` | Usually i16 |
+| `int` | `c_int` | Usually i32 |
+| `long` | `c_long` | 32 or 64 bits! |
+| `long long` | `c_longlong` | Usually i64 |
+| `size_t` | `usize` or `libc::size_t` | |
+| `ssize_t` | `isize` or `libc::ssize_t` | |
+| `float` | `c_float` / `f32` | |
+| `double` | `c_double` / `f64` | |
+| `void*` | `*mut c_void` | |
+| `const void*` | `*const c_void` | |
+
+## Platform Differences
+
+```rust
+#[cfg(target_pointer_width = "64")]
+type PtrDiff = i64;
+
+#[cfg(target_pointer_width = "32")]
+type PtrDiff = i32;
+
+// Better: use isize
+let diff: isize = ptr1 as isize - ptr2 as isize;
+```
+
+## Checklist
+
+- [ ] Am I using std::os::raw or libc types for FFI?
+- [ ] Have I avoided assuming c_long is 64 bits?
+- [ ] Am I using size_t/usize for sizes?
+- [ ] Have I tested on multiple platforms?
+
+## Related Rules
+
+- `ffi-13`: Ensure consistent data layout
+- `ffi-14`: Types in FFI should have stable layout

--- a/.agents/skills/unsafe-checker/rules/ffi-06-string-abi.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-06-string-abi.md
@@ -1,0 +1,151 @@
+---
+id: ffi-06
+original_id: P.UNS.FFI.06
+level: P
+impact: HIGH
+---
+
+# Ensure C-ABI Compatibility for Strings Between Rust and C
+
+## Summary
+
+When passing strings across FFI, ensure both sides agree on encoding, null-termination, and memory ownership.
+
+## Rationale
+
+- Rust strings are UTF-8, C strings are byte arrays
+- C expects null termination, Rust strings don't have it
+- Memory ownership must be explicit to avoid leaks/double-frees
+
+## String Passing Patterns
+
+### Rust to C (Caller Allocates)
+
+```rust
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+extern "C" {
+    fn c_process_string(s: *const c_char);
+}
+
+fn rust_to_c(s: &str) -> Result<(), std::ffi::NulError> {
+    let c_string = CString::new(s)?;
+    // c_string lives until end of scope
+    unsafe {
+        c_process_string(c_string.as_ptr());
+    }
+    // c_string dropped here, memory freed
+    Ok(())
+}
+```
+
+### C to Rust (C Allocates, Rust Borrows)
+
+```rust
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+extern "C" {
+    fn c_get_string() -> *const c_char;
+}
+
+fn c_to_rust() -> Option<String> {
+    let ptr = unsafe { c_get_string() };
+    if ptr.is_null() {
+        return None;
+    }
+    // Borrow from C, don't take ownership
+    let c_str = unsafe { CStr::from_ptr(ptr) };
+    Some(c_str.to_string_lossy().into_owned())
+}
+```
+
+### C to Rust (Ownership Transfer)
+
+```rust
+extern "C" {
+    fn c_create_string() -> *mut c_char;
+    fn c_free_string(s: *mut c_char);
+}
+
+struct CAllocatedString {
+    ptr: *mut c_char,
+}
+
+impl CAllocatedString {
+    fn new() -> Option<Self> {
+        let ptr = unsafe { c_create_string() };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(Self { ptr })
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        let c_str = unsafe { CStr::from_ptr(self.ptr) };
+        c_str.to_str().unwrap_or("")
+    }
+}
+
+impl Drop for CAllocatedString {
+    fn drop(&mut self) {
+        unsafe { c_free_string(self.ptr); }
+    }
+}
+```
+
+### Rust to C (Ownership Transfer)
+
+```rust
+extern "C" {
+    fn c_take_ownership(s: *mut c_char);  // C will free
+}
+
+fn give_to_c(s: &str) -> Result<(), std::ffi::NulError> {
+    let c_string = CString::new(s)?;
+    let ptr = c_string.into_raw();  // Don't drop CString
+
+    unsafe {
+        c_take_ownership(ptr);
+        // C now owns this memory
+        // To free it back in Rust: let _ = CString::from_raw(ptr);
+    }
+    Ok(())
+}
+```
+
+## Encoding Considerations
+
+```rust
+// UTF-8 to platform encoding
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStrExt;
+
+fn to_platform_string(s: &str) -> CString {
+    // On Unix, UTF-8 usually works
+    CString::new(s).unwrap()
+}
+
+#[cfg(windows)]
+fn to_wide_string(s: &str) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+    std::ffi::OsStr::new(s)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect()
+}
+```
+
+## Checklist
+
+- [ ] Is the string null-terminated when passed to C?
+- [ ] Who allocates the memory? Who frees it?
+- [ ] Is the encoding (UTF-8, ASCII, platform) documented?
+- [ ] Am I handling conversion errors (interior nulls, invalid UTF-8)?
+
+## Related Rules
+
+- `ffi-01`: Use CString/CStr at FFI boundaries
+- `ffi-02`: Read std::ffi documentation

--- a/.agents/skills/unsafe-checker/rules/ffi-07-no-drop-external.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-07-no-drop-external.md
@@ -1,0 +1,131 @@
+---
+id: ffi-07
+original_id: P.UNS.FFI.07
+level: P
+impact: HIGH
+---
+
+# Do Not Implement Drop for Types Passed to External Code
+
+## Summary
+
+If a type will be passed to external code that manages its lifetime, don't implement `Drop`. Otherwise, both Rust and the external code will try to free it.
+
+## Rationale
+
+- External code (C library) may take ownership of the data
+- If Rust also tries to drop it, you get double-free
+- Need clear ownership boundaries
+
+## Bad Example
+
+```rust
+// DON'T: Drop on type that external code will free
+#[repr(C)]
+struct EventHandler {
+    callback: extern "C" fn(i32),
+    user_data: *mut c_void,
+}
+
+impl Drop for EventHandler {
+    fn drop(&mut self) {
+        // BAD: What if the C library already freed user_data?
+        unsafe { libc::free(self.user_data); }
+    }
+}
+
+extern "C" {
+    // C takes ownership and frees EventHandler when done
+    fn register_handler(h: *mut EventHandler);
+}
+
+fn bad_register() {
+    let handler = EventHandler { /* ... */ };
+    let ptr = Box::into_raw(Box::new(handler));
+    unsafe {
+        register_handler(ptr);
+        // If C code frees this, and Rust's Drop runs too = double-free
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: No Drop for types whose lifetime is managed externally
+#[repr(C)]
+struct EventHandler {
+    callback: extern "C" fn(i32),
+    user_data: *mut c_void,
+}
+// No Drop impl - C library manages lifetime
+
+extern "C" {
+    fn register_handler(h: *mut EventHandler);
+    fn unregister_handler(h: *mut EventHandler);
+}
+
+// DO: Wrap in a Rust type that knows when it's safe to drop
+struct RegisteredHandler {
+    ptr: *mut EventHandler,
+    registered: bool,
+}
+
+impl RegisteredHandler {
+    fn register(handler: EventHandler) -> Self {
+        let ptr = Box::into_raw(Box::new(handler));
+        unsafe { register_handler(ptr); }
+        Self { ptr, registered: true }
+    }
+
+    fn unregister(&mut self) {
+        if self.registered {
+            unsafe { unregister_handler(self.ptr); }
+            self.registered = false;
+        }
+    }
+}
+
+impl Drop for RegisteredHandler {
+    fn drop(&mut self) {
+        self.unregister();
+        // Only free if we still own it
+        if !self.registered {
+            unsafe { drop(Box::from_raw(self.ptr)); }
+        }
+    }
+}
+
+// DO: Use ManuallyDrop for explicit control
+use std::mem::ManuallyDrop;
+
+fn explicit_ownership() {
+    let handler = ManuallyDrop::new(EventHandler { /* ... */ });
+    let ptr = &*handler as *const EventHandler as *mut EventHandler;
+    unsafe {
+        register_handler(ptr);
+        // C now owns handler, don't drop it in Rust
+    }
+}
+```
+
+## Ownership Patterns
+
+| Pattern | Who Owns | Rust Drop? |
+|---------|----------|------------|
+| Rust creates, Rust frees | Rust | Yes |
+| Rust creates, C frees | C | No |
+| C creates, C frees | C | No (use wrapper) |
+| C creates, Rust frees | Rust | Yes (in wrapper) |
+
+## Checklist
+
+- [ ] Who will free this type's memory?
+- [ ] If external code frees it, am I avoiding Drop?
+- [ ] If ownership is conditional, do I track it?
+- [ ] Am I using ManuallyDrop or forget() when transferring ownership?
+
+## Related Rules
+
+- `ffi-03`: Implement Drop for wrapped C pointers (opposite case)
+- `mem-03`: Don't let String/Vec drop foreign memory

--- a/.agents/skills/unsafe-checker/rules/ffi-08-error-handling.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-08-error-handling.md
@@ -1,0 +1,146 @@
+---
+id: ffi-08
+original_id: P.UNS.FFI.08
+level: P
+impact: HIGH
+---
+
+# Handle Errors Properly in FFI
+
+## Summary
+
+FFI functions must use C-compatible error handling (return codes, errno, out parameters). Rust's Result/Option don't cross FFI boundaries.
+
+## Rationale
+
+- C doesn't have Result or Option
+- Exceptions don't exist in C
+- Must use patterns C code understands
+
+## Bad Example
+
+```rust
+// DON'T: Return Result across FFI
+#[no_mangle]
+pub extern "C" fn bad_open(path: *const c_char) -> Result<Handle, Error> {
+    // Result is not C-compatible!
+    unimplemented!()
+}
+
+// DON'T: Return Option across FFI
+#[no_mangle]
+pub extern "C" fn bad_find(id: i32) -> Option<*mut Data> {
+    // Option<*mut T> might work but is confusing
+    unimplemented!()
+}
+```
+
+## Good Example
+
+```rust
+use std::os::raw::{c_char, c_int};
+
+// Error codes
+const SUCCESS: c_int = 0;
+const ERR_NULL_PTR: c_int = 1;
+const ERR_INVALID_PATH: c_int = 2;
+const ERR_FILE_NOT_FOUND: c_int = 3;
+const ERR_PERMISSION: c_int = 4;
+const ERR_UNKNOWN: c_int = -1;
+
+// DO: Return error code, output via pointer
+#[no_mangle]
+pub extern "C" fn open_file(
+    path: *const c_char,
+    out_handle: *mut *mut Handle
+) -> c_int {
+    if path.is_null() || out_handle.is_null() {
+        return ERR_NULL_PTR;
+    }
+
+    let path_str = match unsafe { CStr::from_ptr(path) }.to_str() {
+        Ok(s) => s,
+        Err(_) => return ERR_INVALID_PATH,
+    };
+
+    match File::open(path_str) {
+        Ok(file) => {
+            let handle = Box::into_raw(Box::new(Handle { file }));
+            unsafe { *out_handle = handle; }
+            SUCCESS
+        }
+        Err(e) => {
+            match e.kind() {
+                std::io::ErrorKind::NotFound => ERR_FILE_NOT_FOUND,
+                std::io::ErrorKind::PermissionDenied => ERR_PERMISSION,
+                _ => ERR_UNKNOWN,
+            }
+        }
+    }
+}
+
+// DO: Use errno for POSIX-style APIs
+#[cfg(unix)]
+#[no_mangle]
+pub extern "C" fn posix_style_read(
+    fd: c_int,
+    buf: *mut u8,
+    count: usize
+) -> isize {
+    if buf.is_null() {
+        unsafe { *libc::__errno_location() = libc::EINVAL; }
+        return -1;
+    }
+
+    // ... do read ...
+    // On error:
+    // unsafe { *libc::__errno_location() = error_code; }
+    // return -1;
+
+    count as isize
+}
+
+// DO: Provide error message function
+thread_local! {
+    static LAST_ERROR: std::cell::RefCell<Option<String>> = std::cell::RefCell::new(None);
+}
+
+#[no_mangle]
+pub extern "C" fn get_error_message(buf: *mut c_char, len: usize) -> c_int {
+    LAST_ERROR.with(|e| {
+        if let Some(msg) = e.borrow().as_ref() {
+            let bytes = msg.as_bytes();
+            let copy_len = std::cmp::min(bytes.len(), len.saturating_sub(1));
+            unsafe {
+                std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf as *mut u8, copy_len);
+                *buf.add(copy_len) = 0;
+            }
+            SUCCESS
+        } else {
+            ERR_UNKNOWN
+        }
+    })
+}
+```
+
+## Error Handling Patterns
+
+| Pattern | Usage |
+|---------|-------|
+| Return code | Simple success/failure |
+| Return code + out param | Return value on success |
+| errno | POSIX-style APIs |
+| Error message function | Detailed error info |
+| Last-error thread-local | Windows-style APIs |
+
+## Checklist
+
+- [ ] Am I returning C-compatible error indicators?
+- [ ] Are output parameters used for return values?
+- [ ] Is there a way to get detailed error info?
+- [ ] Am I documenting all possible error codes?
+
+## Related Rules
+
+- `ffi-04`: Handle panics at FFI boundary
+- `safety-10`: Document safety requirements

--- a/.agents/skills/unsafe-checker/rules/ffi-09-ref-not-ptr.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-09-ref-not-ptr.md
@@ -1,0 +1,136 @@
+---
+id: ffi-09
+original_id: P.UNS.FFI.09
+level: P
+impact: MEDIUM
+---
+
+# Use References Instead of Raw Pointers When Calling Safe C Functions
+
+## Summary
+
+When wrapping C functions that don't need null pointers, use Rust references in the safe wrapper to enforce non-null at compile time.
+
+## Rationale
+
+- References guarantee non-null
+- References have lifetime tracking
+- Raw pointers should stay in the unsafe FFI layer
+- Safe Rust API should use safe types
+
+## Bad Example
+
+```rust
+extern "C" {
+    fn c_process(data: *const u8, len: usize);
+}
+
+// DON'T: Expose raw pointers in safe API
+pub fn process(data: *const u8, len: usize) {
+    // Caller might pass null!
+    unsafe { c_process(data, len); }
+}
+
+// DON'T: Unsafe function when it could be safe
+pub unsafe fn process_unsafe(data: *const u8, len: usize) {
+    // Why force caller to use unsafe?
+    c_process(data, len);
+}
+```
+
+## Good Example
+
+```rust
+extern "C" {
+    fn c_process(data: *const u8, len: usize);
+    fn c_modify(data: *mut Data);
+    fn c_optional(data: *const Data);  // Can be null
+}
+
+// DO: Use slice reference for safe API
+pub fn process(data: &[u8]) {
+    // Reference guarantees non-null
+    // Slice guarantees valid length
+    unsafe { c_process(data.as_ptr(), data.len()); }
+}
+
+// DO: Use &mut for exclusive access
+pub fn modify(data: &mut Data) {
+    // Mutable reference guarantees:
+    // - Non-null
+    // - Exclusive access
+    // - Valid for duration
+    unsafe { c_modify(data as *mut Data); }
+}
+
+// DO: Use Option<&T> for nullable parameters
+pub fn optional(data: Option<&Data>) {
+    let ptr = data.map(|d| d as *const Data).unwrap_or(std::ptr::null());
+    unsafe { c_optional(ptr); }
+}
+
+// DO: Wrap FFI types in safe Rust types
+pub struct SafeHandle(*mut c_void);
+
+impl SafeHandle {
+    pub fn new() -> Option<Self> {
+        let ptr = unsafe { create_handle() };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(Self(ptr))
+        }
+    }
+
+    // Methods take &self or &mut self, not raw pointers
+    pub fn do_something(&self) {
+        unsafe { handle_operation(self.0); }
+    }
+}
+```
+
+## Converting Between References and Pointers
+
+```rust
+// Reference to pointer
+fn ref_to_ptr(r: &Data) -> *const Data {
+    r as *const Data
+}
+
+fn mut_ref_to_ptr(r: &mut Data) -> *mut Data {
+    r as *mut Data
+}
+
+// Slice to pointer
+fn slice_to_ptr(s: &[u8]) -> (*const u8, usize) {
+    (s.as_ptr(), s.len())
+}
+
+// Pointer to reference (unsafe)
+unsafe fn ptr_to_ref<'a>(p: *const Data) -> &'a Data {
+    &*p
+}
+
+unsafe fn ptr_to_mut<'a>(p: *mut Data) -> &'a mut Data {
+    &mut *p
+}
+```
+
+## When to Use Raw Pointers
+
+- FFI declarations (`extern "C"`)
+- Implementing the unsafe boundary layer
+- When null is a valid value
+- When the pointee might not be valid Rust (e.g., uninitialized)
+
+## Checklist
+
+- [ ] Can this parameter be a reference instead of a pointer?
+- [ ] Am I checking for null in the unsafe layer?
+- [ ] Is the safe API free of raw pointers?
+- [ ] Do I use Option<&T> for nullable references?
+
+## Related Rules
+
+- `safety-06`: Don't expose raw pointers in public APIs
+- `ffi-02`: Read std::ffi documentation

--- a/.agents/skills/unsafe-checker/rules/ffi-10-thread-safety.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-10-thread-safety.md
@@ -1,0 +1,132 @@
+---
+id: ffi-10
+original_id: P.UNS.FFI.10
+level: P
+impact: CRITICAL
+---
+
+# Exported Rust Functions Must Be Designed for Thread-Safety
+
+## Summary
+
+Functions exported to C with `#[no_mangle] extern "C"` may be called from multiple threads. Ensure they are thread-safe.
+
+## Rationale
+
+- C code doesn't know about Rust's thread safety guarantees
+- C may call your function from any thread
+- Global state must be synchronized
+- Race conditions are undefined behavior
+
+## Bad Example
+
+```rust
+// DON'T: Unsynchronized global state
+static mut COUNTER: i32 = 0;
+
+#[no_mangle]
+pub extern "C" fn increment() -> i32 {
+    unsafe {
+        COUNTER += 1;  // Data race if called from multiple threads!
+        COUNTER
+    }
+}
+
+// DON'T: Thread-local assuming single thread
+thread_local! {
+    static CONFIG: RefCell<Config> = RefCell::new(Config::default());
+}
+
+#[no_mangle]
+pub extern "C" fn set_config(value: i32) {
+    // Different threads get different configs!
+    // Is that what the C caller expects?
+    CONFIG.with(|c| c.borrow_mut().value = value);
+}
+
+// DON'T: Non-Send types in globals
+static mut HANDLE: Option<Rc<Data>> = None;  // Rc is not Send!
+```
+
+## Good Example
+
+```rust
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+// DO: Use atomics for simple counters
+static COUNTER: AtomicI32 = AtomicI32::new(0);
+
+#[no_mangle]
+pub extern "C" fn increment() -> i32 {
+    COUNTER.fetch_add(1, Ordering::SeqCst) + 1
+}
+
+// DO: Use Mutex for complex state
+static CONFIG: OnceLock<Mutex<Config>> = OnceLock::new();
+
+fn get_config() -> &'static Mutex<Config> {
+    CONFIG.get_or_init(|| Mutex::new(Config::default()))
+}
+
+#[no_mangle]
+pub extern "C" fn set_config_value(value: i32) -> i32 {
+    match get_config().lock() {
+        Ok(mut config) => {
+            config.value = value;
+            0  // Success
+        }
+        Err(_) => -1  // Lock poisoned
+    }
+}
+
+// DO: Document thread safety requirements
+/// Initializes the library. NOT thread-safe.
+/// Must be called once from main thread before any other function.
+#[no_mangle]
+pub extern "C" fn init() -> i32 {
+    // One-time initialization
+    0
+}
+
+/// Processes data. Thread-safe.
+/// May be called from multiple threads concurrently.
+#[no_mangle]
+pub extern "C" fn process(data: *const u8, len: usize) -> i32 {
+    // Uses only local state or synchronized globals
+    0
+}
+
+// DO: Make non-thread-safe APIs explicit
+/// Handle for single-threaded use only.
+///
+/// # Thread Safety
+///
+/// This handle must only be used from the thread that created it.
+struct SingleThreadHandle {
+    data: *mut Data,
+    _not_send: std::marker::PhantomData<*const ()>,  // !Send
+}
+```
+
+## Synchronization Patterns
+
+| Pattern | Use Case |
+|---------|----------|
+| `AtomicT` | Simple counters, flags |
+| `Mutex<T>` | Complex shared state |
+| `RwLock<T>` | Read-heavy shared state |
+| `OnceLock<T>` | Lazy one-time init |
+| `thread_local!` | Per-thread state (document!) |
+
+## Checklist
+
+- [ ] Does my exported function access global state?
+- [ ] Is that state properly synchronized?
+- [ ] Have I documented thread-safety guarantees?
+- [ ] Are any types !Send/!Sync exposed across FFI?
+
+## Related Rules
+
+- `ptr-01`: Don't share raw pointers across threads
+- `safety-05`: Send/Sync implementation safety

--- a/.agents/skills/unsafe-checker/rules/ffi-11-packed-ub.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-11-packed-ub.md
@@ -1,0 +1,142 @@
+---
+id: ffi-11
+original_id: P.UNS.FFI.11
+level: P
+impact: HIGH
+clippy: unaligned_references
+---
+
+# Be Careful with UB When Referencing #[repr(packed)] Struct Fields
+
+## Summary
+
+Creating references to fields in `#[repr(packed)]` structs is undefined behavior if the field is misaligned. Use raw pointers and `read_unaligned`/`write_unaligned` instead.
+
+## Rationale
+
+- Packed structs have no padding, so fields may be misaligned
+- References must be aligned; misaligned references are UB
+- Even implicit references (method calls, match) can cause UB
+
+## Bad Example
+
+```rust
+#[repr(C, packed)]
+struct Packet {
+    header: u8,
+    value: u32,   // Misaligned! At offset 1, not 4
+    data: u64,    // Misaligned! At offset 5, not 8
+}
+
+fn bad_reference(p: &Packet) -> &u32 {
+    &p.value  // UB: Creates misaligned reference!
+}
+
+fn bad_match(p: &Packet) {
+    match p.value {  // UB: Match creates a reference
+        0 => {},
+        _ => {},
+    }
+}
+
+fn bad_method(p: &Packet) {
+    p.value.to_string();  // UB: Method call creates reference
+}
+
+fn bad_borrow(p: &mut Packet) {
+    let v = &mut p.value;  // UB: Misaligned mutable reference
+    *v = 42;
+}
+```
+
+## Good Example
+
+```rust
+#[repr(C, packed)]
+struct Packet {
+    header: u8,
+    value: u32,
+    data: u64,
+}
+
+// DO: Copy out the value
+fn good_read(p: &Packet) -> u32 {
+    p.value  // Copies the value, no reference created
+}
+
+// DO: Use addr_of! for raw pointer (Rust 2021+)
+fn good_ptr_read(p: &Packet) -> u32 {
+    // SAFETY: read_unaligned handles misalignment
+    unsafe {
+        std::ptr::addr_of!(p.value).read_unaligned()
+    }
+}
+
+// DO: Use addr_of_mut! for writing
+fn good_ptr_write(p: &mut Packet, value: u32) {
+    // SAFETY: write_unaligned handles misalignment
+    unsafe {
+        std::ptr::addr_of_mut!(p.value).write_unaligned(value);
+    }
+}
+
+// DO: Create accessor methods
+impl Packet {
+    fn value(&self) -> u32 {
+        unsafe { std::ptr::addr_of!(self.value).read_unaligned() }
+    }
+
+    fn set_value(&mut self, value: u32) {
+        unsafe { std::ptr::addr_of_mut!(self.value).write_unaligned(value); }
+    }
+
+    fn data(&self) -> u64 {
+        unsafe { std::ptr::addr_of!(self.data).read_unaligned() }
+    }
+}
+
+// DO: Consider using byte arrays + from_ne_bytes
+#[repr(C, packed)]
+struct PacketBytes {
+    header: u8,
+    value: [u8; 4],  // Store as bytes
+    data: [u8; 8],
+}
+
+impl PacketBytes {
+    fn value(&self) -> u32 {
+        u32::from_ne_bytes(self.value)  // Safe, no alignment issue
+    }
+}
+```
+
+## Safe Alternatives
+
+```rust
+// Alternative 1: Don't use packed
+#[repr(C)]
+struct AlignedPacket {
+    header: u8,
+    _pad: [u8; 3],
+    value: u32,
+    data: u64,
+}
+
+// Alternative 2: Use zerocopy crate
+// use zerocopy::{AsBytes, FromBytes};
+
+// Alternative 3: Use bytemuck
+// use bytemuck::{Pod, Zeroable};
+```
+
+## Checklist
+
+- [ ] Am I creating references to packed struct fields?
+- [ ] Am I using addr_of! / addr_of_mut! for field access?
+- [ ] Am I using read_unaligned / write_unaligned?
+- [ ] Would a byte array representation be safer?
+
+## Related Rules
+
+- `ptr-04`: Don't dereference misaligned pointers
+- `mem-01`: Choose appropriate data layout

--- a/.agents/skills/unsafe-checker/rules/ffi-12-invariant-doc.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-12-invariant-doc.md
@@ -1,0 +1,164 @@
+---
+id: ffi-12
+original_id: P.UNS.FFI.12
+level: P
+impact: MEDIUM
+---
+
+# Document Invariant Assumptions for C-Provided Parameters
+
+## Summary
+
+When receiving parameters from C, document what invariants you assume (non-null, alignment, validity, lifetime) and verify them when possible.
+
+## Rationale
+
+- C doesn't enforce invariants at compile time
+- Rust code needs to validate or document assumptions
+- Debugging FFI bugs is hard without clear documentation
+
+## Bad Example
+
+```rust
+// DON'T: Undocumented assumptions
+extern "C" {
+    fn get_data() -> *mut Data;
+}
+
+fn bad_use() -> &'static Data {
+    let ptr = unsafe { get_data() };
+    // Assumes:
+    // - ptr is non-null (not documented)
+    // - ptr is aligned (not checked)
+    // - Data is valid (not verified)
+    // - Lifetime is 'static (just guessing)
+    unsafe { &*ptr }
+}
+
+// DON'T: Silent assumptions in function signature
+#[no_mangle]
+pub extern "C" fn process(data: *const Data, len: usize) {
+    // What if data is null?
+    // What if len is wrong?
+    // What if data contains invalid Data?
+    let slice = unsafe {
+        std::slice::from_raw_parts(data, len)
+    };
+}
+```
+
+## Good Example
+
+```rust
+/// Retrieves data from the C library.
+///
+/// # Invariants Assumed from C
+///
+/// - Returns a non-null pointer on success, null on failure
+/// - Returned pointer is valid for the lifetime of the library
+/// - Returned pointer is aligned for `Data`
+/// - The `Data` struct is fully initialized
+extern "C" {
+    fn get_data() -> *mut Data;
+}
+
+fn documented_use() -> Option<&'static Data> {
+    let ptr = unsafe { get_data() };
+
+    // Verify what we can
+    if ptr.is_null() {
+        return None;
+    }
+
+    // Document what we can't verify
+    // SAFETY:
+    // - Non-null: checked above
+    // - Aligned: documented in C library docs
+    // - Valid: C library guarantees initialized Data
+    // - Lifetime: C library guarantees static lifetime
+    Some(unsafe { &*ptr })
+}
+
+/// Processes data provided by C caller.
+///
+/// # Parameters
+///
+/// - `data`: Must be non-null, aligned for `Data`, and point to `len` valid `Data` items
+/// - `len`: Number of items. Must not exceed `isize::MAX / size_of::<Data>()`
+///
+/// # Returns
+///
+/// - `0` on success
+/// - `-1` if `data` is null
+/// - `-2` if `len` is invalid
+///
+/// # Thread Safety
+///
+/// This function is thread-safe. The `data` array must not be mutated during the call.
+#[no_mangle]
+pub extern "C" fn process_documented(data: *const Data, len: usize) -> i32 {
+    // Verify invariants we can check
+    if data.is_null() {
+        return -1;
+    }
+
+    if len > isize::MAX as usize / std::mem::size_of::<Data>() {
+        return -2;
+    }
+
+    // SAFETY:
+    // - Non-null: checked above
+    // - Aligned: documented requirement for caller
+    // - Valid for len items: documented requirement for caller
+    // - Not mutated: documented thread safety requirement
+    let slice = unsafe { std::slice::from_raw_parts(data, len) };
+
+    for item in slice {
+        // process...
+    }
+
+    0
+}
+```
+
+## Documentation Template
+
+```rust
+/// Brief description.
+///
+/// # Parameters
+///
+/// - `param`: Description, constraints (non-null, aligned, etc.)
+///
+/// # Invariants Assumed
+///
+/// The following invariants are assumed and NOT verified:
+/// - Invariant 1: explanation
+/// - Invariant 2: explanation
+///
+/// The following invariants ARE verified at runtime:
+/// - Verified 1: how it's checked
+///
+/// # Safety (for unsafe fn)
+///
+/// Caller must ensure:
+/// - Requirement 1
+/// - Requirement 2
+///
+/// # Errors
+///
+/// Returns error code when:
+/// - Condition 1: error code
+```
+
+## Checklist
+
+- [ ] Have I documented all assumptions about C parameters?
+- [ ] Which invariants can I verify at runtime?
+- [ ] Which must I trust the C caller to uphold?
+- [ ] Have I documented error conditions and return values?
+
+## Related Rules
+
+- `safety-02`: Verify safety invariants
+- `safety-10`: Document safety requirements

--- a/.agents/skills/unsafe-checker/rules/ffi-13-data-layout.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-13-data-layout.md
@@ -1,0 +1,146 @@
+---
+id: ffi-13
+original_id: P.UNS.FFI.13
+level: P
+impact: HIGH
+---
+
+# Ensure Consistent Data Layout for Custom Types
+
+## Summary
+
+Types shared between Rust and C must have `#[repr(C)]` to ensure the memory layout matches what C expects.
+
+## Rationale
+
+- Rust's default layout is unspecified and may change
+- C has specific, standardized layout rules
+- Mismatched layouts cause memory corruption
+
+## Bad Example
+
+```rust
+// DON'T: Rust layout for FFI types
+struct BadStruct {
+    a: u8,
+    b: u32,
+    c: u8,
+}
+// Rust may reorder to: b, a, c (for better packing)
+// C expects: a, padding, b, c, padding
+
+extern "C" {
+    fn use_struct(s: *const BadStruct);  // Layout mismatch!
+}
+
+// DON'T: Assume Rust enum layout matches C
+enum BadEnum {
+    A,
+    B(i32),
+    C { x: u8, y: u8 },
+}
+// Rust enum layout is complex and not C-compatible
+```
+
+## Good Example
+
+```rust
+// DO: Use repr(C) for FFI structs
+#[repr(C)]
+struct GoodStruct {
+    a: u8,      // offset 0
+    // 3 bytes padding
+    b: u32,     // offset 4
+    c: u8,      // offset 8
+    // 3 bytes padding
+}
+// Total size: 12, align: 4
+
+// DO: Use repr(C) for enums with explicit discriminant
+#[repr(C)]
+enum GoodEnum {
+    A = 0,
+    B = 1,
+    C = 2,
+}
+// Equivalent to C: enum { A = 0, B = 1, C = 2 };
+
+// DO: For complex enums, use tagged unions
+#[repr(C)]
+struct TaggedUnion {
+    tag: GoodEnum,
+    data: GoodUnionData,
+}
+
+#[repr(C)]
+union GoodUnionData {
+    a: (),         // For GoodEnum::A
+    b: i32,        // For GoodEnum::B
+    c: [u8; 2],    // For GoodEnum::C
+}
+
+// DO: Verify layout at compile time
+const _: () = {
+    assert!(std::mem::size_of::<GoodStruct>() == 12);
+    assert!(std::mem::align_of::<GoodStruct>() == 4);
+};
+```
+
+## Layout Verification
+
+```rust
+use std::mem::{size_of, align_of, offset_of};
+
+#[repr(C)]
+struct Verified {
+    a: u8,
+    b: u32,
+    c: u8,
+}
+
+// Compile-time layout verification
+const _: () = {
+    assert!(size_of::<Verified>() == 12);
+    assert!(align_of::<Verified>() == 4);
+    // offset_of! requires nightly or crate
+    // assert!(offset_of!(Verified, a) == 0);
+    // assert!(offset_of!(Verified, b) == 4);
+    // assert!(offset_of!(Verified, c) == 8);
+};
+
+// Runtime verification
+#[test]
+fn verify_layout() {
+    assert_eq!(size_of::<Verified>(), 12);
+    assert_eq!(align_of::<Verified>(), 4);
+
+    let v = Verified { a: 0, b: 0, c: 0 };
+    let base = &v as *const _ as usize;
+
+    assert_eq!(&v.a as *const _ as usize - base, 0);
+    assert_eq!(&v.b as *const _ as usize - base, 4);
+    assert_eq!(&v.c as *const _ as usize - base, 8);
+}
+```
+
+## repr Options
+
+| Attribute | Effect |
+|-----------|--------|
+| `#[repr(C)]` | C-compatible layout |
+| `#[repr(C, packed)]` | C layout, no padding |
+| `#[repr(C, align(N))]` | C layout, minimum align N |
+| `#[repr(transparent)]` | Same layout as single field |
+| `#[repr(u8)]` etc. | Enum discriminant type |
+
+## Checklist
+
+- [ ] Is every FFI struct marked `#[repr(C)]`?
+- [ ] Is every FFI enum using explicit discriminants?
+- [ ] Have I verified the layout matches the C header?
+- [ ] Have I added compile-time assertions?
+
+## Related Rules
+
+- `mem-01`: Choose appropriate data layout
+- `ffi-14`: Types in FFI should have stable layout

--- a/.agents/skills/unsafe-checker/rules/ffi-14-stable-layout.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-14-stable-layout.md
@@ -1,0 +1,135 @@
+---
+id: ffi-14
+original_id: P.UNS.FFI.14
+level: P
+impact: HIGH
+---
+
+# Types Used in FFI Should Have Stable Layout
+
+## Summary
+
+FFI types should not change layout between versions. Use `#[repr(C)]` and avoid types with unstable layout like generic `std` types.
+
+## Rationale
+
+- ABI compatibility requires stable layout
+- Dynamic libraries may be loaded with different compiler versions
+- Layout changes break binary compatibility
+
+## Bad Example
+
+```rust
+// DON'T: Use Rust std types with unstable layout in FFI
+extern "C" {
+    // Vec layout is not stable!
+    fn bad_vec(v: Vec<i32>);
+
+    // String layout is not stable!
+    fn bad_string(s: String);
+
+    // HashMap layout varies between versions
+    fn bad_map(m: std::collections::HashMap<i32, i32>);
+}
+
+// DON'T: Use Rust-specific types in C structs
+#[repr(C)]
+struct BadMixed {
+    id: i32,
+    data: Vec<u8>,  // Vec is not C-compatible!
+}
+
+// DON'T: Use Option with non-null optimization assumptions
+#[repr(C)]
+struct BadOption {
+    value: Option<std::num::NonZeroU32>,  // Layout may change!
+}
+```
+
+## Good Example
+
+```rust
+use std::os::raw::{c_int, c_char, c_void};
+
+// DO: Use C-compatible types
+#[repr(C)]
+struct GoodStruct {
+    id: c_int,
+    name: *const c_char,  // C-style string
+    data: *const c_void,  // Generic pointer
+    data_len: usize,
+}
+
+// DO: Use explicit struct for what Vec would provide
+#[repr(C)]
+struct GoodBuffer {
+    ptr: *mut u8,
+    len: usize,
+    cap: usize,
+}
+
+impl GoodBuffer {
+    fn from_vec(mut v: Vec<u8>) -> Self {
+        let buf = Self {
+            ptr: v.as_mut_ptr(),
+            len: v.len(),
+            cap: v.capacity(),
+        };
+        std::mem::forget(v);
+        buf
+    }
+
+    /// # Safety
+    /// Must have been created by from_vec()
+    unsafe fn into_vec(self) -> Vec<u8> {
+        Vec::from_raw_parts(self.ptr, self.len, self.cap)
+    }
+}
+
+// DO: Use fixed-size arrays for bounded data
+#[repr(C)]
+struct FixedName {
+    name: [c_char; 64],
+    name_len: usize,
+}
+
+// DO: Define your own stable option type
+#[repr(C)]
+struct OptionalU32 {
+    has_value: bool,
+    value: u32,
+}
+
+impl From<Option<u32>> for OptionalU32 {
+    fn from(opt: Option<u32>) -> Self {
+        match opt {
+            Some(v) => Self { has_value: true, value: v },
+            None => Self { has_value: false, value: 0 },
+        }
+    }
+}
+```
+
+## Stable Types for FFI
+
+| Use Instead Of | Stable Type |
+|----------------|-------------|
+| `Vec<T>` | `*mut T` + `len` + `cap` |
+| `String` | `*const c_char` or `*mut c_char` + `len` |
+| `&[T]` | `*const T` + `len` |
+| `Option<T>` | Custom tagged struct |
+| `Result<T, E>` | Error code + out parameter |
+| `Box<T>` | `*mut T` |
+| `bool` | `c_int` or explicit `u8` |
+
+## Checklist
+
+- [ ] Am I using only C-compatible primitive types?
+- [ ] Am I avoiding std collection types in FFI signatures?
+- [ ] Have I created stable wrappers for Rust types?
+- [ ] Is the layout documented for other languages?
+
+## Related Rules
+
+- `ffi-13`: Ensure consistent data layout
+- `ffi-05`: Use portable type aliases

--- a/.agents/skills/unsafe-checker/rules/ffi-15-validate-external.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-15-validate-external.md
@@ -1,0 +1,145 @@
+---
+id: ffi-15
+original_id: P.UNS.FFI.15
+level: P
+impact: HIGH
+---
+
+# Validate Non-Robust External Values
+
+## Summary
+
+Data received from external sources (FFI, files, network) may be invalid. Validate before using it as Rust types with stricter invariants.
+
+## Rationale
+
+- External data can be malicious or corrupted
+- Rust types have invariants (e.g., valid UTF-8 for str)
+- Invalid data causes undefined behavior
+
+## Bad Example
+
+```rust
+// DON'T: Trust external data
+extern "C" {
+    fn get_status() -> u8;
+}
+
+#[derive(Debug)]
+enum Status { Active = 0, Inactive = 1, Pending = 2 }
+
+fn bad_convert() -> Status {
+    let raw = unsafe { get_status() };
+    // BAD: Assumes C returns valid enum value
+    unsafe { std::mem::transmute(raw) }  // UB if raw > 2
+}
+
+// DON'T: Trust strings from C
+fn bad_string(ptr: *const c_char) -> &str {
+    let cstr = unsafe { CStr::from_ptr(ptr) };
+    // BAD: Assumes valid UTF-8
+    cstr.to_str().unwrap()
+}
+
+// DON'T: Trust size values
+fn bad_size(ptr: *const u8, len: usize) -> Vec<u8> {
+    // BAD: len could be huge, causing OOM
+    // BAD: len could exceed actual data
+    unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec()
+}
+```
+
+## Good Example
+
+```rust
+// DO: Validate enum values
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+enum Status {
+    Active = 0,
+    Inactive = 1,
+    Pending = 2,
+}
+
+impl TryFrom<u8> for Status {
+    type Error = InvalidStatusError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Status::Active),
+            1 => Ok(Status::Inactive),
+            2 => Ok(Status::Pending),
+            _ => Err(InvalidStatusError(value)),
+        }
+    }
+}
+
+fn good_convert() -> Result<Status, InvalidStatusError> {
+    let raw = unsafe { get_status() };
+    Status::try_from(raw)  // Returns error for invalid values
+}
+
+// DO: Handle invalid UTF-8
+fn good_string(ptr: *const c_char) -> Result<String, std::str::Utf8Error> {
+    if ptr.is_null() {
+        return Ok(String::new());
+    }
+    let cstr = unsafe { CStr::from_ptr(ptr) };
+    cstr.to_str().map(|s| s.to_owned())
+}
+
+fn good_string_lossy(ptr: *const c_char) -> String {
+    if ptr.is_null() {
+        return String::new();
+    }
+    let cstr = unsafe { CStr::from_ptr(ptr) };
+    cstr.to_string_lossy().into_owned()  // Replaces invalid UTF-8
+}
+
+// DO: Validate sizes
+const MAX_REASONABLE_SIZE: usize = 100 * 1024 * 1024;  // 100 MB
+
+fn good_size(ptr: *const u8, len: usize) -> Result<Vec<u8>, ValidationError> {
+    if ptr.is_null() {
+        return Err(ValidationError::NullPointer);
+    }
+    if len > MAX_REASONABLE_SIZE {
+        return Err(ValidationError::SizeTooLarge);
+    }
+
+    // Still need to trust that ptr points to len valid bytes
+    // Document this as a caller requirement
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+    Ok(slice.to_vec())
+}
+
+// DO: Use num_enum for safe enum conversion
+// use num_enum::TryFromPrimitive;
+//
+// #[derive(TryFromPrimitive)]
+// #[repr(u8)]
+// enum Status { Active = 0, Inactive = 1, Pending = 2 }
+```
+
+## Validation Patterns
+
+| External Data | Validation |
+|---------------|------------|
+| Enum discriminant | Match against valid values |
+| String | Check UTF-8 or use lossy conversion |
+| Size/length | Check against maximum |
+| Pointer | Check for null |
+| Boolean | Explicit 0/1 check or treat any non-zero as true |
+| Float | Check for NaN, infinity if problematic |
+
+## Checklist
+
+- [ ] Am I validating external enum values?
+- [ ] Am I handling potential invalid UTF-8?
+- [ ] Am I checking sizes against reasonable limits?
+- [ ] Am I using TryFrom instead of transmute?
+
+## Related Rules
+
+- `ffi-12`: Document invariant assumptions
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/ffi-16-closure-to-c.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-16-closure-to-c.md
@@ -1,0 +1,141 @@
+---
+id: ffi-16
+original_id: P.UNS.FFI.16
+level: P
+impact: HIGH
+---
+
+# Separate Data and Code When Passing Rust Closures to C
+
+## Summary
+
+C callbacks are function pointers without captured state. To pass Rust closures to C, separate the function pointer from the closure data using a "trampoline" pattern.
+
+## Rationale
+
+- Rust closures can capture state (like lambdas)
+- C function pointers are just addresses, no state
+- Must pass state separately via `void*` user_data
+
+## Bad Example
+
+```rust
+// DON'T: Try to pass closure directly
+extern "C" {
+    fn set_callback(cb: fn(i32) -> i32);  // Only works for non-capturing!
+}
+
+fn bad_closure() {
+    let multiplier = 2;
+    let closure = |x| x * multiplier;  // Captures multiplier
+
+    // This won't compile - closure is not fn pointer
+    // set_callback(closure);
+}
+
+// DON'T: Transmute closure to function pointer
+fn bad_transmute() {
+    let closure = |x: i32| x * 2;
+    let fp: fn(i32) -> i32 = unsafe { std::mem::transmute(closure) };
+    // UB: Closure may have non-zero size
+}
+```
+
+## Good Example
+
+```rust
+use std::os::raw::c_void;
+use std::ffi::c_int;
+
+// C callback signature with user_data
+type CCallback = extern "C" fn(value: c_int, user_data: *mut c_void) -> c_int;
+
+extern "C" {
+    fn set_callback(cb: CCallback, user_data: *mut c_void);
+    fn remove_callback();
+}
+
+// DO: Use trampoline pattern
+fn good_closure<F: FnMut(i32) -> i32>(mut closure: F) {
+    // Trampoline function that forwards to the closure
+    extern "C" fn trampoline<F: FnMut(i32) -> i32>(
+        value: c_int,
+        user_data: *mut c_void,
+    ) -> c_int {
+        let closure = unsafe { &mut *(user_data as *mut F) };
+        closure(value as i32) as c_int
+    }
+
+    let user_data = &mut closure as *mut F as *mut c_void;
+
+    unsafe {
+        set_callback(trampoline::<F>, user_data);
+        // Important: closure must live until callback is removed!
+    }
+}
+
+// DO: Box the closure for 'static lifetime
+struct CallbackHandle {
+    closure: Box<dyn FnMut(i32) -> i32>,
+}
+
+impl CallbackHandle {
+    fn new<F: FnMut(i32) -> i32 + 'static>(closure: F) -> Self {
+        Self { closure: Box::new(closure) }
+    }
+
+    fn register(&mut self) {
+        extern "C" fn trampoline(value: c_int, user_data: *mut c_void) -> c_int {
+            let closure = unsafe { &mut *(user_data as *mut Box<dyn FnMut(i32) -> i32>) };
+            closure(value as i32) as c_int
+        }
+
+        let user_data = &mut self.closure as *mut _ as *mut c_void;
+        unsafe { set_callback(trampoline, user_data); }
+    }
+}
+
+impl Drop for CallbackHandle {
+    fn drop(&mut self) {
+        unsafe { remove_callback(); }
+        // Now safe to drop closure
+    }
+}
+
+// Usage
+fn example() {
+    let multiplier = 2;
+    let mut handle = CallbackHandle::new(move |x| x * multiplier);
+    handle.register();
+    // handle must live until callback is no longer needed
+}
+```
+
+## Trampoline Pattern
+
+```
+Rust Closure: |x| x * captured_value
+     |
+     v
++-----------------+     +-----------------+
+| trampoline fn   | --> | closure data    |
+| (no captures)   |     | (captured_value)|
++-----------------+     +-----------------+
+     |                         ^
+     |    user_data ptr        |
+     +-------------------------+
+
+C sees: function pointer + void* user_data
+```
+
+## Checklist
+
+- [ ] Does my closure capture any state?
+- [ ] Am I using the trampoline pattern?
+- [ ] Does the closure data live long enough?
+- [ ] Am I unregistering before dropping the closure?
+
+## Related Rules
+
+- `ffi-03`: Implement Drop for resource wrappers
+- `ffi-10`: Thread safety for callbacks

--- a/.agents/skills/unsafe-checker/rules/ffi-17-opaque-types.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-17-opaque-types.md
@@ -1,0 +1,152 @@
+---
+id: ffi-17
+original_id: P.UNS.FFI.17
+level: P
+impact: MEDIUM
+---
+
+# Use Dedicated Opaque Type Pointers Instead of c_void for C Opaque Types
+
+## Summary
+
+Instead of using `*mut c_void` for opaque C handles, create dedicated marker types that provide type safety.
+
+## Rationale
+
+- `*mut c_void` accepts any pointer, easy to mix up handles
+- Dedicated types catch mistakes at compile time
+- Self-documenting code
+- Prevents accidental use of wrong free function
+
+## Bad Example
+
+```rust
+use std::ffi::c_void;
+
+extern "C" {
+    fn create_database() -> *mut c_void;
+    fn create_connection() -> *mut c_void;
+    fn execute(conn: *mut c_void, query: *const i8);
+    fn close_database(db: *mut c_void);
+    fn close_connection(conn: *mut c_void);
+}
+
+fn bad_usage() {
+    let db = unsafe { create_database() };
+    let conn = unsafe { create_connection() };
+
+    // BUG: Passed db where conn was expected - compiles fine!
+    unsafe { execute(db, b"SELECT 1\0".as_ptr() as *const i8) };
+
+    // BUG: Wrong close function - compiles fine!
+    unsafe { close_connection(db) };
+    unsafe { close_database(conn) };
+}
+```
+
+## Good Example
+
+```rust
+use std::marker::PhantomData;
+
+// DO: Define opaque marker types
+#[repr(C)]
+pub struct Database {
+    _private: [u8; 0],
+    _marker: PhantomData<(*mut u8, std::marker::PhantomPinned)>,
+}
+
+#[repr(C)]
+pub struct Connection {
+    _private: [u8; 0],
+    _marker: PhantomData<(*mut u8, std::marker::PhantomPinned)>,
+}
+
+extern "C" {
+    fn create_database() -> *mut Database;
+    fn create_connection(db: *mut Database) -> *mut Connection;
+    fn execute(conn: *mut Connection, query: *const i8) -> i32;
+    fn close_database(db: *mut Database);
+    fn close_connection(conn: *mut Connection);
+}
+
+fn good_usage() {
+    let db = unsafe { create_database() };
+    let conn = unsafe { create_connection(db) };
+
+    // Compile error: expected *mut Connection, found *mut Database
+    // unsafe { execute(db, b"SELECT 1\0".as_ptr() as *const i8) };
+
+    // Correct usage
+    unsafe { execute(conn, b"SELECT 1\0".as_ptr() as *const i8) };
+
+    unsafe { close_connection(conn) };
+    unsafe { close_database(db) };
+}
+
+// DO: Wrap in safe Rust types
+pub struct SafeDatabase {
+    ptr: *mut Database,
+}
+
+impl SafeDatabase {
+    pub fn new() -> Option<Self> {
+        let ptr = unsafe { create_database() };
+        if ptr.is_null() { None } else { Some(Self { ptr }) }
+    }
+
+    pub fn connect(&self) -> Option<SafeConnection<'_>> {
+        let ptr = unsafe { create_connection(self.ptr) };
+        if ptr.is_null() { None } else { Some(SafeConnection { ptr, _db: PhantomData }) }
+    }
+}
+
+impl Drop for SafeDatabase {
+    fn drop(&mut self) {
+        unsafe { close_database(self.ptr); }
+    }
+}
+
+pub struct SafeConnection<'db> {
+    ptr: *mut Connection,
+    _db: PhantomData<&'db SafeDatabase>,
+}
+
+impl SafeConnection<'_> {
+    pub fn execute(&self, query: &str) -> Result<(), ()> {
+        let query = std::ffi::CString::new(query).map_err(|_| ())?;
+        let result = unsafe { execute(self.ptr, query.as_ptr()) };
+        if result == 0 { Ok(()) } else { Err(()) }
+    }
+}
+
+impl Drop for SafeConnection<'_> {
+    fn drop(&mut self) {
+        unsafe { close_connection(self.ptr); }
+    }
+}
+```
+
+## Opaque Type Pattern
+
+```rust
+// The zero-sized array makes it impossible to construct
+// PhantomData ensures proper variance and !Send/!Sync if needed
+#[repr(C)]
+pub struct OpaqueHandle {
+    _private: [u8; 0],
+    _marker: PhantomData<(*mut u8, std::marker::PhantomPinned)>,
+}
+```
+
+## Checklist
+
+- [ ] Am I using `*mut c_void` for distinct handle types?
+- [ ] Would dedicated types prevent bugs?
+- [ ] Have I wrapped opaque pointers in safe Rust types?
+- [ ] Do my types enforce correct handle/function pairing?
+
+## Related Rules
+
+- `ffi-02`: Read std::ffi documentation
+- `ffi-03`: Implement Drop for wrapped pointers

--- a/.agents/skills/unsafe-checker/rules/ffi-18-no-trait-objects.md
+++ b/.agents/skills/unsafe-checker/rules/ffi-18-no-trait-objects.md
@@ -1,0 +1,165 @@
+---
+id: ffi-18
+original_id: P.UNS.FFI.18
+level: P
+impact: HIGH
+---
+
+# Avoid Passing Trait Objects to C Interfaces
+
+## Summary
+
+Trait objects (`dyn Trait`) have Rust-specific layout (fat pointers with vtable) that is not compatible with C.
+
+## Rationale
+
+- Trait objects are "fat pointers": data ptr + vtable ptr
+- C expects thin pointers (single pointer)
+- Vtable layout is not stable across Rust versions
+- C cannot call Rust vtable methods
+
+## Bad Example
+
+```rust
+// DON'T: Pass trait objects to C
+trait Handler {
+    fn handle(&self, data: i32);
+}
+
+extern "C" {
+    // This won't work - dyn Handler is a fat pointer!
+    fn set_handler(h: *const dyn Handler);
+}
+
+// DON'T: Store trait objects in FFI structs
+#[repr(C)]
+struct BadCallback {
+    handler: *const dyn Handler,  // Not C-compatible!
+}
+```
+
+## Good Example
+
+```rust
+use std::os::raw::{c_int, c_void};
+
+// DO: Use function pointers with user_data (trampoline pattern)
+type HandlerFn = extern "C" fn(data: c_int, user_data: *mut c_void);
+
+extern "C" {
+    fn set_handler(handler: HandlerFn, user_data: *mut c_void);
+}
+
+trait Handler {
+    fn handle(&self, data: i32);
+}
+
+fn register_handler<H: Handler + 'static>(handler: H) {
+    // Box the handler
+    let boxed: Box<H> = Box::new(handler);
+    let user_data = Box::into_raw(boxed) as *mut c_void;
+
+    extern "C" fn trampoline<H: Handler>(data: c_int, user_data: *mut c_void) {
+        let handler = unsafe { &*(user_data as *const H) };
+        handler.handle(data as i32);
+    }
+
+    unsafe {
+        set_handler(trampoline::<H>, user_data);
+    }
+}
+
+// DO: Use concrete types when possible
+struct ConcreteHandler {
+    multiplier: i32,
+}
+
+impl Handler for ConcreteHandler {
+    fn handle(&self, data: i32) {
+        println!("{}", data * self.multiplier);
+    }
+}
+
+// DO: Create C-compatible vtable manually if needed
+#[repr(C)]
+struct HandlerVtable {
+    handle: extern "C" fn(this: *const c_void, data: c_int),
+    drop: extern "C" fn(this: *mut c_void),
+}
+
+#[repr(C)]
+struct CCompatibleHandler {
+    data: *mut c_void,
+    vtable: *const HandlerVtable,
+}
+
+impl CCompatibleHandler {
+    fn new<H: Handler + 'static>(handler: H) -> Self {
+        extern "C" fn handle_impl<H: Handler>(this: *const c_void, data: c_int) {
+            let handler = unsafe { &*(this as *const H) };
+            handler.handle(data as i32);
+        }
+
+        extern "C" fn drop_impl<H: Handler>(this: *mut c_void) {
+            unsafe { drop(Box::from_raw(this as *mut H)); }
+        }
+
+        static VTABLE: HandlerVtable = HandlerVtable {
+            handle: handle_impl::<ConcreteHandler>,  // Need concrete type
+            drop: drop_impl::<ConcreteHandler>,
+        };
+
+        Self {
+            data: Box::into_raw(Box::new(handler)) as *mut c_void,
+            vtable: &VTABLE,
+        }
+    }
+
+    fn handle(&self, data: i32) {
+        unsafe {
+            ((*self.vtable).handle)(self.data, data as c_int);
+        }
+    }
+}
+
+impl Drop for CCompatibleHandler {
+    fn drop(&mut self) {
+        unsafe {
+            ((*self.vtable).drop)(self.data);
+        }
+    }
+}
+```
+
+## Why Trait Objects Don't Work
+
+```
+Rust trait object (*const dyn Handler):
+[data pointer][vtable pointer]  <- 16 bytes on 64-bit
+
+C pointer (void*):
+[pointer]  <- 8 bytes on 64-bit
+
+The sizes don't match!
+```
+
+## Alternatives to Trait Objects
+
+| Instead of | Use |
+|------------|-----|
+| `dyn Trait` | Function pointer + user_data |
+| `Box<dyn Trait>` | Boxed concrete type + trampoline |
+| `&dyn Trait` | C-compatible vtable struct |
+| `Arc<dyn Trait>` | Reference counting wrapper |
+
+## Checklist
+
+- [ ] Am I passing trait objects across FFI?
+- [ ] Can I use concrete types instead?
+- [ ] Have I used the trampoline pattern for callbacks?
+- [ ] If vtable is needed, is it C-compatible?
+
+## Related Rules
+
+- `ffi-16`: Closure to C with trampoline pattern
+- `ffi-14`: Types should have stable layout

--- a/.agents/skills/unsafe-checker/rules/general-01-no-abuse.md
+++ b/.agents/skills/unsafe-checker/rules/general-01-no-abuse.md
@@ -1,0 +1,71 @@
+---
+id: general-01
+original_id: P.UNS.01
+level: P
+impact: CRITICAL
+---
+
+# Do Not Abuse Unsafe to Escape Compiler Safety Checks
+
+## Summary
+
+Unsafe Rust should not be used as an escape hatch from the borrow checker or other compiler safety mechanisms.
+
+## Rationale
+
+The borrow checker exists to prevent memory safety bugs. Using `unsafe` to bypass it defeats Rust's safety guarantees and introduces potential undefined behavior.
+
+## Bad Example
+
+```rust
+// DON'T: Using unsafe to bypass borrow checker
+fn bad_alias() {
+    let mut data = vec![1, 2, 3];
+    let ptr = data.as_mut_ptr();
+
+    // Unsafe used to create aliasing mutable references
+    unsafe {
+        let ref1 = &mut *ptr;
+        let ref2 = &mut *ptr;  // UB: Two mutable references!
+        *ref1 = 10;
+        *ref2 = 20;
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Work with the borrow checker, not against it
+fn good_sequential() {
+    let mut data = vec![1, 2, 3];
+    data[0] = 10;
+    data[0] = 20;  // Sequential mutations are fine
+}
+
+// DO: Use interior mutability when needed
+use std::cell::RefCell;
+
+fn good_interior_mut() {
+    let data = RefCell::new(vec![1, 2, 3]);
+    data.borrow_mut()[0] = 10;
+}
+```
+
+## Legitimate Uses of Unsafe
+
+1. **FFI**: Calling C functions or implementing C-compatible interfaces
+2. **Low-level abstractions**: Implementing collections, synchronization primitives
+3. **Performance**: Only after profiling shows measurable improvement, and with careful safety analysis
+
+## Checklist
+
+- [ ] Have I tried all safe alternatives first?
+- [ ] Is the borrow checker preventing a genuine design need?
+- [ ] Can I restructure the code to satisfy the borrow checker?
+- [ ] If unsafe is necessary, have I documented the safety invariants?
+
+## Related Rules
+
+- `general-02`: Don't blindly use unsafe for performance
+- `safety-02`: Unsafe code authors must verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/general-02-not-for-perf.md
+++ b/.agents/skills/unsafe-checker/rules/general-02-not-for-perf.md
@@ -1,0 +1,90 @@
+---
+id: general-02
+original_id: P.UNS.02
+level: P
+impact: CRITICAL
+---
+
+# Do Not Blindly Use Unsafe for Performance
+
+## Summary
+
+Do not assume that using `unsafe` will automatically improve performance. Always measure first and verify the safety invariants.
+
+## Rationale
+
+1. Modern Rust optimizers often eliminate bounds checks when they can prove safety
+2. Unsafe code may prevent optimizations by breaking aliasing assumptions
+3. Unmeasured "optimizations" often provide no real benefit while introducing risk
+
+## Bad Example
+
+```rust
+// DON'T: Blind unsafe for "performance"
+fn sum_bad(slice: &[i32]) -> i32 {
+    let mut sum = 0;
+    // Unnecessary unsafe - LLVM can optimize the safe version
+    for i in 0..slice.len() {
+        unsafe {
+            sum += *slice.get_unchecked(i);
+        }
+    }
+    sum
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use safe iteration - compiler optimizes bounds checks away
+fn sum_good(slice: &[i32]) -> i32 {
+    slice.iter().sum()
+}
+
+// DO: If unsafe is justified, document why
+fn sum_justified(slice: &[i32]) -> i32 {
+    let mut sum = 0;
+    // This is actually slower than iter().sum() in most cases
+    // Only use get_unchecked when:
+    // 1. Profiler shows bounds checks as bottleneck
+    // 2. Iterator patterns can't be used
+    // 3. Safety is proven by other means
+    for i in 0..slice.len() {
+        // SAFETY: i is always < slice.len() due to loop condition
+        unsafe {
+            sum += *slice.get_unchecked(i);
+        }
+    }
+    sum
+}
+```
+
+## When Unsafe Might Be Justified for Performance
+
+1. **Hot inner loops** where profiling shows bounds checks are a bottleneck
+2. **SIMD operations** that require specific memory alignment
+3. **Lock-free data structures** with carefully verified memory orderings
+
+## Measurement Workflow
+
+```bash
+# 1. Benchmark the safe version first
+cargo bench --bench my_bench
+
+# 2. Profile to identify actual bottlenecks
+cargo flamegraph --bench my_bench
+
+# 3. Only then consider unsafe, with measurements
+```
+
+## Checklist
+
+- [ ] Have I benchmarked the safe version?
+- [ ] Does profiling show this specific code as a bottleneck?
+- [ ] Have I measured the actual improvement from unsafe?
+- [ ] Is the performance gain worth the safety risk?
+
+## Related Rules
+
+- `general-01`: Don't abuse unsafe to escape safety checks
+- `safety-02`: Unsafe code authors must verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/general-03-no-alias.md
+++ b/.agents/skills/unsafe-checker/rules/general-03-no-alias.md
@@ -1,0 +1,74 @@
+---
+id: general-03
+original_id: G.UNS.01
+level: G
+impact: MEDIUM
+---
+
+# Do Not Create Aliases for Types/Methods Named "Unsafe"
+
+## Summary
+
+Do not create type aliases, re-exports, or wrapper methods that hide the "unsafe" nature of operations.
+
+## Rationale
+
+The word "unsafe" in Rust is a signal to developers that extra scrutiny is required. Hiding this signal makes code review harder and can lead to accidental misuse.
+
+## Bad Example
+
+```rust
+// DON'T: Hide unsafe behind an alias
+type SafePointer = *mut u8;  // Still unsafe to dereference!
+
+// DON'T: Wrap unsafe in a "safe-looking" name
+pub fn get_value(ptr: *const i32) -> i32 {
+    unsafe { *ptr }  // Caller doesn't know this is unsafe!
+}
+
+// DON'T: Re-export unsafe functions with different names
+pub use std::mem::transmute as convert;
+```
+
+## Good Example
+
+```rust
+// DO: Keep "unsafe" visible in the API
+pub unsafe fn get_value_unchecked(ptr: *const i32) -> i32 {
+    *ptr
+}
+
+// DO: If providing a safe wrapper, make the safety contract clear
+/// Returns the value at the pointer.
+///
+/// # Safety
+/// This is safe because the pointer is validated internally.
+pub fn get_value_checked(ptr: *const i32) -> Option<i32> {
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: We checked for null above
+        Some(unsafe { *ptr })
+    }
+}
+
+// DO: Use clear naming for raw pointer types
+type RawHandle = *mut c_void;  // "Raw" signals potential unsafety
+```
+
+## Common Violations
+
+1. Creating type aliases that hide pointer types
+2. Wrapping unsafe functions in safe-looking functions without proper safety analysis
+3. Re-exporting unsafe functions with "friendlier" names
+
+## Checklist
+
+- [ ] Does my API preserve visibility of unsafe operations?
+- [ ] If wrapping unsafe code in safe API, is the safety invariant enforced?
+- [ ] Are type aliases clearly named to indicate their nature?
+
+## Related Rules
+
+- `safety-06`: Don't expose raw pointers in public APIs
+- `safety-09`: Add SAFETY comment before any unsafe block

--- a/.agents/skills/unsafe-checker/rules/io-01-raw-handle.md
+++ b/.agents/skills/unsafe-checker/rules/io-01-raw-handle.md
@@ -1,0 +1,151 @@
+---
+id: io-01
+original_id: P.UNS.FIO.01
+level: P
+impact: HIGH
+---
+
+# Ensure I/O Safety When Using Raw Handles
+
+## Summary
+
+When working with raw file descriptors or handles, ensure they are valid for the duration of use and properly ownership-tracked.
+
+## Rationale
+
+- Raw handles can be closed by other code
+- Using a closed handle is undefined behavior
+- Handle reuse can cause data corruption
+- Rust 1.63+ provides I/O safety traits
+
+## Bad Example
+
+```rust
+#[cfg(unix)]
+mod bad_example {
+    use std::os::unix::io::RawFd;
+
+    // DON'T: Accept raw handle without ownership
+    fn bad_read(fd: RawFd) -> std::io::Result<Vec<u8>> {
+        // What if fd was closed? What if it's reused?
+        let mut buf = vec![0u8; 1024];
+        let n = unsafe {
+            libc::read(fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len())
+        };
+        if n < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            buf.truncate(n as usize);
+            Ok(buf)
+        }
+    }
+
+    // DON'T: Store raw handle without tracking ownership
+    struct BadFileRef {
+        fd: RawFd,  // Who owns this? Who closes it?
+    }
+}
+```
+
+## Good Example
+
+```rust
+#[cfg(unix)]
+mod good_example {
+    use std::os::unix::io::{AsFd, BorrowedFd, OwnedFd, FromRawFd, AsRawFd};
+    use std::fs::File;
+
+    // DO: Use BorrowedFd for borrowed access (Rust 1.63+)
+    fn good_read(fd: BorrowedFd<'_>) -> std::io::Result<Vec<u8>> {
+        let mut buf = vec![0u8; 1024];
+        // BorrowedFd guarantees the fd is valid for this call
+        let n = unsafe {
+            libc::read(
+                fd.as_raw_fd(),
+                buf.as_mut_ptr() as *mut libc::c_void,
+                buf.len()
+            )
+        };
+        if n < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            buf.truncate(n as usize);
+            Ok(buf)
+        }
+    }
+
+    // DO: Use OwnedFd for owned handles
+    struct GoodFileOwner {
+        fd: OwnedFd,  // Clearly owns the handle
+    }
+
+    impl Drop for GoodFileOwner {
+        fn drop(&mut self) {
+            // OwnedFd closes automatically
+        }
+    }
+
+    // DO: Use generic AsFd bound for flexibility
+    fn generic_read<F: AsFd>(f: &F) -> std::io::Result<Vec<u8>> {
+        good_read(f.as_fd())
+    }
+
+    // Usage
+    fn example() -> std::io::Result<()> {
+        let file = File::open("test.txt")?;
+
+        // Pass as BorrowedFd
+        let data = good_read(file.as_fd())?;
+
+        // Or use generic function
+        let data = generic_read(&file)?;
+
+        Ok(())
+    }
+
+    // DO: Take ownership from raw fd
+    fn from_raw(fd: i32) -> Option<GoodFileOwner> {
+        if fd < 0 {
+            return None;
+        }
+        // SAFETY: Caller guarantees fd is valid and ownership is transferred
+        let owned = unsafe { OwnedFd::from_raw_fd(fd) };
+        Some(GoodFileOwner { fd: owned })
+    }
+}
+```
+
+## I/O Safety Types (Rust 1.63+)
+
+| Type | Meaning |
+|------|---------|
+| `OwnedFd` | Owns a file descriptor, closes on drop |
+| `BorrowedFd<'a>` | Borrows a fd for lifetime 'a |
+| `RawFd` | Raw integer, no safety guarantees |
+| `AsFd` | Trait for types that have a fd |
+| `From<OwnedFd>` | Create from owned fd |
+| `Into<OwnedFd>` | Convert to owned fd |
+
+## Windows Equivalents
+
+```rust
+#[cfg(windows)]
+use std::os::windows::io::{
+    OwnedHandle, BorrowedHandle, RawHandle,
+    AsHandle, FromRawHandle,
+    OwnedSocket, BorrowedSocket, RawSocket,
+    AsSocket, FromRawSocket,
+};
+```
+
+## Checklist
+
+- [ ] Am I using BorrowedFd/OwnedFd instead of RawFd?
+- [ ] Is ownership of handles clear?
+- [ ] Am I using the AsFd trait for generic code?
+- [ ] Is the fd guaranteed valid for the duration of use?
+
+## Related Rules
+
+- `ffi-03`: Implement Drop for resource wrappers
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/mem-01-repr-layout.md
+++ b/.agents/skills/unsafe-checker/rules/mem-01-repr-layout.md
@@ -1,0 +1,130 @@
+---
+id: mem-01
+original_id: P.UNS.MEM.01
+level: P
+impact: HIGH
+---
+
+# Choose Appropriate Data Layout for Struct/Tuple/Enum
+
+## Summary
+
+Use `#[repr(...)]` attributes to control data layout when interfacing with C, doing memory mapping, or needing specific guarantees.
+
+## Rationale
+
+Rust's default layout is unspecified and may change between compiler versions. For FFI, persistence, or low-level memory operations, you need predictable layout.
+
+## Repr Attributes
+
+| Attribute | Use Case |
+|-----------|----------|
+| `#[repr(C)]` | C-compatible layout, stable field order |
+| `#[repr(transparent)]` | Single-field struct with same layout as field |
+| `#[repr(packed)]` | No padding (alignment = 1), careful with references! |
+| `#[repr(align(N))]` | Minimum alignment of N bytes |
+| `#[repr(u8)]`, `#[repr(i32)]`, etc. | Enum discriminant type |
+
+## Bad Example
+
+```rust
+// DON'T: Assume Rust struct layout matches C
+struct BadFFI {
+    a: u8,
+    b: u32,
+    c: u8,
+}
+// Rust may reorder fields or add different padding than C
+
+// DON'T: Use packed without understanding the risks
+#[repr(packed)]
+struct Dangerous {
+    a: u8,
+    b: u32,
+}
+
+fn bad_ref(d: &Dangerous) -> &u32 {
+    &d.b  // UB: Creates unaligned reference!
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use repr(C) for FFI
+#[repr(C)]
+struct GoodFFI {
+    a: u8,
+    b: u32,
+    c: u8,
+}
+// Guaranteed: a at 0, padding 1-3, b at 4, c at 8, padding 9-11
+
+// DO: Use repr(transparent) for newtypes
+#[repr(transparent)]
+struct Wrapper(u32);
+// Guaranteed same layout as u32, can be transmuted
+
+// DO: Use repr(packed) carefully, access via copy
+#[repr(C, packed)]
+struct PackedData {
+    header: u8,
+    value: u32,
+}
+
+impl PackedData {
+    fn value(&self) -> u32 {
+        // Copy out the value to avoid unaligned reference
+        let ptr = std::ptr::addr_of!(self.value);
+        // SAFETY: Reading unaligned is OK with read_unaligned
+        unsafe { ptr.read_unaligned() }
+    }
+}
+
+// DO: Use align for SIMD or cache line alignment
+#[repr(C, align(64))]
+struct CacheAligned {
+    data: [u8; 64],
+}
+
+// DO: Specify enum discriminant for FFI
+#[repr(u8)]
+enum Status {
+    Ok = 0,
+    Error = 1,
+    Unknown = 255,
+}
+```
+
+## Layout Guarantees
+
+```rust
+use std::mem::{size_of, align_of};
+
+#[repr(C)]
+struct Example {
+    a: u8,   // offset 0, size 1
+    // padding: 3 bytes
+    b: u32,  // offset 4, size 4
+    c: u8,   // offset 8, size 1
+    // padding: 3 bytes
+}
+
+assert_eq!(size_of::<Example>(), 12);
+assert_eq!(align_of::<Example>(), 4);
+
+// repr(Rust) might reorder to: b, a, c -> size 8
+```
+
+## Checklist
+
+- [ ] Is this type used in FFI? → Use `#[repr(C)]`
+- [ ] Is this a newtype wrapper? → Consider `#[repr(transparent)]`
+- [ ] Do I need specific alignment? → Use `#[repr(align(N))]`
+- [ ] Am I using packed? → Never create references to packed fields
+
+## Related Rules
+
+- `ffi-13`: Ensure consistent data layout for custom types
+- `ffi-14`: Types in FFI should have stable layout
+- `ptr-04`: Alignment considerations

--- a/.agents/skills/unsafe-checker/rules/mem-02-no-other-process.md
+++ b/.agents/skills/unsafe-checker/rules/mem-02-no-other-process.md
@@ -1,0 +1,113 @@
+---
+id: mem-02
+original_id: P.UNS.MEM.02
+level: P
+impact: CRITICAL
+---
+
+# Do Not Modify Memory Variables of Other Processes or Dynamic Libraries
+
+## Summary
+
+Do not directly manipulate memory belonging to other processes or dynamically loaded libraries. Use proper IPC or FFI mechanisms.
+
+## Rationale
+
+- Other processes have separate address spaces; direct access is impossible on modern OSes
+- Shared memory requires explicit setup and synchronization
+- Dynamic library memory has ownership rules that must be respected
+- Violating these causes undefined behavior or security vulnerabilities
+
+## Bad Example
+
+```rust
+// DON'T: Try to access another process's memory directly
+fn bad_cross_process(ptr: *mut i32) {
+    // This pointer from another process is meaningless in our address space
+    unsafe { *ptr = 42; }  // Undefined behavior or crash
+}
+
+// DON'T: Modify library internals
+extern "C" {
+    static mut LIBRARY_INTERNAL: i32;
+}
+
+fn bad_library_access() {
+    // Modifying library internals breaks encapsulation
+    unsafe { LIBRARY_INTERNAL = 100; }  // May corrupt library state
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use proper IPC for cross-process communication
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+
+fn ipc_communication() -> std::io::Result<()> {
+    let mut stream = UnixStream::connect("/tmp/socket")?;
+    stream.write_all(b"message")?;
+    Ok(())
+}
+
+// DO: Use shared memory with proper synchronization
+#[cfg(unix)]
+fn shared_memory_example() {
+    use std::sync::atomic::{AtomicI32, Ordering};
+
+    // Properly set up shared memory region
+    // let shm = mmap shared memory...
+
+    // Use atomic operations for synchronization
+    let shared: &AtomicI32 = /* ... */;
+    shared.store(42, Ordering::Release);
+}
+
+// DO: Use proper FFI for library interaction
+mod ffi {
+    extern "C" {
+        pub fn library_set_value(value: i32);
+        pub fn library_get_value() -> i32;
+    }
+}
+
+fn proper_library_access() {
+    unsafe {
+        ffi::library_set_value(42);
+        let value = ffi::library_get_value();
+    }
+}
+
+// DO: Use Rust's libloading for dynamic libraries
+fn dynamic_library() -> Result<(), Box<dyn std::error::Error>> {
+    let lib = unsafe { libloading::Library::new("mylib.so")? };
+    let func: libloading::Symbol<extern "C" fn(i32) -> i32> =
+        unsafe { lib.get(b"my_function")? };
+    let result = func(42);
+    Ok(())
+}
+```
+
+## Memory Ownership Rules
+
+| Memory Type | Owner | Safe Access |
+|-------------|-------|-------------|
+| Stack variables | Current function | Direct |
+| Heap (Box, Vec) | Rust allocator | Through smart pointers |
+| Static | Program | With proper synchronization |
+| Shared memory | Multiple processes | Atomic ops, mutexes |
+| Library memory | Library | Through library API |
+| FFI-allocated | C allocator | Through C free functions |
+
+## Checklist
+
+- [ ] Who allocated this memory?
+- [ ] Who is responsible for freeing it?
+- [ ] Is proper synchronization in place for shared access?
+- [ ] Am I using the correct API for cross-boundary access?
+
+## Related Rules
+
+- `mem-03`: Don't let String/Vec drop other process's memory
+- `ffi-03`: Implement Drop for wrapped C pointers

--- a/.agents/skills/unsafe-checker/rules/mem-03-no-auto-drop-foreign.md
+++ b/.agents/skills/unsafe-checker/rules/mem-03-no-auto-drop-foreign.md
@@ -1,0 +1,127 @@
+---
+id: mem-03
+original_id: P.UNS.MEM.03
+level: P
+impact: CRITICAL
+---
+
+# Do Not Let String/Vec Auto-Drop Other Process's Memory
+
+## Summary
+
+Never create `String`, `Vec`, or `Box` from memory allocated outside Rust's allocator. They will try to free the memory with the wrong deallocator.
+
+## Rationale
+
+`String`, `Vec`, and `Box` assume memory was allocated by Rust's global allocator. When dropped, they call `dealloc`. If the memory came from C's `malloc`, a different allocator, or shared memory, this causes undefined behavior.
+
+## Bad Example
+
+```rust
+// DON'T: Create String from C-allocated memory
+extern "C" {
+    fn c_get_string() -> *mut std::os::raw::c_char;
+}
+
+fn bad_string() -> String {
+    unsafe {
+        let ptr = c_get_string();
+        // BAD: String will try to free with Rust allocator
+        String::from_raw_parts(ptr as *mut u8, len, cap)
+    }
+}
+
+// DON'T: Create Vec from foreign memory
+fn bad_vec(ptr: *mut u8, len: usize) -> Vec<u8> {
+    // BAD: Vec will free this memory incorrectly
+    unsafe { Vec::from_raw_parts(ptr, len, len) }
+}
+
+// DON'T: Wrap shared memory in Box
+fn bad_box(shared_ptr: *mut Data) -> Box<Data> {
+    // BAD: Box will try to deallocate shared memory!
+    unsafe { Box::from_raw(shared_ptr) }
+}
+```
+
+## Good Example
+
+```rust
+use std::ffi::CStr;
+
+extern "C" {
+    fn c_get_string() -> *mut std::os::raw::c_char;
+    fn c_free_string(s: *mut std::os::raw::c_char);
+}
+
+// DO: Copy data into Rust-owned allocation
+fn good_string() -> String {
+    unsafe {
+        let ptr = c_get_string();
+        let cstr = CStr::from_ptr(ptr);
+        let result = cstr.to_string_lossy().into_owned();
+        c_free_string(ptr);  // Free with correct deallocator
+        result
+    }
+}
+
+// DO: Use wrapper that calls correct deallocator
+struct CString {
+    ptr: *mut std::os::raw::c_char,
+}
+
+impl Drop for CString {
+    fn drop(&mut self) {
+        unsafe { c_free_string(self.ptr); }
+    }
+}
+
+// DO: Use slice for borrowed view, don't take ownership
+fn good_slice(ptr: *const u8, len: usize) -> &'static [u8] {
+    // Only borrow, don't own
+    unsafe { std::slice::from_raw_parts(ptr, len) }
+}
+
+// DO: For shared memory, use raw pointers or custom wrapper
+struct SharedBuffer {
+    ptr: *mut u8,
+    len: usize,
+}
+
+impl SharedBuffer {
+    fn as_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+    }
+}
+
+impl Drop for SharedBuffer {
+    fn drop(&mut self) {
+        // Unmap shared memory, don't deallocate
+        // munmap(self.ptr, self.len);
+    }
+}
+```
+
+## Memory Allocation Compatibility
+
+| Allocator | Can use Rust Vec/String/Box? |
+|-----------|------------------------------|
+| Rust global allocator | Yes |
+| C malloc | No - use wrapper with C free |
+| C++ new | No - use wrapper with C++ delete |
+| Custom allocator | No - use allocator_api |
+| mmap/shared memory | No - use munmap |
+| Stack/static | No - never "free" |
+
+## Checklist
+
+- [ ] Who allocated this memory?
+- [ ] Is it from Rust's global allocator?
+- [ ] If not, do I have a custom Drop that frees correctly?
+- [ ] Am I copying data or taking ownership?
+
+## Related Rules
+
+- `mem-02`: Don't modify other process's memory
+- `ffi-03`: Implement Drop for wrapped C pointers
+- `ffi-07`: Don't implement Drop for types passed to external code

--- a/.agents/skills/unsafe-checker/rules/mem-04-reentrant.md
+++ b/.agents/skills/unsafe-checker/rules/mem-04-reentrant.md
@@ -1,0 +1,121 @@
+---
+id: mem-04
+original_id: P.UNS.MEM.04
+level: P
+impact: HIGH
+---
+
+# Prefer Reentrant Versions of C-API or Syscalls
+
+## Summary
+
+When calling C functions or system calls, use reentrant (`_r`) versions to avoid data races from global state.
+
+## Rationale
+
+Many C library functions use static buffers or global state, making them unsafe in multithreaded programs. Reentrant versions use caller-provided buffers instead.
+
+## Bad Example
+
+```rust
+use std::ffi::CStr;
+
+extern "C" {
+    fn strtok(s: *mut i8, delim: *const i8) -> *mut i8;
+    fn localtime(time: *const i64) -> *mut Tm;
+    fn rand() -> i32;
+}
+
+// DON'T: Use non-reentrant functions
+fn bad_tokenize(s: &mut [i8]) {
+    unsafe {
+        let delim = b" \0".as_ptr() as *const i8;
+        // strtok uses static buffer - not thread-safe!
+        let token = strtok(s.as_mut_ptr(), delim);
+    }
+}
+
+fn bad_time() {
+    unsafe {
+        let now: i64 = 0;
+        // localtime returns pointer to static buffer
+        let tm = localtime(&now);  // Data race if called from multiple threads!
+    }
+}
+
+fn bad_random() -> i32 {
+    // rand() uses global state - not thread-safe
+    unsafe { rand() }
+}
+```
+
+## Good Example
+
+```rust
+extern "C" {
+    fn strtok_r(s: *mut i8, delim: *const i8, saveptr: *mut *mut i8) -> *mut i8;
+    fn localtime_r(time: *const i64, result: *mut Tm) -> *mut Tm;
+    fn rand_r(seed: *mut u32) -> i32;
+}
+
+// DO: Use reentrant versions
+fn good_tokenize(s: &mut [i8]) {
+    unsafe {
+        let delim = b" \0".as_ptr() as *const i8;
+        let mut saveptr: *mut i8 = std::ptr::null_mut();
+        // strtok_r uses caller-provided saveptr
+        let token = strtok_r(s.as_mut_ptr(), delim, &mut saveptr);
+    }
+}
+
+fn good_time() {
+    unsafe {
+        let now: i64 = 0;
+        let mut result: Tm = std::mem::zeroed();
+        // localtime_r writes to caller-provided buffer
+        localtime_r(&now, &mut result);
+    }
+}
+
+fn good_random(seed: &mut u32) -> i32 {
+    // rand_r uses caller-provided seed
+    unsafe { rand_r(seed) }
+}
+
+// BETTER: Use Rust standard library
+fn best_time() {
+    use std::time::SystemTime;
+    let now = SystemTime::now();  // Thread-safe!
+}
+
+fn best_random() -> u32 {
+    use rand::Rng;
+    rand::thread_rng().gen()  // Thread-safe!
+}
+```
+
+## Common Non-Reentrant Functions
+
+| Non-Reentrant | Reentrant | Rust Alternative |
+|---------------|-----------|------------------|
+| `strtok` | `strtok_r` | `str::split` |
+| `localtime` | `localtime_r` | `chrono` crate |
+| `gmtime` | `gmtime_r` | `chrono` crate |
+| `ctime` | `ctime_r` | `chrono` crate |
+| `rand` | `rand_r` | `rand` crate |
+| `strerror` | `strerror_r` | `std::io::Error` |
+| `getenv` | None (inherent race) | `std::env::var` (not atomic) |
+| `readdir` | `readdir_r` | `std::fs::read_dir` |
+| `gethostbyname` | `getaddrinfo` | `std::net::ToSocketAddrs` |
+
+## Checklist
+
+- [ ] Am I calling a C function that might use global state?
+- [ ] Is there a `_r` reentrant version available?
+- [ ] Is there a Rust standard library alternative?
+- [ ] If neither, do I need synchronization?
+
+## Related Rules
+
+- `ffi-10`: Exported functions must be thread-safe
+- `ptr-01`: Don't share raw pointers across threads

--- a/.agents/skills/unsafe-checker/rules/mem-05-bitfield-crates.md
+++ b/.agents/skills/unsafe-checker/rules/mem-05-bitfield-crates.md
@@ -1,0 +1,147 @@
+---
+id: mem-05
+original_id: P.UNS.MEM.05
+level: P
+impact: MEDIUM
+---
+
+# Use Third-Party Crates for Bitfields
+
+## Summary
+
+Use crates like `bitflags`, `bitvec`, or `modular-bitfield` instead of manual bit manipulation for complex bitfield operations.
+
+## Rationale
+
+- Manual bit manipulation is error-prone
+- Easy to get offsets, masks, or endianness wrong
+- Crates provide type-safe, tested abstractions
+- Proc-macro crates generate efficient code
+
+## Bad Example
+
+```rust
+// DON'T: Manual bitfield manipulation
+struct Flags(u32);
+
+impl Flags {
+    const READ: u32 = 1 << 0;
+    const WRITE: u32 = 1 << 1;
+    const EXECUTE: u32 = 1 << 2;
+
+    fn has_read(&self) -> bool {
+        (self.0 & Self::READ) != 0
+    }
+
+    fn set_read(&mut self) {
+        self.0 |= Self::READ;
+    }
+
+    fn clear_read(&mut self) {
+        self.0 &= !Self::READ;  // Easy to forget the !
+    }
+}
+
+// DON'T: Manual packed bitfields for FFI
+#[repr(C)]
+struct PackedHeader {
+    data: u32,
+}
+
+impl PackedHeader {
+    // Error-prone: wrong shift or mask values
+    fn version(&self) -> u8 {
+        ((self.data >> 24) & 0xFF) as u8
+    }
+
+    fn flags(&self) -> u16 {
+        ((self.data >> 8) & 0xFFFF) as u16
+    }
+
+    fn tag(&self) -> u8 {
+        (self.data & 0xFF) as u8
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use bitflags for flag sets
+use bitflags::bitflags;
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct Flags: u32 {
+        const READ = 1 << 0;
+        const WRITE = 1 << 1;
+        const EXECUTE = 1 << 2;
+        const RW = Self::READ.bits() | Self::WRITE.bits();
+    }
+}
+
+fn use_flags() {
+    let mut flags = Flags::READ | Flags::WRITE;
+    flags.insert(Flags::EXECUTE);
+    flags.remove(Flags::WRITE);
+
+    if flags.contains(Flags::READ) {
+        println!("Readable");
+    }
+}
+
+// DO: Use modular-bitfield for packed structures
+use modular_bitfield::prelude::*;
+
+#[bitfield]
+#[repr(C)]
+struct PackedHeader {
+    tag: B8,      // 8 bits
+    flags: B16,   // 16 bits
+    version: B8,  // 8 bits
+}
+
+fn use_packed() {
+    let header = PackedHeader::new()
+        .with_version(1)
+        .with_flags(0x1234)
+        .with_tag(0xAB);
+
+    assert_eq!(header.version(), 1);
+    assert_eq!(header.flags(), 0x1234);
+}
+
+// DO: Use bitvec for arbitrary bit manipulation
+use bitvec::prelude::*;
+
+fn use_bitvec() {
+    let mut bits = bitvec![u8, Msb0; 0; 16];
+    bits.set(0, true);
+    bits.set(7, true);
+
+    let byte: u8 = bits[0..8].load_be();
+    assert_eq!(byte, 0b1000_0001);
+}
+```
+
+## Recommended Crates
+
+| Crate | Use Case | Features |
+|-------|----------|----------|
+| `bitflags` | Flag sets (like C enums) | Type-safe, const, derives |
+| `modular-bitfield` | Packed struct fields | Proc macro, repr(C) |
+| `bitvec` | Arbitrary bit arrays | Slicing, iteration |
+| `packed_struct` | Binary protocol structs | Endianness, derive |
+| `deku` | Binary parsing | Derive, read/write |
+
+## Checklist
+
+- [ ] Am I manipulating multiple bit flags? → Use `bitflags`
+- [ ] Am I packing fields into bytes? → Use `modular-bitfield` or `packed_struct`
+- [ ] Am I doing binary protocol work? → Consider `deku`
+- [ ] Is the manual approach really simpler?
+
+## Related Rules
+
+- `mem-01`: Choose appropriate data layout
+- `ffi-13`: Ensure consistent data layout

--- a/.agents/skills/unsafe-checker/rules/mem-06-maybeuninit.md
+++ b/.agents/skills/unsafe-checker/rules/mem-06-maybeuninit.md
@@ -1,0 +1,146 @@
+---
+id: mem-06
+original_id: G.UNS.MEM.01
+level: G
+impact: HIGH
+clippy: uninit_assumed_init, uninit_vec
+---
+
+# Use MaybeUninit<T> for Uninitialized Memory
+
+## Summary
+
+Use `MaybeUninit<T>` instead of `mem::uninitialized()` or `mem::zeroed()` when working with uninitialized memory.
+
+## Rationale
+
+- `mem::uninitialized()` is deprecated and unsound
+- `mem::zeroed()` is UB for types where zero is invalid (references, NonZero, bool)
+- `MaybeUninit<T>` clearly marks memory as potentially uninitialized
+- Compiler can optimize based on initialization state
+
+## Bad Example
+
+```rust
+// DON'T: Use deprecated uninitialized
+fn bad_uninit<T>() -> T {
+    unsafe { std::mem::uninitialized() }  // Deprecated, UB
+}
+
+// DON'T: Use zeroed for types where zero is invalid
+fn bad_zeroed() -> &'static str {
+    unsafe { std::mem::zeroed() }  // UB: null reference
+}
+
+fn bad_zeroed_bool() -> bool {
+    unsafe { std::mem::zeroed() }  // UB: 0 might not be valid bool
+}
+
+// DON'T: Transmute to "initialize"
+fn bad_transmute() -> [String; 10] {
+    unsafe { std::mem::transmute([0u8; std::mem::size_of::<[String; 10]>()]) }
+}
+
+// DON'T: Set Vec length without initializing
+fn bad_vec() -> Vec<String> {
+    let mut v = Vec::with_capacity(10);
+    unsafe { v.set_len(10); }  // Elements are uninitialized!
+    v
+}
+```
+
+## Good Example
+
+```rust
+use std::mem::MaybeUninit;
+
+// DO: Use MaybeUninit for delayed initialization
+fn good_array() -> [String; 10] {
+    let mut arr: [MaybeUninit<String>; 10] =
+        unsafe { MaybeUninit::uninit().assume_init() };
+
+    for (i, elem) in arr.iter_mut().enumerate() {
+        elem.write(format!("item {}", i));
+    }
+
+    // SAFETY: All elements initialized above
+    unsafe { std::mem::transmute::<_, [String; 10]>(arr) }
+}
+
+// DO: Use MaybeUninit with arrays (cleaner with array_assume_init)
+fn good_array_nightly() -> [String; 10] {
+    let mut arr: [MaybeUninit<String>; 10] =
+        [const { MaybeUninit::uninit() }; 10];
+
+    for (i, elem) in arr.iter_mut().enumerate() {
+        elem.write(format!("item {}", i));
+    }
+
+    // On nightly: arr.map(|e| unsafe { e.assume_init() })
+    unsafe { MaybeUninit::array_assume_init(arr) }
+}
+
+// DO: Use zeroed only for types where it's valid
+fn good_zeroed() -> [u8; 1024] {
+    // SAFETY: All-zero bytes is valid for u8
+    unsafe { std::mem::zeroed() }
+}
+
+// DO: Initialize buffer properly
+fn good_vec() -> Vec<u8> {
+    let mut v = Vec::with_capacity(1024);
+
+    // Option 1: Resize with default value
+    v.resize(1024, 0);
+
+    // Option 2: Use spare_capacity_mut
+    let spare = v.spare_capacity_mut();
+    for elem in spare.iter_mut().take(1024) {
+        elem.write(0);
+    }
+    unsafe { v.set_len(1024); }
+
+    v
+}
+
+// DO: Use MaybeUninit::uninit_array (nightly) or const array
+fn good_uninit_array<const N: usize>() -> [MaybeUninit<u8>; N] {
+    // Stable: create array of uninit
+    [const { MaybeUninit::uninit() }; N]
+}
+```
+
+## MaybeUninit API
+
+```rust
+use std::mem::MaybeUninit;
+
+// Creation
+let uninit: MaybeUninit<T> = MaybeUninit::uninit();
+let zeroed: MaybeUninit<T> = MaybeUninit::zeroed();
+let init: MaybeUninit<T> = MaybeUninit::new(value);
+
+// Writing
+uninit.write(value);  // Returns &mut T
+
+// Reading (unsafe)
+let value: T = unsafe { uninit.assume_init() };
+let ref_: &T = unsafe { uninit.assume_init_ref() };
+let mut_: &mut T = unsafe { uninit.assume_init_mut() };
+
+// Pointer access
+let ptr: *const T = uninit.as_ptr();
+let mut_ptr: *mut T = uninit.as_mut_ptr();
+```
+
+## Checklist
+
+- [ ] Am I using `mem::uninitialized()`? → Replace with `MaybeUninit`
+- [ ] Am I using `mem::zeroed()` for non-POD types? → Use `MaybeUninit`
+- [ ] Am I setting Vec length without initialization? → Use proper initialization
+- [ ] Have I initialized all MaybeUninit before assume_init?
+
+## Related Rules
+
+- `safety-03`: Don't expose uninitialized memory in APIs
+- `safety-01`: Panic safety with partial initialization

--- a/.agents/skills/unsafe-checker/rules/ptr-01-no-thread-share.md
+++ b/.agents/skills/unsafe-checker/rules/ptr-01-no-thread-share.md
@@ -1,0 +1,113 @@
+---
+id: ptr-01
+original_id: P.UNS.PTR.01
+level: P
+impact: CRITICAL
+---
+
+# Do Not Share Raw Pointers Across Threads
+
+## Summary
+
+Raw pointers (`*const T`, `*mut T`) are not `Send` or `Sync` by default. Do not share them across threads without ensuring proper synchronization.
+
+## Rationale
+
+Raw pointers have no synchronization guarantees. Sharing them across threads can lead to data races, which are undefined behavior.
+
+## Bad Example
+
+```rust
+use std::thread;
+
+// DON'T: Share raw pointers across threads
+fn bad_sharing() {
+    let mut data = 42i32;
+    let ptr = &mut data as *mut i32;
+
+    let handle = thread::spawn(move || {
+        // This is undefined behavior!
+        unsafe { *ptr = 100; }
+    });
+
+    // Main thread also accesses - data race!
+    unsafe { *ptr = 200; }
+
+    handle.join().unwrap();
+}
+
+// DON'T: Wrap in struct and impl Send unsafely
+struct UnsafePtr(*mut i32);
+unsafe impl Send for UnsafePtr {}  // Unsound without synchronization!
+```
+
+## Good Example
+
+```rust
+use std::sync::{Arc, Mutex, atomic::{AtomicPtr, Ordering}};
+use std::thread;
+
+// DO: Use Arc<Mutex<T>> for shared mutable access
+fn good_mutex() {
+    let data = Arc::new(Mutex::new(42i32));
+    let data_clone = Arc::clone(&data);
+
+    let handle = thread::spawn(move || {
+        *data_clone.lock().unwrap() = 100;
+    });
+
+    *data.lock().unwrap() = 200;
+    handle.join().unwrap();
+}
+
+// DO: Use AtomicPtr for lock-free pointer sharing
+fn good_atomic() {
+    let data = Box::into_raw(Box::new(42i32));
+    let atomic_ptr = Arc::new(AtomicPtr::new(data));
+    let atomic_clone = Arc::clone(&atomic_ptr);
+
+    let handle = thread::spawn(move || {
+        let ptr = atomic_clone.load(Ordering::Acquire);
+        // SAFETY: We have exclusive access through atomic operations
+        unsafe { println!("Value: {}", *ptr); }
+    });
+
+    handle.join().unwrap();
+
+    // SAFETY: All threads done, we own the memory
+    unsafe { drop(Box::from_raw(atomic_ptr.load(Ordering::Relaxed))); }
+}
+
+// DO: If you must use raw pointers, ensure exclusive access
+fn good_exclusive() {
+    let mut data = vec![1, 2, 3];
+
+    // Send data ownership to thread, not pointer
+    let handle = thread::spawn(move || {
+        data.push(4);
+        data
+    });
+
+    let data = handle.join().unwrap();
+    println!("{:?}", data);
+}
+```
+
+## When Raw Pointers Across Threads Are Valid
+
+Only with proper synchronization:
+- Through `AtomicPtr` with appropriate memory orderings
+- Protected by a `Mutex` (don't share the pointer, share the Mutex)
+- Using lock-free algorithms with careful memory ordering
+
+## Checklist
+
+- [ ] Does my pointer cross thread boundaries?
+- [ ] Is there synchronization preventing concurrent access?
+- [ ] Can I use a higher-level abstraction (Arc, Mutex)?
+- [ ] If implementing Send/Sync, is thread safety proven?
+
+## Related Rules
+
+- `safety-05`: Consider safety when implementing Send/Sync
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/ptr-02-prefer-nonnull.md
+++ b/.agents/skills/unsafe-checker/rules/ptr-02-prefer-nonnull.md
@@ -1,0 +1,114 @@
+---
+id: ptr-02
+original_id: P.UNS.PTR.02
+level: P
+impact: MEDIUM
+---
+
+# Prefer NonNull<T> Over *mut T
+
+## Summary
+
+Use `NonNull<T>` instead of `*mut T` when the pointer should never be null. This enables null pointer optimization and makes the intent clear.
+
+## Rationale
+
+- `NonNull<T>` guarantees non-null at the type level
+- Enables niche optimization: `Option<NonNull<T>>` is the same size as `*mut T`
+- Makes invariants explicit in the type system
+- Covariant over `T` (like `&T`), which is usually what you want
+
+## Bad Example
+
+```rust
+// DON'T: Use *mut when pointer is always non-null
+struct MyBox<T> {
+    ptr: *mut T,  // Invariant: never null, but not enforced
+}
+
+impl<T> MyBox<T> {
+    pub fn new(value: T) -> Self {
+        let ptr = Box::into_raw(Box::new(value));
+        // ptr is guaranteed non-null, but type doesn't show it
+        Self { ptr }
+    }
+
+    pub fn get(&self) -> &T {
+        // Must add null check or document the invariant
+        unsafe { &*self.ptr }
+    }
+}
+```
+
+## Good Example
+
+```rust
+use std::ptr::NonNull;
+
+// DO: Use NonNull when pointer is never null
+struct MyBox<T> {
+    ptr: NonNull<T>,  // Type guarantees non-null
+}
+
+impl<T> MyBox<T> {
+    pub fn new(value: T) -> Self {
+        let ptr = Box::into_raw(Box::new(value));
+        // SAFETY: Box::into_raw never returns null
+        let ptr = unsafe { NonNull::new_unchecked(ptr) };
+        Self { ptr }
+    }
+
+    pub fn get(&self) -> &T {
+        // SAFETY: NonNull guarantees ptr is valid
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T> Drop for MyBox<T> {
+    fn drop(&mut self) {
+        // SAFETY: ptr was created from Box::into_raw
+        unsafe { drop(Box::from_raw(self.ptr.as_ptr())); }
+    }
+}
+
+// DO: Niche optimization with Option
+struct OptionalBox<T> {
+    ptr: Option<NonNull<T>>,  // Same size as *mut T!
+}
+```
+
+## NonNull API
+
+```rust
+use std::ptr::NonNull;
+
+// Creating NonNull
+let ptr: NonNull<i32> = NonNull::new(raw_ptr).expect("null pointer");
+let ptr: NonNull<i32> = unsafe { NonNull::new_unchecked(raw_ptr) };
+let ptr: NonNull<i32> = NonNull::dangling();  // For ZSTs or uninitialized
+
+// Using NonNull
+let raw: *mut i32 = ptr.as_ptr();
+let reference: &i32 = unsafe { ptr.as_ref() };
+let mut_ref: &mut i32 = unsafe { ptr.as_mut() };
+
+// Casting
+let ptr: NonNull<u8> = ptr.cast::<u8>();
+```
+
+## When to Use *mut T Instead
+
+- When null is a valid/expected value
+- FFI with C code that may return null
+- When variance matters (NonNull is covariant, sometimes you need invariance)
+
+## Checklist
+
+- [ ] Is my pointer ever null? If no, use NonNull
+- [ ] Do I need null pointer optimization?
+- [ ] Is the variance correct for my use case?
+
+## Related Rules
+
+- `ptr-03`: Use PhantomData for variance and ownership
+- `safety-06`: Don't expose raw pointers in public APIs

--- a/.agents/skills/unsafe-checker/rules/ptr-03-phantomdata.md
+++ b/.agents/skills/unsafe-checker/rules/ptr-03-phantomdata.md
@@ -1,0 +1,125 @@
+---
+id: ptr-03
+original_id: P.UNS.PTR.03
+level: P
+impact: HIGH
+---
+
+# Use PhantomData<T> for Variance and Ownership with Pointer Generics
+
+## Summary
+
+When a struct contains raw pointers but logically owns or borrows the pointed-to data, use `PhantomData<T>` to tell the compiler about the relationship.
+
+## Rationale
+
+Raw pointers don't carry ownership or lifetime information. `PhantomData` lets you:
+- Indicate ownership (for `Drop` check)
+- Control variance (covariant, contravariant, invariant)
+- Participate in lifetime elision
+
+## Bad Example
+
+```rust
+// DON'T: Raw pointer without PhantomData
+struct MyVec<T> {
+    ptr: *mut T,
+    len: usize,
+    cap: usize,
+}
+
+// Problems:
+// 1. Compiler doesn't know we "own" the T values
+// 2. T might be incorrectly determined as unused
+// 3. Drop check may allow dangling references
+```
+
+## Good Example
+
+```rust
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
+// DO: Use PhantomData to express ownership
+struct MyVec<T> {
+    ptr: NonNull<T>,
+    len: usize,
+    cap: usize,
+    _marker: PhantomData<T>,  // We own T values
+}
+
+// For owned data: PhantomData<T>
+// For borrowed data: PhantomData<&'a T>
+// For mutably borrowed: PhantomData<&'a mut T>
+// For function pointers: PhantomData<fn(T)> (contravariant)
+
+// DO: Express lifetime relationships
+struct Iter<'a, T> {
+    ptr: *const T,
+    end: *const T,
+    _marker: PhantomData<&'a T>,  // Borrows T for 'a
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.ptr == self.end {
+            None
+        } else {
+            // SAFETY: ptr < end, so ptr is valid
+            // Lifetime is tied to 'a through PhantomData
+            let current = unsafe { &*self.ptr };
+            self.ptr = unsafe { self.ptr.add(1) };
+            Some(current)
+        }
+    }
+}
+```
+
+## PhantomData Patterns
+
+| Phantom Type | Meaning | Variance |
+|--------------|---------|----------|
+| `PhantomData<T>` | Owns T | Covariant |
+| `PhantomData<&'a T>` | Borrows T for 'a | Covariant in T, covariant in 'a |
+| `PhantomData<&'a mut T>` | Mutably borrows T | Invariant in T, covariant in 'a |
+| `PhantomData<*const T>` | Just has pointer | Covariant |
+| `PhantomData<*mut T>` | Just has pointer | Invariant |
+| `PhantomData<fn(T)>` | Consumes T | Contravariant |
+| `PhantomData<fn() -> T>` | Produces T | Covariant |
+
+## Drop Check
+
+```rust
+use std::marker::PhantomData;
+
+// This tells the compiler that dropping MyVec may drop T values
+struct MyVec<T> {
+    ptr: NonNull<T>,
+    _marker: PhantomData<T>,
+}
+
+impl<T> Drop for MyVec<T> {
+    fn drop(&mut self) {
+        // Drop all T values...
+    }
+}
+
+// Without PhantomData<T>, this might compile incorrectly:
+// let x = MyVec::new(&local);
+// drop(local);  // Would be UB if allowed
+// drop(x);      // Tries to access dropped local
+```
+
+## Checklist
+
+- [ ] Does my pointer type logically own the pointed-to data?
+- [ ] Do I need to express a lifetime relationship?
+- [ ] What variance do I need for my generic parameter?
+- [ ] Will the type be dropped, and does it need drop check?
+
+## Related Rules
+
+- `ptr-02`: Prefer NonNull over *mut T
+- `safety-05`: Send/Sync implementation safety

--- a/.agents/skills/unsafe-checker/rules/ptr-04-alignment.md
+++ b/.agents/skills/unsafe-checker/rules/ptr-04-alignment.md
@@ -1,0 +1,117 @@
+---
+id: ptr-04
+original_id: G.UNS.PTR.01
+level: G
+impact: HIGH
+clippy: cast_ptr_alignment
+---
+
+# Do Not Dereference Pointers Cast to Misaligned Types
+
+## Summary
+
+When casting a pointer to a different type, ensure the resulting pointer is properly aligned for the target type.
+
+## Rationale
+
+Misaligned pointer dereferences are undefined behavior on most architectures. Even on architectures that support unaligned access, it may cause performance penalties or subtle bugs.
+
+## Bad Example
+
+```rust
+// DON'T: Cast without checking alignment
+fn bad_cast(bytes: &[u8]) -> u32 {
+    // BAD: bytes might not be aligned for u32
+    let ptr = bytes.as_ptr() as *const u32;
+    unsafe { *ptr }  // UB if misaligned!
+}
+
+// DON'T: Assume struct layout
+#[repr(C)]
+struct Header {
+    flags: u8,
+    value: u32,  // Aligned at offset 4 in the struct
+}
+
+fn bad_field_access(bytes: &[u8]) -> u32 {
+    let header = bytes.as_ptr() as *const Header;
+    // Even if bytes is 4-byte aligned, this might fail
+    // if Header has different alignment than expected
+    unsafe { (*header).value }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use read_unaligned for potentially misaligned data
+fn good_cast(bytes: &[u8]) -> u32 {
+    assert!(bytes.len() >= 4);
+    let ptr = bytes.as_ptr() as *const u32;
+    // SAFETY: We're reading 4 bytes, alignment doesn't matter for read_unaligned
+    unsafe { ptr.read_unaligned() }
+}
+
+// DO: Check alignment before cast
+fn good_aligned_cast(bytes: &[u8]) -> Option<&u32> {
+    if bytes.len() >= 4 && bytes.as_ptr() as usize % std::mem::align_of::<u32>() == 0 {
+        // SAFETY: Checked length and alignment
+        Some(unsafe { &*(bytes.as_ptr() as *const u32) })
+    } else {
+        None
+    }
+}
+
+// DO: Use from_ne_bytes for portable byte conversion
+fn good_from_bytes(bytes: &[u8]) -> u32 {
+    u32::from_ne_bytes(bytes[..4].try_into().unwrap())
+}
+
+// DO: Use bytemuck for safe transmutation
+// use bytemuck::{Pod, Zeroable};
+// let value: u32 = bytemuck::pod_read_unaligned(bytes);
+
+// DO: Use align_to for splitting at alignment boundaries
+fn process_aligned(bytes: &[u8]) {
+    let (prefix, aligned, suffix) = unsafe { bytes.align_to::<u32>() };
+    // prefix and suffix are unaligned portions
+    // aligned is a &[u32] that's properly aligned
+}
+```
+
+## Alignment Check Helpers
+
+```rust
+fn is_aligned<T>(ptr: *const u8) -> bool {
+    ptr as usize % std::mem::align_of::<T>() == 0
+}
+
+/// Align a pointer up to the next aligned address
+fn align_up<T>(ptr: *const u8) -> *const u8 {
+    let align = std::mem::align_of::<T>();
+    let addr = ptr as usize;
+    let aligned = (addr + align - 1) & !(align - 1);
+    aligned as *const u8
+}
+```
+
+## Architecture Notes
+
+| Arch | Misaligned Access |
+|------|-------------------|
+| x86/x64 | Works but slower |
+| ARM | UB, may trap or give wrong results |
+| RISC-V | UB, may trap |
+| WASM | UB |
+
+## Checklist
+
+- [ ] Is my pointer cast changing alignment requirements?
+- [ ] Is the source pointer guaranteed to be aligned?
+- [ ] Should I use read_unaligned instead?
+- [ ] Can I use safe conversion methods (from_ne_bytes)?
+
+## Related Rules
+
+- `mem-01`: Choose appropriate data layout
+- `ffi-13`: Ensure consistent data layout

--- a/.agents/skills/unsafe-checker/rules/ptr-05-no-const-to-mut.md
+++ b/.agents/skills/unsafe-checker/rules/ptr-05-no-const-to-mut.md
@@ -1,0 +1,120 @@
+---
+id: ptr-05
+original_id: G.UNS.PTR.02
+level: G
+impact: CRITICAL
+clippy: cast_ref_to_mut
+---
+
+# Do Not Manually Convert Immutable Pointer to Mutable
+
+## Summary
+
+Never cast `*const T` to `*mut T` and dereference it to write. This violates aliasing rules and is undefined behavior.
+
+## Rationale
+
+Creating `*const T` from `&T` implies immutability. Other references might exist. Writing through a `*mut T` created from `*const T` creates mutable aliasing, which is UB.
+
+## Bad Example
+
+```rust
+// DON'T: Cast *const to *mut
+fn bad_mutate(value: &i32) {
+    let ptr = value as *const i32 as *mut i32;
+    unsafe { *ptr = 42; }  // UB: Mutating through &
+}
+
+// DON'T: Use transmute to convert
+fn bad_transmute(value: &i32) -> &mut i32 {
+    unsafe { std::mem::transmute(value) }  // UB!
+}
+
+// DON'T: "I know this is the only reference"
+fn bad_claim(value: &i32) {
+    // Even if you "know" there's only one reference,
+    // the compiler assumes & means no mutation
+    let ptr = value as *const i32 as *mut i32;
+    unsafe { *ptr += 1; }  // Still UB - compiler may optimize incorrectly
+}
+```
+
+## Good Example
+
+```rust
+// DO: Take &mut if you need to mutate
+fn good_mutate(value: &mut i32) {
+    *value = 42;
+}
+
+// DO: Use interior mutability
+use std::cell::{Cell, RefCell, UnsafeCell};
+
+struct Mutable {
+    value: Cell<i32>,  // Interior mutability
+}
+
+impl Mutable {
+    fn modify(&self) {
+        self.value.set(42);  // OK: Cell provides interior mutability
+    }
+}
+
+// DO: Use UnsafeCell if you need raw unsafe interior mutability
+struct RawMutable {
+    value: UnsafeCell<i32>,
+}
+
+impl RawMutable {
+    fn modify(&self) {
+        // SAFETY: We ensure exclusive access through external means
+        unsafe { *self.value.get() = 42; }
+    }
+}
+```
+
+## The UnsafeCell Exception
+
+`UnsafeCell<T>` is the ONLY valid way to get `*mut T` from `&self`:
+
+```rust
+use std::cell::UnsafeCell;
+
+pub struct MyMutex<T> {
+    data: UnsafeCell<T>,
+    // ... lock state
+}
+
+impl<T> MyMutex<T> {
+    pub fn lock(&self) -> Guard<'_, T> {
+        // acquire lock...
+
+        // SAFETY: UnsafeCell allows this, lock ensures exclusivity
+        Guard { data: unsafe { &mut *self.data.get() } }
+    }
+}
+```
+
+## Why This Is Always UB
+
+The compiler assumes:
+1. `&T` means no mutation will occur
+2. Multiple `&T` can exist simultaneously
+3. Optimizations can be made based on these assumptions
+
+When you mutate through cast pointer:
+1. Other `&T` references see inconsistent values
+2. Compiler may cache/eliminate reads
+3. Results are unpredictable
+
+## Checklist
+
+- [ ] Am I trying to mutate through `&`?
+- [ ] Should I use `&mut` instead?
+- [ ] Should I use `Cell`, `RefCell`, or `UnsafeCell`?
+- [ ] Is the original type designed for interior mutability?
+
+## Related Rules
+
+- `safety-08`: Mutable return from immutable parameter is wrong
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/ptr-06-prefer-cast.md
+++ b/.agents/skills/unsafe-checker/rules/ptr-06-prefer-cast.md
@@ -1,0 +1,110 @@
+---
+id: ptr-06
+original_id: G.UNS.PTR.03
+level: G
+impact: LOW
+clippy: ptr_as_ptr
+---
+
+# Prefer pointer::cast Over `as` for Pointer Casting
+
+## Summary
+
+Use the `cast()` method instead of `as` for pointer type conversions. It's clearer and prevents accidental provenance loss.
+
+## Rationale
+
+- `cast()` only changes the pointed-to type, not pointer properties
+- `as` can accidentally convert to integer and back, losing provenance
+- `cast()` is more explicit about intent
+- Better tooling support (clippy, miri)
+
+## Bad Example
+
+```rust
+// DON'T: Use `as` for pointer casts
+fn bad_cast(ptr: *const u8) -> *const i32 {
+    ptr as *const i32  // Works, but less clear
+}
+
+// DON'T: Accidental provenance loss
+fn bad_roundtrip(ptr: *const u8) -> *const u8 {
+    let addr = ptr as usize;   // Converts to integer
+    addr as *const u8          // Loses provenance information!
+}
+
+// DON'T: Multiple `as` casts in chain
+fn bad_chain(ptr: *const u8) -> *mut i32 {
+    ptr as *mut u8 as *mut i32  // Hard to follow
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use cast() for pointer type changes
+fn good_cast(ptr: *const u8) -> *const i32 {
+    ptr.cast::<i32>()
+}
+
+// DO: Use cast_mut() for const-to-mut (when valid)
+fn good_cast_mut(ptr: *const u8) -> *mut u8 {
+    ptr.cast_mut()  // Only use when mutation is valid!
+}
+
+// DO: Use cast_const() for mut-to-const
+fn good_cast_const(ptr: *mut u8) -> *const u8 {
+    ptr.cast_const()
+}
+
+// DO: Chain casts clearly
+fn good_chain(ptr: *const u8) -> *mut i32 {
+    ptr.cast_mut().cast::<i32>()
+}
+
+// DO: Use with_addr() for address manipulation (nightly)
+#[cfg(feature = "strict_provenance")]
+fn good_provenance(ptr: *const u8, new_addr: usize) -> *const u8 {
+    ptr.with_addr(new_addr)  // Preserves provenance
+}
+```
+
+## Pointer Method Reference
+
+| Method | From | To | Notes |
+|--------|------|-----|-------|
+| `.cast::<U>()` | `*T` | `*U` | Changes pointee type |
+| `.cast_mut()` | `*const T` | `*mut T` | Removes const |
+| `.cast_const()` | `*mut T` | `*const T` | Adds const |
+| `.addr()` | `*T` | `usize` | Gets address (nightly) |
+| `.with_addr(usize)` | `*T` | `*T` | Changes address, keeps provenance |
+| `.map_addr(fn)` | `*T` | `*T` | Transforms address |
+
+## Provenance Considerations
+
+```rust
+// Provenance = permission to access memory
+
+// BAD: Loses provenance
+let ptr: *const u8 = &data as *const u8;
+let addr = ptr as usize;
+let ptr2 = addr as *const u8;  // ptr2 has no provenance!
+
+// GOOD: Preserves provenance (nightly strict_provenance)
+let ptr2 = ptr.with_addr(addr);  // Still has permission
+
+// GOOD: Use expose/from_exposed when provenance must cross integer
+let addr = ptr.expose_addr();  // "Expose" the provenance
+let ptr2 = std::ptr::from_exposed_addr(addr);  // Recover it
+```
+
+## Checklist
+
+- [ ] Am I using `as` where `cast()` would be clearer?
+- [ ] Am I accidentally converting through `usize`?
+- [ ] Do I need to preserve provenance?
+
+## Related Rules
+
+- `ptr-04`: Alignment considerations when casting
+- `ptr-05`: Don't convert const to mut improperly

--- a/.agents/skills/unsafe-checker/rules/safety-01-panic-safety.md
+++ b/.agents/skills/unsafe-checker/rules/safety-01-panic-safety.md
@@ -1,0 +1,113 @@
+---
+id: safety-01
+original_id: P.UNS.SAS.01
+level: P
+impact: CRITICAL
+clippy: panic_in_result_fn
+---
+
+# Be Aware of Memory Safety Issues from Panics
+
+## Summary
+
+Panics in unsafe code can leave data structures in an inconsistent state, leading to undefined behavior when the panic is caught.
+
+## Rationale
+
+When a panic occurs, Rust unwinds the stack and runs destructors. If unsafe code has partially modified data, the destructors may observe invalid state.
+
+## Bad Example
+
+```rust
+// DON'T: Panic can leave Vec in invalid state
+impl<T> MyVec<T> {
+    pub fn push(&mut self, value: T) {
+        if self.len == self.cap {
+            self.grow();  // Might panic during allocation
+        }
+
+        unsafe {
+            // If Clone::clone() panics after incrementing len,
+            // drop will try to drop uninitialized memory
+            self.len += 1;
+            ptr::write(self.ptr.add(self.len - 1), value.clone());
+        }
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Ensure panic safety by ordering operations correctly
+impl<T> MyVec<T> {
+    pub fn push(&mut self, value: T) {
+        if self.len == self.cap {
+            self.grow();
+        }
+
+        unsafe {
+            // Write first, then increment len
+            // If write somehow panics, len is still valid
+            ptr::write(self.ptr.add(self.len), value);
+            self.len += 1;  // Only increment after successful write
+        }
+    }
+}
+
+// DO: Use guards for complex operations
+impl<T: Clone> MyVec<T> {
+    pub fn extend_from_slice(&mut self, slice: &[T]) {
+        self.reserve(slice.len());
+
+        let mut guard = PanicGuard {
+            vec: self,
+            initialized: 0,
+        };
+
+        for item in slice {
+            unsafe {
+                ptr::write(guard.vec.ptr.add(guard.vec.len + guard.initialized), item.clone());
+                guard.initialized += 1;
+            }
+        }
+
+        // Success - update len and forget guard
+        self.len += guard.initialized;
+        std::mem::forget(guard);
+    }
+}
+
+struct PanicGuard<'a, T> {
+    vec: &'a mut MyVec<T>,
+    initialized: usize,
+}
+
+impl<T> Drop for PanicGuard<'_, T> {
+    fn drop(&mut self) {
+        // Clean up partially initialized elements on panic
+        unsafe {
+            for i in 0..self.initialized {
+                ptr::drop_in_place(self.vec.ptr.add(self.vec.len + i));
+            }
+        }
+    }
+}
+```
+
+## Key Patterns
+
+1. **Update bookkeeping after operations**: Increment length only after writing
+2. **Use panic guards**: RAII types that clean up on panic
+3. **Order operations carefully**: Ensure invariants hold if panic occurs at any point
+
+## Checklist
+
+- [ ] What happens if this code panics at each line?
+- [ ] Are all invariants maintained if we unwind from here?
+- [ ] Do I need a panic guard for cleanup?
+
+## Related Rules
+
+- `safety-04`: Avoid double-free from panic safety issues
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/safety-02-verify-invariants.md
+++ b/.agents/skills/unsafe-checker/rules/safety-02-verify-invariants.md
@@ -1,0 +1,90 @@
+---
+id: safety-02
+original_id: P.UNS.SAS.02
+level: P
+impact: CRITICAL
+---
+
+# Unsafe Code Authors Must Verify Safety Invariants
+
+## Summary
+
+When writing unsafe code, you are taking responsibility for upholding all safety invariants that the compiler normally enforces.
+
+## Rationale
+
+Unsafe blocks don't disable safety requirements - they transfer responsibility from the compiler to the programmer. You must manually verify what the compiler normally checks.
+
+## Safety Invariants to Verify
+
+1. **Pointer validity**: Non-null, aligned, points to valid memory
+2. **Aliasing**: No mutable aliasing (two &mut to same memory)
+3. **Initialization**: Memory is initialized before read
+4. **Lifetime**: References don't outlive their referents
+5. **Type validity**: Data matches the expected type's invariants
+6. **Thread safety**: Proper synchronization for concurrent access
+
+## Bad Example
+
+```rust
+// DON'T: Blindly trust inputs
+unsafe fn process(ptr: *const Data, len: usize) {
+    for i in 0..len {
+        // No verification that ptr is valid or len is correct!
+        let item = &*ptr.add(i);
+        process_item(item);
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Document and verify invariants
+/// Processes a slice of Data items.
+///
+/// # Safety
+///
+/// - `ptr` must be non-null and aligned for `Data`
+/// - `ptr` must point to `len` consecutive initialized `Data` items
+/// - The memory must not be mutated during this call
+/// - `len * size_of::<Data>()` must not overflow `isize::MAX`
+unsafe fn process(ptr: *const Data, len: usize) {
+    debug_assert!(!ptr.is_null(), "ptr must not be null");
+    debug_assert!(ptr.is_aligned(), "ptr must be aligned");
+
+    for i in 0..len {
+        // SAFETY: Caller guarantees ptr points to len valid items
+        let item = &*ptr.add(i);
+        process_item(item);
+    }
+}
+
+// DO: Provide safe wrapper when possible
+fn process_slice(data: &[Data]) {
+    // SAFETY: slice guarantees all invariants
+    unsafe { process(data.as_ptr(), data.len()) }
+}
+```
+
+## Invariant Documentation Template
+
+```rust
+/// # Safety
+///
+/// The caller must ensure that:
+/// - [List each invariant]
+/// - [Explain why each matters]
+```
+
+## Checklist
+
+- [ ] Have I listed all safety invariants?
+- [ ] Can I prove each invariant holds at the call site?
+- [ ] Have I added debug assertions where possible?
+- [ ] Have I documented invariants in /// # Safety section?
+
+## Related Rules
+
+- `safety-09`: Add SAFETY comment before any unsafe block
+- `safety-10`: Add Safety section in docs for public unsafe functions

--- a/.agents/skills/unsafe-checker/rules/safety-03-no-uninit-api.md
+++ b/.agents/skills/unsafe-checker/rules/safety-03-no-uninit-api.md
@@ -1,0 +1,121 @@
+---
+id: safety-03
+original_id: P.UNS.SAS.03
+level: P
+impact: CRITICAL
+clippy: uninit_assumed_init
+---
+
+# Do Not Expose Uninitialized Memory in Public APIs
+
+## Summary
+
+Public APIs must never return or expose uninitialized memory to callers.
+
+## Rationale
+
+Reading uninitialized memory is undefined behavior in Rust. Safe code should never be able to access uninitialized memory through your API.
+
+## Bad Example
+
+```rust
+// DON'T: Expose uninitialized memory
+pub struct Buffer {
+    data: [u8; 1024],
+    len: usize,
+}
+
+impl Buffer {
+    pub fn new() -> Self {
+        // BAD: data is uninitialized
+        unsafe {
+            Self {
+                data: std::mem::MaybeUninit::uninit().assume_init(),
+                len: 0,
+            }
+        }
+    }
+
+    // BAD: Returns reference to potentially uninitialized data
+    pub fn as_slice(&self) -> &[u8] {
+        &self.data[..self.len]  // What if len > initialized portion?
+    }
+}
+```
+
+## Good Example
+
+```rust
+use std::mem::MaybeUninit;
+
+// DO: Use MaybeUninit properly and only expose initialized data
+pub struct Buffer {
+    data: Box<[MaybeUninit<u8>; 1024]>,
+    len: usize,  // Invariant: data[0..len] is initialized
+}
+
+impl Buffer {
+    pub fn new() -> Self {
+        Self {
+            // MaybeUninit doesn't require initialization
+            data: Box::new([MaybeUninit::uninit(); 1024]),
+            len: 0,
+        }
+    }
+
+    pub fn push(&mut self, byte: u8) {
+        if self.len < 1024 {
+            self.data[self.len].write(byte);
+            self.len += 1;
+        }
+    }
+
+    // Only returns initialized portion
+    pub fn as_slice(&self) -> &[u8] {
+        // SAFETY: self.len bytes are initialized (invariant)
+        unsafe {
+            std::slice::from_raw_parts(
+                self.data.as_ptr() as *const u8,
+                self.len
+            )
+        }
+    }
+}
+
+impl Drop for Buffer {
+    fn drop(&mut self) {
+        // Only drop initialized elements
+        // For u8 this is a no-op, but important for Drop types
+    }
+}
+```
+
+## Patterns for Uninitialized Memory
+
+```rust
+// Pattern 1: MaybeUninit for delayed initialization
+let mut value: MaybeUninit<ExpensiveType> = MaybeUninit::uninit();
+initialize_expensive(&mut value);
+let value = unsafe { value.assume_init() };
+
+// Pattern 2: Vec::with_capacity for growable buffers
+let mut vec = Vec::with_capacity(100);
+// vec.len() is 0, capacity is 100
+// No uninitialized memory is accessible
+
+// Pattern 3: Box::new_uninit (nightly)
+let mut boxed = Box::<[u8; 1024]>::new_uninit();
+boxed.write([0u8; 1024]);
+let boxed = unsafe { boxed.assume_init() };
+```
+
+## Checklist
+
+- [ ] Does my API ever return references to uninitialized memory?
+- [ ] Are length/capacity invariants properly maintained?
+- [ ] Is MaybeUninit used instead of transmute for uninitialized data?
+
+## Related Rules
+
+- `mem-06`: Use MaybeUninit<T> for uninitialized memory
+- `safety-01`: Panic safety with partial initialization

--- a/.agents/skills/unsafe-checker/rules/safety-04-double-free.md
+++ b/.agents/skills/unsafe-checker/rules/safety-04-double-free.md
@@ -1,0 +1,109 @@
+---
+id: safety-04
+original_id: P.UNS.SAS.04
+level: P
+impact: CRITICAL
+---
+
+# Avoid Double-Free from Panic Safety Issues
+
+## Summary
+
+Ensure that resources are not freed twice, especially when panics can occur during operations.
+
+## Rationale
+
+Double-free is undefined behavior. Panics during unsafe operations can cause destructors to run on already-freed or partially-constructed data.
+
+## Bad Example
+
+```rust
+// DON'T: Potential double-free on panic
+impl<T> MyVec<T> {
+    pub fn pop(&mut self) -> Option<T> {
+        if self.len == 0 {
+            None
+        } else {
+            self.len -= 1;
+            unsafe {
+                // If something panics after this read but before return,
+                // Drop will try to drop this element again
+                Some(ptr::read(self.ptr.add(self.len)))
+            }
+        }
+    }
+}
+
+// DON'T: Double-free with ManuallyDrop misuse
+fn bad_swap<T>(a: &mut T, b: &mut T) {
+    unsafe {
+        let tmp = ptr::read(a);
+        ptr::write(a, ptr::read(b));  // If this panics, tmp leaks
+        ptr::write(b, tmp);
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use std::mem::take or swap
+fn good_swap<T: Default>(a: &mut T, b: &mut T) {
+    std::mem::swap(a, b);  // Safe and correct
+}
+
+// DO: Use ManuallyDrop for panic safety
+use std::mem::ManuallyDrop;
+
+impl<T> MyVec<T> {
+    pub fn pop(&mut self) -> Option<T> {
+        if self.len == 0 {
+            None
+        } else {
+            self.len -= 1;  // Decrement first
+            unsafe {
+                // SAFETY: len was decremented, so this slot won't be
+                // dropped again by Vec's Drop impl
+                Some(ptr::read(self.ptr.add(self.len)))
+            }
+        }
+    }
+}
+
+// DO: Use scopeguard or manual cleanup
+fn safe_operation<T: Clone>(data: &mut [T], source: &[T]) {
+    // Track what we've written for cleanup on panic
+    let mut written = 0;
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        for (i, item) in source.iter().enumerate() {
+            data[i] = item.clone();
+            written = i + 1;
+        }
+    }));
+
+    if result.is_err() {
+        // Clean up on panic (if T needs special handling)
+        // In this case, safe code handles it automatically
+    }
+}
+```
+
+## Patterns to Avoid Double-Free
+
+1. **Decrement length before reading**: Vec's Drop won't touch the read element
+2. **Use ManuallyDrop**: Explicitly control when Drop runs
+3. **Use std::mem::replace/swap**: Safe alternatives for move semantics
+4. **Panic guards**: RAII cleanup on unwind
+
+## Checklist
+
+- [ ] After reading memory, is it marked as "moved"?
+- [ ] Will Drop run on this memory? Should it?
+- [ ] What happens if this code panics at each point?
+- [ ] Are length/count bookkeeping updates ordered correctly?
+
+## Related Rules
+
+- `safety-01`: Panic safety in unsafe code
+- `ptr-01`: Don't share raw pointers across threads

--- a/.agents/skills/unsafe-checker/rules/safety-05-send-sync.md
+++ b/.agents/skills/unsafe-checker/rules/safety-05-send-sync.md
@@ -1,0 +1,113 @@
+---
+id: safety-05
+original_id: P.UNS.SAS.05
+level: P
+impact: CRITICAL
+clippy: non_send_fields_in_send_ty
+---
+
+# Consider Safety When Manually Implementing Auto Traits
+
+## Summary
+
+When manually implementing `Send` or `Sync`, you must ensure thread safety invariants are upheld.
+
+## Rationale
+
+`Send` and `Sync` are unsafe traits because incorrect implementations cause data races, which are undefined behavior. The compiler auto-implements them conservatively, but manual implementations require careful analysis.
+
+## Trait Meanings
+
+- **`Send`**: Safe to transfer ownership to another thread
+- **`Sync`**: Safe to share references (`&T`) between threads (i.e., `&T: Send`)
+
+## Bad Example
+
+```rust
+// DON'T: Unsafe Send/Sync without thread safety
+struct NotThreadSafe {
+    ptr: *mut i32,  // Raw pointers are not Send/Sync
+}
+
+// BAD: This is unsound!
+unsafe impl Send for NotThreadSafe {}
+unsafe impl Sync for NotThreadSafe {}
+
+// DON'T: Rc-like type with unsafe Sync
+struct MyRc<T> {
+    ptr: *mut RcInner<T>,
+}
+
+struct RcInner<T> {
+    count: usize,  // Not atomic!
+    data: T,
+}
+
+// BAD: count is not atomic, concurrent access is UB
+unsafe impl<T: Send> Sync for MyRc<T> {}
+```
+
+## Good Example
+
+```rust
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::ptr::NonNull;
+
+// DO: Use atomic operations for thread-safe reference counting
+struct MyArc<T> {
+    ptr: NonNull<ArcInner<T>>,
+}
+
+struct ArcInner<T> {
+    count: AtomicUsize,  // Atomic for thread safety
+    data: T,
+}
+
+// SAFETY: The data is behind atomic reference counting,
+// and T: Send + Sync ensures the data itself is thread-safe
+unsafe impl<T: Send + Sync> Send for MyArc<T> {}
+unsafe impl<T: Send + Sync> Sync for MyArc<T> {}
+
+// DO: Document why it's safe
+/// A thread-safe wrapper around a raw file descriptor.
+///
+/// # Safety
+///
+/// The file descriptor is valid for the lifetime of this struct,
+/// and file descriptors are safe to use from any thread.
+struct ThreadSafeFd {
+    fd: std::os::unix::io::RawFd,
+}
+
+// SAFETY: File descriptors are just integers and can be used
+// from any thread. The actual I/O operations are thread-safe
+// at the OS level.
+unsafe impl Send for ThreadSafeFd {}
+unsafe impl Sync for ThreadSafeFd {}
+```
+
+## Decision Tree
+
+```
+Does your type contain:
+  - Raw pointers? → Probably not auto Send/Sync
+  - Rc/RefCell? → Not Sync (Rc not Send either)
+  - Cell/UnsafeCell? → Not Sync
+  - Interior mutability? → Needs synchronization for Sync
+
+To manually implement:
+  - Send: Can another thread safely drop this?
+  - Sync: Can multiple threads safely call &self methods?
+```
+
+## Checklist
+
+- [ ] Does my type contain any non-Send/Sync fields?
+- [ ] Is interior mutability properly synchronized (Mutex, atomic)?
+- [ ] Would concurrent access cause data races?
+- [ ] Have I documented why the implementation is safe?
+
+## Related Rules
+
+- `ptr-01`: Don't share raw pointers across threads
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/safety-06-no-raw-ptr-api.md
+++ b/.agents/skills/unsafe-checker/rules/safety-06-no-raw-ptr-api.md
@@ -1,0 +1,137 @@
+---
+id: safety-06
+original_id: P.UNS.SAS.06
+level: P
+impact: HIGH
+---
+
+# Do Not Expose Raw Pointers in Public APIs
+
+## Summary
+
+Public APIs should use safe abstractions (references, slices, smart pointers) instead of exposing raw pointers.
+
+## Rationale
+
+Raw pointers bypass Rust's safety guarantees. Exposing them in public APIs forces users into unsafe code and makes it easy to create undefined behavior.
+
+## Bad Example
+
+```rust
+// DON'T: Expose raw pointers in public API
+pub struct Buffer {
+    data: *mut u8,
+    len: usize,
+}
+
+impl Buffer {
+    // BAD: Returns raw pointer
+    pub fn as_ptr(&self) -> *const u8 {
+        self.data
+    }
+
+    // BAD: Takes raw pointer as input
+    pub fn from_ptr(ptr: *mut u8, len: usize) -> Self {
+        Self { data: ptr, len }
+    }
+
+    // BAD: Exposes internal pointer mutably
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.data
+    }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use safe abstractions
+pub struct Buffer {
+    data: Vec<u8>,
+}
+
+impl Buffer {
+    // Returns a safe reference
+    pub fn as_slice(&self) -> &[u8] {
+        &self.data
+    }
+
+    // Takes safe input
+    pub fn from_slice(data: &[u8]) -> Self {
+        Self { data: data.to_vec() }
+    }
+
+    // Mutable access through safe reference
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.data
+    }
+}
+
+// DO: If raw pointers are needed, provide unsafe API with documentation
+impl Buffer {
+    /// Returns a pointer to the buffer's data.
+    ///
+    /// # Safety
+    ///
+    /// The pointer is valid for `self.len()` bytes and must not be
+    /// used after the Buffer is dropped or reallocated.
+    pub fn as_ptr(&self) -> *const u8 {
+        self.data.as_ptr()
+    }
+
+    /// Creates a Buffer from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must point to `len` valid bytes
+    /// - The memory must be allocated with the global allocator
+    /// - Caller transfers ownership of the memory to Buffer
+    pub unsafe fn from_raw_parts(ptr: *mut u8, len: usize, cap: usize) -> Self {
+        Self {
+            data: Vec::from_raw_parts(ptr, len, cap)
+        }
+    }
+}
+```
+
+## Patterns for Safe Pointer APIs
+
+```rust
+// Pattern 1: Use NonNull for internal pointers
+use std::ptr::NonNull;
+
+pub struct MyBox<T> {
+    ptr: NonNull<T>,  // Internal use only
+}
+
+impl<T> MyBox<T> {
+    // Safe public API
+    pub fn get(&self) -> &T {
+        // SAFETY: ptr is always valid while MyBox exists
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+// Pattern 2: Callback-based access
+impl Buffer {
+    // User can work with pointer in controlled context
+    pub fn with_ptr<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(*const u8, usize) -> R,
+    {
+        f(self.data.as_ptr(), self.data.len())
+    }
+}
+```
+
+## Checklist
+
+- [ ] Can this API use references instead of pointers?
+- [ ] Can this API use slices instead of pointer + length?
+- [ ] If pointers are necessary, is the API marked `unsafe`?
+- [ ] Are safety requirements documented?
+
+## Related Rules
+
+- `general-03`: Don't create aliases for unsafe items
+- `safety-10`: Document safety requirements for public unsafe functions

--- a/.agents/skills/unsafe-checker/rules/safety-07-unsafe-pair.md
+++ b/.agents/skills/unsafe-checker/rules/safety-07-unsafe-pair.md
@@ -1,0 +1,107 @@
+---
+id: safety-07
+original_id: P.UNS.SAS.07
+level: P
+impact: MEDIUM
+---
+
+# Provide Unsafe Counterparts for Performance Alongside Safe Methods
+
+## Summary
+
+When providing performance-critical operations that skip safety checks, offer both a safe checked version and an unsafe unchecked version.
+
+## Rationale
+
+Users who need maximum performance can opt into unsafe, while others get safety by default. This follows the "safe by default, unsafe opt-in" principle.
+
+## Bad Example
+
+```rust
+// DON'T: Only provide unsafe version
+impl<T> MySlice<T> {
+    /// Gets an element by index.
+    ///
+    /// # Safety
+    /// Index must be in bounds.
+    pub unsafe fn get(&self, index: usize) -> &T {
+        &*self.ptr.add(index)
+    }
+}
+
+// DON'T: Only provide checked version when performance matters
+impl<T> MySlice<T> {
+    pub fn get(&self, index: usize) -> Option<&T> {
+        if index < self.len {
+            Some(unsafe { &*self.ptr.add(index) })
+        } else {
+            None
+        }
+    }
+    // Missing: get_unchecked for performance-critical code
+}
+```
+
+## Good Example
+
+```rust
+// DO: Provide both versions
+impl<T> MySlice<T> {
+    /// Gets an element by index, returning `None` if out of bounds.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&T> {
+        if index < self.len {
+            // SAFETY: We just verified index < len
+            Some(unsafe { self.get_unchecked(index) })
+        } else {
+            None
+        }
+    }
+
+    /// Gets an element by index without bounds checking.
+    ///
+    /// # Safety
+    ///
+    /// Calling this method with an out-of-bounds index is undefined behavior.
+    #[inline]
+    pub unsafe fn get_unchecked(&self, index: usize) -> &T {
+        debug_assert!(index < self.len, "index out of bounds");
+        &*self.ptr.add(index)
+    }
+
+    /// Gets an element, panicking if out of bounds.
+    #[inline]
+    pub fn get_or_panic(&self, index: usize) -> &T {
+        assert!(index < self.len, "index {} out of bounds for len {}", index, self.len);
+        // SAFETY: We just asserted index < len
+        unsafe { self.get_unchecked(index) }
+    }
+}
+```
+
+## Standard Library Patterns
+
+| Safe Method | Unsafe Counterpart |
+|-------------|-------------------|
+| `slice.get(i)` | `slice.get_unchecked(i)` |
+| `str.chars().nth(i)` | `str.get_unchecked(range)` |
+| `vec.pop()` | `vec.set_len()` + `ptr::read` |
+| `String::from_utf8()` | `String::from_utf8_unchecked()` |
+
+## Naming Conventions
+
+- Safe: `method_name()`
+- Unsafe: `method_name_unchecked()`
+- Or: `get()` vs `get_unchecked()`
+
+## Checklist
+
+- [ ] Does my safe method have an unsafe counterpart for hot paths?
+- [ ] Does my unsafe method have a safe alternative for normal use?
+- [ ] Are both methods documented with their trade-offs?
+- [ ] Does the unsafe version include debug assertions?
+
+## Related Rules
+
+- `general-02`: Don't blindly use unsafe for performance
+- `safety-09`: Add SAFETY comments

--- a/.agents/skills/unsafe-checker/rules/safety-08-no-mut-from-immut.md
+++ b/.agents/skills/unsafe-checker/rules/safety-08-no-mut-from-immut.md
@@ -1,0 +1,124 @@
+---
+id: safety-08
+original_id: P.UNS.SAS.08
+level: P
+impact: CRITICAL
+clippy: mut_from_ref
+---
+
+# Mutable Return from Immutable Parameter is Wrong
+
+## Summary
+
+A function taking `&self` or `&T` must not return `&mut T` to the same data without interior mutability.
+
+## Rationale
+
+Returning `&mut` from `&` violates Rust's aliasing rules. The caller has an immutable borrow, so they can create additional `&` references. Returning `&mut` creates mutable aliasing, which is undefined behavior.
+
+## Bad Example
+
+```rust
+// DON'T: Return &mut from &self
+struct Container {
+    data: i32,
+}
+
+impl Container {
+    // WRONG: This is undefined behavior!
+    pub fn get_mut(&self) -> &mut i32 {
+        unsafe {
+            // Creating &mut from & is ALWAYS wrong
+            &mut *(&self.data as *const i32 as *mut i32)
+        }
+    }
+}
+
+// DON'T: Transmute & to &mut
+fn bad_transmute<T>(reference: &T) -> &mut T {
+    unsafe { std::mem::transmute(reference) }  // UB!
+}
+```
+
+## Good Example
+
+```rust
+use std::cell::{Cell, RefCell, UnsafeCell};
+
+// DO: Use interior mutability types
+struct Container {
+    data: Cell<i32>,          // For Copy types
+    complex: RefCell<String>, // For non-Copy with runtime checks
+}
+
+impl Container {
+    pub fn get(&self) -> i32 {
+        self.data.get()
+    }
+
+    pub fn set(&self, value: i32) {
+        self.data.set(value);
+    }
+
+    pub fn modify_complex(&self, f: impl FnOnce(&mut String)) {
+        f(&mut self.complex.borrow_mut());
+    }
+}
+
+// DO: Use UnsafeCell for custom interior mutability
+struct MyMutex<T> {
+    locked: std::sync::atomic::AtomicBool,
+    data: UnsafeCell<T>,
+}
+
+impl<T> MyMutex<T> {
+    pub fn lock(&self) -> MutexGuard<'_, T> {
+        // Acquire lock...
+        MutexGuard { mutex: self }
+    }
+}
+
+struct MutexGuard<'a, T> {
+    mutex: &'a MyMutex<T>,
+}
+
+impl<T> std::ops::DerefMut for MutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: We hold the lock, so exclusive access is guaranteed
+        unsafe { &mut *self.mutex.data.get() }
+    }
+}
+```
+
+## The Only Valid Pattern
+
+The ONLY way to get `&mut` from `&` is through `UnsafeCell`:
+
+```rust
+use std::cell::UnsafeCell;
+
+struct ValidInteriorMut {
+    data: UnsafeCell<i32>,
+}
+
+impl ValidInteriorMut {
+    // This is sound ONLY because UnsafeCell opts out of aliasing rules
+    // AND we guarantee exclusive access (e.g., through a lock)
+    pub fn get_mut(&self) -> &mut i32 {
+        // Must ensure no other references exist!
+        unsafe { &mut *self.data.get() }
+    }
+}
+```
+
+## Checklist
+
+- [ ] Am I trying to return &mut from a & method?
+- [ ] If yes, am I using UnsafeCell or a type built on it?
+- [ ] Am I guaranteeing exclusive access before creating &mut?
+- [ ] Would Cell, RefCell, or Mutex solve my problem safely?
+
+## Related Rules
+
+- `ptr-05`: Don't manually convert *const to *mut
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/safety-09-safety-comment.md
+++ b/.agents/skills/unsafe-checker/rules/safety-09-safety-comment.md
@@ -1,0 +1,122 @@
+---
+id: safety-09
+original_id: P.UNS.SAS.09
+level: P
+impact: CRITICAL
+clippy: undocumented_unsafe_blocks
+---
+
+# Add SAFETY Comment Before Any Unsafe Block
+
+## Summary
+
+Every `unsafe` block or `unsafe impl` must have a `// SAFETY:` comment explaining why the operation is safe.
+
+## Rationale
+
+SAFETY comments force the author to think about invariants and help reviewers verify correctness. They serve as documentation for future maintainers.
+
+## Bad Example
+
+```rust
+// DON'T: Unsafe without explanation
+fn get_unchecked(slice: &[i32], index: usize) -> i32 {
+    unsafe { *slice.get_unchecked(index) }
+}
+
+// DON'T: Vague or unhelpful comments
+fn bad_comments(ptr: *const i32) -> i32 {
+    // This is unsafe
+    unsafe { *ptr }
+
+    // Trust me
+    unsafe { *ptr }
+
+    // Safe because I know what I'm doing
+    unsafe { *ptr }
+}
+```
+
+## Good Example
+
+```rust
+// DO: Explain the safety invariant
+fn get_unchecked(slice: &[i32], index: usize) -> i32 {
+    // SAFETY: Caller guarantees index < slice.len()
+    unsafe { *slice.get_unchecked(index) }
+}
+
+// DO: Be specific about what makes it safe
+fn read_header(buffer: &[u8]) -> Header {
+    assert!(buffer.len() >= std::mem::size_of::<Header>());
+
+    // SAFETY:
+    // - buffer.len() >= size_of::<Header>() (asserted above)
+    // - buffer is aligned for u8, which is compatible with any alignment
+    // - Header is #[repr(C)] and has no padding requirements
+    unsafe {
+        std::ptr::read_unaligned(buffer.as_ptr() as *const Header)
+    }
+}
+
+// DO: Document unsafe impl
+struct MySendType(*mut i32);
+
+// SAFETY: The pointer is to thread-local storage that is only accessed
+// from the owning thread. MySendType is only sent when the TLS slot
+// is being transferred between threads with proper synchronization.
+unsafe impl Send for MySendType {}
+
+// DO: Multi-line for complex invariants
+fn complex_operation(data: &mut [u8], ranges: &[(usize, usize)]) {
+    for &(start, end) in ranges {
+        // SAFETY:
+        // 1. All ranges were validated to be within data.len()
+        //    in the calling function `validate_ranges()`
+        // 2. Ranges are non-overlapping (invariant of RangeSet)
+        // 3. We have &mut access to data, so no aliasing
+        unsafe {
+            let ptr = data.as_mut_ptr().add(start);
+            std::ptr::write_bytes(ptr, 0, end - start);
+        }
+    }
+}
+```
+
+## SAFETY Comment Format
+
+```rust
+// SAFETY: <brief explanation>
+
+// Or for complex cases:
+// SAFETY:
+// - Invariant 1: explanation
+// - Invariant 2: explanation
+// - Why this is upheld: explanation
+```
+
+## What to Include
+
+1. **What invariants must hold** for this to be safe
+2. **Why those invariants hold** at this specific call site
+3. **What could go wrong** if the invariants were violated (optional but helpful)
+
+## Clippy Configuration
+
+```toml
+# clippy.toml
+accept-comment-above-statement = true
+accept-comment-above-attributes = true
+```
+
+## Checklist
+
+- [ ] Does every unsafe block have a SAFETY comment?
+- [ ] Does the comment explain WHY it's safe, not just WHAT it does?
+- [ ] Are all relevant invariants mentioned?
+- [ ] Would a reviewer understand the safety argument?
+
+## Related Rules
+
+- `safety-02`: Verify safety invariants
+- `safety-10`: Add Safety section in docs for public unsafe functions

--- a/.agents/skills/unsafe-checker/rules/safety-10-safety-doc.md
+++ b/.agents/skills/unsafe-checker/rules/safety-10-safety-doc.md
@@ -1,0 +1,127 @@
+---
+id: safety-10
+original_id: G.UNS.SAS.01
+level: G
+impact: HIGH
+clippy: missing_safety_doc
+---
+
+# Add Safety Section in Docs for Public Unsafe Functions
+
+## Summary
+
+Public `unsafe` functions must have a `# Safety` section in their documentation explaining the caller's obligations.
+
+## Rationale
+
+Unlike SAFETY comments (which explain why an unsafe block is sound), `# Safety` docs tell callers what they must guarantee. Without this, users cannot safely call the function.
+
+## Bad Example
+
+```rust
+// DON'T: Unsafe function without safety docs
+pub unsafe fn process_buffer(ptr: *const u8, len: usize) {
+    // ...
+}
+
+// DON'T: Safety docs that don't explain requirements
+/// Processes a buffer.
+///
+/// This function is unsafe.  // Not helpful!
+pub unsafe fn process_buffer(ptr: *const u8, len: usize) {
+    // ...
+}
+```
+
+## Good Example
+
+```rust
+/// Processes a buffer of bytes.
+///
+/// # Safety
+///
+/// The caller must ensure that:
+///
+/// - `ptr` is non-null and properly aligned for `u8`
+/// - `ptr` points to at least `len` consecutive, initialized bytes
+/// - The memory referenced by `ptr` is not mutated during this call
+/// - `len` does not exceed `isize::MAX`
+///
+/// # Examples
+///
+/// ```
+/// let data = [1u8, 2, 3, 4];
+/// // SAFETY: data is a valid slice, we pass its pointer and length
+/// unsafe { process_buffer(data.as_ptr(), data.len()) };
+/// ```
+pub unsafe fn process_buffer(ptr: *const u8, len: usize) {
+    // ...
+}
+
+/// Creates a `Vec<T>` from raw parts.
+///
+/// # Safety
+///
+/// This is highly unsafe due to the number of invariants that must
+/// be upheld by the caller:
+///
+/// * `ptr` must have been allocated via the global allocator
+/// * `T` must have the same alignment as the original allocation
+/// * `capacity` must be the capacity the pointer was allocated with
+/// * `length` must be less than or equal to `capacity`
+/// * The first `length` values must be properly initialized
+/// * The allocated memory must not be used elsewhere
+///
+/// Violating these may cause undefined behavior including
+/// use-after-free, double-free, and memory corruption.
+pub unsafe fn from_raw_parts(ptr: *mut T, length: usize, capacity: usize) -> Vec<T> {
+    // ...
+}
+```
+
+## Safety Documentation Template
+
+```rust
+/// Brief description of what the function does.
+///
+/// # Safety
+///
+/// The caller must ensure that:
+///
+/// - Requirement 1: detailed explanation
+/// - Requirement 2: detailed explanation
+///
+/// # Panics (if applicable)
+///
+/// Panics if...
+///
+/// # Examples
+///
+/// ```
+/// // SAFETY: explanation of why this call is safe
+/// unsafe { function_name(...) };
+/// ```
+```
+
+## What to Document
+
+| Category | Example |
+|----------|---------|
+| Pointer validity | "ptr must be non-null and aligned" |
+| Memory state | "must point to initialized memory" |
+| Aliasing | "no other references to this memory may exist" |
+| Lifetime | "pointer must be valid for the duration of the call" |
+| Thread safety | "must not be called concurrently with..." |
+| Invariants | "len must not exceed isize::MAX" |
+
+## Checklist
+
+- [ ] Does the function have a `# Safety` section?
+- [ ] Are ALL caller obligations listed?
+- [ ] Is each requirement specific and verifiable?
+- [ ] Does the example show correct usage with SAFETY comment?
+
+## Related Rules
+
+- `safety-09`: SAFETY comments for unsafe blocks
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/unsafe-checker/rules/safety-11-assert-not-debug.md
+++ b/.agents/skills/unsafe-checker/rules/safety-11-assert-not-debug.md
@@ -1,0 +1,105 @@
+---
+id: safety-11
+original_id: G.UNS.SAS.02
+level: G
+impact: MEDIUM
+clippy: debug_assert_with_mut_call
+---
+
+# Use assert! Instead of debug_assert! in Unsafe Functions
+
+## Summary
+
+In `unsafe` functions or functions containing unsafe blocks, prefer `assert!` over `debug_assert!` for checking safety invariants.
+
+## Rationale
+
+`debug_assert!` is compiled out in release builds. If an invariant is important enough to check for safety, it should be checked in all builds to catch violations.
+
+## Bad Example
+
+```rust
+// DON'T: Use debug_assert for safety-critical checks
+pub unsafe fn get_unchecked(slice: &[i32], index: usize) -> &i32 {
+    debug_assert!(index < slice.len());  // Gone in release!
+    &*slice.as_ptr().add(index)
+}
+
+// DON'T: Rely on debug_assert for FFI safety
+pub unsafe fn call_c_function(ptr: *const Data) {
+    debug_assert!(!ptr.is_null());  // Won't catch bugs in release
+    ffi::process_data(ptr);
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use assert! for safety checks (when performance allows)
+pub unsafe fn get_unchecked(slice: &[i32], index: usize) -> &i32 {
+    assert!(index < slice.len(), "index {} out of bounds for len {}", index, slice.len());
+    &*slice.as_ptr().add(index)
+}
+
+// DO: Use debug_assert when CALLER is responsible
+/// # Safety
+/// index must be less than slice.len()
+pub unsafe fn get_unchecked_fast(slice: &[i32], index: usize) -> &i32 {
+    // Caller is responsible; debug_assert just helps catch bugs during development
+    debug_assert!(index < slice.len());
+    &*slice.as_ptr().add(index)
+}
+
+// DO: Use assert for internal safety, debug_assert for caller obligations
+pub fn get_checked(slice: &[i32], index: usize) -> Option<&i32> {
+    if index < slice.len() {
+        // SAFETY: We just checked index < len
+        // debug_assert is fine here because the if-check is the real guard
+        Some(unsafe {
+            debug_assert!(index < slice.len()); // Redundant, just for documentation
+            &*slice.as_ptr().add(index)
+        })
+    } else {
+        None
+    }
+}
+```
+
+## When to Use Each
+
+| Assertion | Use When |
+|-----------|----------|
+| `assert!` | Invariant is not already checked; function is called with untrusted input |
+| `debug_assert!` | Invariant is the caller's responsibility (documented in `# Safety`); performance-critical |
+| No assert | Invariant is enforced by types or prior checks in the same function |
+
+## Hybrid Approach
+
+```rust
+// Use cfg to have both safety and performance
+pub unsafe fn process(slice: &[u8], index: usize) {
+    // Always check in tests and debug
+    #[cfg(any(test, debug_assertions))]
+    assert!(index < slice.len());
+
+    // Optional: paranoid mode for production
+    #[cfg(feature = "paranoid")]
+    assert!(index < slice.len());
+
+    // SAFETY: Caller guarantees index < len (checked in debug)
+    let ptr = slice.as_ptr().add(index);
+    // ...
+}
+```
+
+## Checklist
+
+- [ ] Is this a safety-critical invariant?
+- [ ] Who is responsible for upholding it (caller or this function)?
+- [ ] Can the assertion be optimized away when provably true?
+- [ ] What's the performance impact of the assertion?
+
+## Related Rules
+
+- `safety-02`: Verify safety invariants
+- `safety-09`: SAFETY comments

--- a/.agents/skills/unsafe-checker/rules/union-01-avoid-except-ffi.md
+++ b/.agents/skills/unsafe-checker/rules/union-01-avoid-except-ffi.md
@@ -1,0 +1,117 @@
+---
+id: union-01
+original_id: P.UNS.UNI.01
+level: P
+impact: HIGH
+---
+
+# Avoid Union Except for C Interop
+
+## Summary
+
+Only use `union` for FFI with C code. For Rust-only code, use `enum` with explicit tags.
+
+## Rationale
+
+- Unions require unsafe to read (any field access is unsafe)
+- Easy to read wrong field, causing undefined behavior
+- Enums are type-safe and the compiler tracks the active variant
+- Unions don't run destructors properly
+
+## Bad Example
+
+```rust
+// DON'T: Use union for space optimization in Rust-only code
+union IntOrFloat {
+    i: i32,
+    f: f32,
+}
+
+fn bad_usage() {
+    let mut u = IntOrFloat { i: 42 };
+
+    // BAD: Reading wrong field is UB
+    let f = unsafe { u.f };  // UB if i was the last written field
+}
+
+// DON'T: Use union for variant types
+union Variant {
+    string: std::mem::ManuallyDrop<String>,
+    number: i64,
+}
+
+// Problems:
+// 1. Must manually track which variant is active
+// 2. Must manually call drop on String variant
+// 3. Easy to have memory leaks or double-free
+```
+
+## Good Example
+
+```rust
+// DO: Use enum for variant types in Rust
+enum Variant {
+    String(String),
+    Number(i64),
+}
+
+// Compiler tracks active variant, runs correct destructor
+
+// DO: Use union only for C FFI
+#[repr(C)]
+union CUnion {
+    i: i32,
+    f: f32,
+}
+
+// When interfacing with C code that uses this union
+extern "C" {
+    fn c_function_returns_union() -> CUnion;
+    fn c_function_takes_union(u: CUnion);
+}
+
+// DO: Wrap in safe API with explicit variant tracking
+#[repr(C)]
+pub struct SafeUnion {
+    tag: u8,
+    data: CUnion,
+}
+
+impl SafeUnion {
+    pub fn as_int(&self) -> Option<i32> {
+        if self.tag == 0 {
+            // SAFETY: Tag indicates integer variant is active
+            Some(unsafe { self.data.i })
+        } else {
+            None
+        }
+    }
+}
+```
+
+## When Union Is Appropriate
+
+1. **C FFI**: Matching C union layout for interoperability
+2. **MaybeUninit**: The standard library uses union internally
+3. **Very low-level optimization**: Only after profiling and careful safety analysis
+
+## Alternatives to Union
+
+| Use Case | Instead of Union | Use |
+|----------|-----------------|-----|
+| Variant types | union + tag | `enum` |
+| Optional value | union + bool | `Option<T>` |
+| Type punning | union | `transmute` or `from_ne_bytes` |
+| Uninitialized memory | union | `MaybeUninit<T>` |
+
+## Checklist
+
+- [ ] Is this for C FFI? If not, use enum
+- [ ] If union is necessary, is there a tag tracking active variant?
+- [ ] Are destructors handled correctly for Drop types?
+- [ ] Is the union #[repr(C)] for FFI?
+
+## Related Rules
+
+- `union-02`: Don't use union variants across lifetimes
+- `ffi-13`: Ensure consistent data layout

--- a/.agents/skills/unsafe-checker/rules/union-02-no-cross-lifetime.md
+++ b/.agents/skills/unsafe-checker/rules/union-02-no-cross-lifetime.md
@@ -1,0 +1,121 @@
+---
+id: union-02
+original_id: P.UNS.UNI.02
+level: P
+impact: CRITICAL
+---
+
+# Do Not Use Union Variants Across Different Lifetimes
+
+## Summary
+
+Do not write to one union field and read from another field that has a different lifetime or references data with a different lifetime.
+
+## Rationale
+
+Union fields share the same memory. If one field stores a reference with lifetime `'a` and you read it as a reference with lifetime `'b`, you bypass lifetime checking and can create dangling references.
+
+## Bad Example
+
+```rust
+// DON'T: Extend lifetime through union
+union LifetimeBypass<'a, 'b> {
+    short: &'a str,
+    long: &'b str,
+}
+
+fn bad_lifetime_extension<'a, 'b>(short: &'a str) -> &'b str {
+    let u = LifetimeBypass { short };
+    // BAD: Reading with different lifetime is UB
+    unsafe { u.long }
+}
+
+fn exploit() {
+    let long_ref: &'static str;
+    {
+        let temp = String::from("temporary");
+        // Extend local reference to 'static - dangling pointer!
+        long_ref = bad_lifetime_extension(&temp);
+    }
+    // temp is dropped, long_ref is dangling
+    println!("{}", long_ref);  // UB: use after free
+}
+```
+
+## Good Example
+
+```rust
+// DO: Use same lifetime for all reference fields
+union SafeUnion<'a> {
+    str_ref: &'a str,
+    bytes_ref: &'a [u8],
+}
+
+fn safe_conversion<'a>(s: &'a str) -> &'a [u8] {
+    let u = SafeUnion { str_ref: s };
+    // SAFETY: Both fields have same lifetime 'a
+    // AND str and [u8] have compatible representations
+    unsafe { u.bytes_ref }
+}
+
+// Better: Just use as_bytes()
+fn better_conversion(s: &str) -> &[u8] {
+    s.as_bytes()
+}
+
+// DO: Use MaybeUninit for delayed initialization, not lifetime tricks
+use std::mem::MaybeUninit;
+
+fn delayed_init<T>(init: impl FnOnce() -> T) -> T {
+    let mut value: MaybeUninit<T> = MaybeUninit::uninit();
+    value.write(init());
+    unsafe { value.assume_init() }
+}
+```
+
+## Why This Is Dangerous
+
+The Rust lifetime system prevents use-after-free by tracking how long references are valid. Unions can subvert this:
+
+```
+Memory: [pointer to "hello"]
+
+Union as 'short: points to stack memory (valid during function)
+Union as 'long:  claims to point to valid memory forever
+
+Reality: After function returns, pointer is dangling
+```
+
+## Safe Union Patterns
+
+```rust
+// Pattern 1: All fields have same lifetime
+union SameLifetime<'a, T, U> {
+    a: &'a T,
+    b: &'a U,
+}
+
+// Pattern 2: No references at all
+#[repr(C)]
+union NoRefs {
+    i: i32,
+    f: f32,
+}
+
+// Pattern 3: Use ManuallyDrop for owned values (careful with Drop!)
+union OwnedUnion {
+    s: std::mem::ManuallyDrop<String>,
+    v: std::mem::ManuallyDrop<Vec<u8>>,
+}
+```
+
+## Checklist
+
+- [ ] Do all reference fields have the same lifetime parameter?
+- [ ] Am I trying to extend a lifetime through union? (If yes, stop!)
+- [ ] For owned types, am I handling Drop correctly?
+
+## Related Rules
+
+- `union-01`: Avoid union except for C interop
+- `safety-02`: Verify safety invariants

--- a/.agents/skills/verification-before-completion/SKILL.md
+++ b/.agents/skills/verification-before-completion/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: verification-before-completion
+description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always
+---
+
+# Verification Before Completion
+
+## Overview
+
+Claiming work is complete without verification is dishonesty, not efficiency.
+
+**Core principle:** Evidence before claims, always.
+
+**Violating the letter of this rule is violating the spirit of this rule.**
+
+## The Iron Law
+
+```
+NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE
+```
+
+If you haven't run the verification command in this message, you cannot claim it passes.
+
+## The Gate Function
+
+```
+BEFORE claiming any status or expressing satisfaction:
+
+1. IDENTIFY: What command proves this claim?
+2. RUN: Execute the FULL command (fresh, complete)
+3. READ: Full output, check exit code, count failures
+4. VERIFY: Does output confirm the claim?
+   - If NO: State actual status with evidence
+   - If YES: State claim WITH evidence
+5. ONLY THEN: Make the claim
+
+Skip any step = lying, not verifying
+```
+
+## Common Failures
+
+| Claim | Requires | Not Sufficient |
+|-------|----------|----------------|
+| Tests pass | Test command output: 0 failures | Previous run, "should pass" |
+| Linter clean | Linter output: 0 errors | Partial check, extrapolation |
+| Build succeeds | Build command: exit 0 | Linter passing, logs look good |
+| Bug fixed | Test original symptom: passes | Code changed, assumed fixed |
+| Regression test works | Red-green cycle verified | Test passes once |
+| Agent completed | VCS diff shows changes | Agent reports "success" |
+| Requirements met | Line-by-line checklist | Tests passing |
+
+## Red Flags - STOP
+
+- Using "should", "probably", "seems to"
+- Expressing satisfaction before verification ("Great!", "Perfect!", "Done!", etc.)
+- About to commit/push/PR without verification
+- Trusting agent success reports
+- Relying on partial verification
+- Thinking "just this once"
+- Tired and wanting work over
+- **ANY wording implying success without having run verification**
+
+## Rationalization Prevention
+
+| Excuse | Reality |
+|--------|---------|
+| "Should work now" | RUN the verification |
+| "I'm confident" | Confidence ≠ evidence |
+| "Just this once" | No exceptions |
+| "Linter passed" | Linter ≠ compiler |
+| "Agent said success" | Verify independently |
+| "I'm tired" | Exhaustion ≠ excuse |
+| "Partial check is enough" | Partial proves nothing |
+| "Different words so rule doesn't apply" | Spirit over letter |
+
+## Key Patterns
+
+**Tests:**
+```
+✅ [Run test command] [See: 34/34 pass] "All tests pass"
+❌ "Should pass now" / "Looks correct"
+```
+
+**Regression tests (TDD Red-Green):**
+```
+✅ Write → Run (pass) → Revert fix → Run (MUST FAIL) → Restore → Run (pass)
+❌ "I've written a regression test" (without red-green verification)
+```
+
+**Build:**
+```
+✅ [Run build] [See: exit 0] "Build passes"
+❌ "Linter passed" (linter doesn't check compilation)
+```
+
+**Requirements:**
+```
+✅ Re-read plan → Create checklist → Verify each → Report gaps or completion
+❌ "Tests pass, phase complete"
+```
+
+**Agent delegation:**
+```
+✅ Agent reports success → Check VCS diff → Verify changes → Report actual state
+❌ Trust agent report
+```
+
+## Why This Matters
+
+From 24 failure memories:
+- your human partner said "I don't believe you" - trust broken
+- Undefined functions shipped - would crash
+- Missing requirements shipped - incomplete features
+- Time wasted on false completion → redirect → rework
+- Violates: "Honesty is a core value. If you lie, you'll be replaced."
+
+## When To Apply
+
+**ALWAYS before:**
+- ANY variation of success/completion claims
+- ANY expression of satisfaction
+- ANY positive statement about work state
+- Committing, PR creation, task completion
+- Moving to next task
+- Delegating to agents
+
+**Rule applies to:**
+- Exact phrases
+- Paraphrases and synonyms
+- Implications of success
+- ANY communication suggesting completion/correctness
+
+## The Bottom Line
+
+**No shortcuts for verification.**
+
+Run the command. Read the output. THEN claim the result.
+
+This is non-negotiable.

--- a/.agents/skills/writing-plans/SKILL.md
+++ b/.agents/skills/writing-plans/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: writing-plans
+description: Use when you have a spec or requirements for a multi-step task, before touching code
+---
+
+# Writing Plans
+
+## Overview
+
+Write comprehensive implementation plans assuming the engineer has zero context for our codebase and questionable taste. Document everything they need to know: which files to touch for each task, code, testing, docs they might need to check, how to test it. Give them the whole plan as bite-sized tasks. DRY. YAGNI. TDD. Frequent commits.
+
+Assume they are a skilled developer, but know almost nothing about our toolset or problem domain. Assume they don't know good test design very well.
+
+**Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
+
+**Context:** If working in an isolated worktree, it should have been created via the `superpowers:using-git-worktrees` skill at execution time.
+
+**Save plans to:** `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md`
+- (User preferences for plan location override this default)
+
+## Scope Check
+
+If the spec covers multiple independent subsystems, it should have been broken into sub-project specs during brainstorming. If it wasn't, suggest breaking this into separate plans — one per subsystem. Each plan should produce working, testable software on its own.
+
+## File Structure
+
+Before defining tasks, map out which files will be created or modified and what each one is responsible for. This is where decomposition decisions get locked in.
+
+- Design units with clear boundaries and well-defined interfaces. Each file should have one clear responsibility.
+- You reason best about code you can hold in context at once, and your edits are more reliable when files are focused. Prefer smaller, focused files over large ones that do too much.
+- Files that change together should live together. Split by responsibility, not by technical layer.
+- In existing codebases, follow established patterns. If the codebase uses large files, don't unilaterally restructure - but if a file you're modifying has grown unwieldy, including a split in the plan is reasonable.
+
+This structure informs the task decomposition. Each task should produce self-contained changes that make sense independently.
+
+## Bite-Sized Task Granularity
+
+**Each step is one action (2-5 minutes):**
+- "Write the failing test" - step
+- "Run it to make sure it fails" - step
+- "Implement the minimal code to make the test pass" - step
+- "Run the tests and make sure they pass" - step
+- "Commit" - step
+
+## Plan Document Header
+
+**Every plan MUST start with this header:**
+
+```markdown
+# [Feature Name] Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries]
+
+---
+```
+
+## Task Structure
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create: `exact/path/to/file.py`
+- Modify: `exact/path/to/existing.py:123-145`
+- Test: `tests/exact/path/to/test.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_specific_behavior():
+    result = function(input)
+    assert result == expected
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: FAIL with "function not defined"
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+def function(input):
+    return expected
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/path/test.py::test_name -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/path/test.py src/path/file.py
+git commit -m "feat: add specific feature"
+```
+````
+
+## No Placeholders
+
+Every step must contain the actual content an engineer needs. These are **plan failures** — never write them:
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without actual test code)
+- "Similar to Task N" (repeat the code — the engineer may be reading tasks out of order)
+- Steps that describe what to do without showing how (code blocks required for code steps)
+- References to types, functions, or methods not defined in any task
+
+## Remember
+- Exact file paths always
+- Complete code in every step — if a step changes code, show the code
+- Exact commands with expected output
+- DRY, YAGNI, TDD, frequent commits
+
+## Self-Review
+
+After writing the complete plan, look at the spec with fresh eyes and check the plan against it. This is a checklist you run yourself — not a subagent dispatch.
+
+**1. Spec coverage:** Skim each section/requirement in the spec. Can you point to a task that implements it? List any gaps.
+
+**2. Placeholder scan:** Search your plan for red flags — any of the patterns from the "No Placeholders" section above. Fix them.
+
+**3. Type consistency:** Do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in Task 3 but `clearFullLayers()` in Task 7 is a bug.
+
+If you find issues, fix them inline. No need to re-review — just fix and move on. If you find a spec requirement with no task, add the task.
+
+## Execution Handoff
+
+After saving the plan, offer execution choice:
+
+**"Plan complete and saved to `docs/superpowers/plans/<filename>.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?"**
+
+**If Subagent-Driven chosen:**
+- **REQUIRED SUB-SKILL:** Use superpowers:subagent-driven-development
+- Fresh subagent per task + two-stage review
+
+**If Inline Execution chosen:**
+- **REQUIRED SUB-SKILL:** Use superpowers:executing-plans
+- Batch execution with checkpoints for review

--- a/.agents/skills/writing-plans/plan-document-reviewer-prompt.md
+++ b/.agents/skills/writing-plans/plan-document-reviewer-prompt.md
@@ -1,0 +1,49 @@
+# Plan Document Reviewer Prompt Template
+
+Use this template when dispatching a plan document reviewer subagent.
+
+**Purpose:** Verify the plan is complete, matches the spec, and has proper task decomposition.
+
+**Dispatch after:** The complete plan is written.
+
+```
+Task tool (general-purpose):
+  description: "Review plan document"
+  prompt: |
+    You are a plan document reviewer. Verify this plan is complete and ready for implementation.
+
+    **Plan to review:** [PLAN_FILE_PATH]
+    **Spec for reference:** [SPEC_FILE_PATH]
+
+    ## What to Check
+
+    | Category | What to Look For |
+    |----------|------------------|
+    | Completeness | TODOs, placeholders, incomplete tasks, missing steps |
+    | Spec Alignment | Plan covers spec requirements, no major scope creep |
+    | Task Decomposition | Tasks have clear boundaries, steps are actionable |
+    | Buildability | Could an engineer follow this plan without getting stuck? |
+
+    ## Calibration
+
+    **Only flag issues that would cause real problems during implementation.**
+    An implementer building the wrong thing or getting stuck is an issue.
+    Minor wording, stylistic preferences, and "nice to have" suggestions are not.
+
+    Approve unless there are serious gaps — missing requirements from the spec,
+    contradictory steps, placeholder content, or tasks so vague they can't be acted on.
+
+    ## Output Format
+
+    ## Plan Review
+
+    **Status:** Approved | Issues Found
+
+    **Issues (if any):**
+    - [Task X, Step Y]: [specific issue] - [why it matters for implementation]
+
+    **Recommendations (advisory, do not block approval):**
+    - [suggestions for improvement]
+```
+
+**Reviewer returns:** Status, Issues (if any), Recommendations

--- a/.cursor/skills/deltasafe/SKILL.md
+++ b/.cursor/skills/deltasafe/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: deltasafe
+description: Deltasafe LAN file sync tool conventions. Use when editing src/, tests/, or working on TCP transfer protocol, AES encryption, PBKDF2 passwords, server/client sync, or discovery.
+paths:
+  - "src/**/*.rs"
+  - "tests/**/*.rs"
+  - "Cargo.toml"
+---
+
+# Deltasafe Project Skill
+
+## Architecture
+
+- **CLI** (`cli.rs`, `main.rs`): `server`, `sync`, `discover`, `connect`, `watch`
+- **Client** (`sync.rs`): walks source dir, sends JSON `FileHeader`, then framed encrypted chunks
+- **Server** (`server.rs`): accepts multiple files per TCP connection in a loop
+- **Crypto** (`crypto.rs`): PBKDF2 password derivation, hex keys
+- **Discovery** (`discovery.rs`): port scan (mDNS stub only)
+- **Utils** (`utils.rs`): key/address resolution, `KeyRole::Client` vs `KeyRole::Server`
+
+## Transfer Protocol
+
+1. Client sends `u32 BE header_len` + JSON `FileHeader`
+2. Server replies `1` byte ack (`1` = ok, `0` = reject)
+3. For each chunk: `u32 BE payload_len` + `IV (16 bytes)` + AES-256-CBC ciphertext (PKCS7)
+4. Server decrypts until plaintext bytes == `header.file_size`
+5. Repeat from step 1 for next file on same connection
+
+## Password Mode
+
+- **Client** (`KeyRole::Client`): generates random 16-byte PBKDF2 salt per sync session, puts hex in `FileHeader.pbkdf2_salt`
+- **Server** (`KeyRole::Server`): must start with `--password`; re-derives key from header salt + stored password
+- **Hex key mode**: `pbkdf2_salt` is `None`; both sides use the same `--key`
+
+## Conventions
+
+- Received files go to `received_files/` preserving `relative_path`
+- Chunk size constant: `CHUNK_SIZE = 4096` (plaintext read size; encrypted payload is larger)
+- Prefer `anyhow::Result` over panics in server decrypt path
+- Share `FileHeader` and `calculate_file_hash` from `sync.rs`; do not duplicate in `server.rs`
+- Run `cargo test` before finishing changes
+
+## Common Tasks
+
+| Task | Guidance |
+|------|----------|
+| Fix transfer bugs | Verify framed length prefix on both client and server |
+| Add file metadata | Extend `FileHeader`; keep backward-compatible serde defaults |
+| Improve discovery | Implement real mDNS in `discover_via_mdns`, or document port-scan limits |
+| Async refactor | Keep protocol logic testable; avoid blocking tokio runtime in CLI paths |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "deltasafe"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -78,13 +78,15 @@ Deltasafe artık **kullanıcı dostu** hale geldi! Karmaşık hex anahtarlar yer
 deltasafe server  # Geçici anahtar gösterilir
 ```
 
-### 🔍 Sunucu Keşfi (Yeni!)
+### 🔍 Sunucu Keşfi
 
 LAN'daki mevcut Deltasafe sunucularını otomatik olarak keşfedin:
 
 ```bash
 ./target/release/deltasafe discover
 ```
+
+> **Not:** mDNS (Zeroconf) keşfi henüz tamamlanmamıştır. `--auto` modu şu an yerel ağda **port taraması** (12340–12349) kullanır. Güvenilir keşif için `--target IP:port` ile manuel hedef belirtmeniz önerilir.
 
 ### 🖥️ Sunucu Modu
 

--- a/README.md
+++ b/README.md
@@ -78,15 +78,13 @@ Deltasafe artık **kullanıcı dostu** hale geldi! Karmaşık hex anahtarlar yer
 deltasafe server  # Geçici anahtar gösterilir
 ```
 
-### 🔍 Sunucu Keşfi
+### 🔍 Sunucu Keşfi (Yeni!)
 
 LAN'daki mevcut Deltasafe sunucularını otomatik olarak keşfedin:
 
 ```bash
 ./target/release/deltasafe discover
 ```
-
-> **Not:** mDNS (Zeroconf) keşfi henüz tamamlanmamıştır. `--auto` modu şu an yerel ağda **port taraması** (12340–12349) kullanır. Güvenilir keşif için `--target IP:port` ile manuel hedef belirtmeniz önerilir.
 
 ### 🖥️ Sunucu Modu
 
@@ -136,6 +134,31 @@ LAN'daki mevcut Deltasafe sunucularını otomatik olarak keşfedin:
 *   `--password`: Basit şifre (önerilen)
 *   `--key`: 64 karakterlik hex anahtar (ileri seviye)
 *   `--address`: Sunucu adresi (opsiyonel, otomatik tespit)
+
+## 🤖 Agent Skills
+
+Bu proje Cursor Agent Skills kullanır. Skill'ler `.agents/skills/` ve `.cursor/skills/` altında otomatik yüklenir.
+
+**Kurulu Rust skill paketi:** [ZhangHanDong/rust-skills](https://skills.sh/zhanghandong/rust-skills) (skills.sh'de ~26K kurulum)
+
+| Skill | Ne zaman devreye girer |
+|-------|------------------------|
+| `domain-cli` | Clap CLI, alt komutlar, stdout/stderr |
+| `m06-error-handling` | `anyhow`, `Result`, hata mesajları |
+| `m07-concurrency` | Tokio, thread, TCP eşzamanlılık |
+| `m01-ownership` | Borrow checker, lifetime sorunları |
+| `m10-performance` | Chunk transfer, I/O optimizasyonu |
+| `unsafe-checker` | Kripto / düşük seviye kod incelemesi |
+| `deltasafe` | Proje protokolü ve mimari kuralları |
+
+Yeniden kurulum:
+
+```bash
+npx skills add ZhangHanDong/rust-skills -a cursor -y \
+  --skill coding-guidelines --skill domain-cli --skill m01-ownership \
+  --skill m06-error-handling --skill m07-concurrency --skill m10-performance \
+  --skill unsafe-checker
+```
 
 ## 🧪 Test Etme
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,14 +1,61 @@
 {
-  "version": 1,
-  "source": "https://github.com/ZhangHanDong/rust-skills",
-  "skills": [
-    "coding-guidelines",
-    "domain-cli",
-    "m01-ownership",
-    "m06-error-handling",
-    "m07-concurrency",
-    "m10-performance",
-    "unsafe-checker"
+  "version": 2,
+  "packages": [
+    {
+      "name": "rust-skills",
+      "source": "https://github.com/ZhangHanDong/rust-skills",
+      "skills": [
+        "coding-guidelines",
+        "domain-cli",
+        "m01-ownership",
+        "m06-error-handling",
+        "m07-concurrency",
+        "m10-performance",
+        "unsafe-checker"
+      ],
+      "installCommand": "npx skills add ZhangHanDong/rust-skills -a cursor -y --skill coding-guidelines --skill domain-cli --skill m01-ownership --skill m06-error-handling --skill m07-concurrency --skill m10-performance --skill unsafe-checker"
+    },
+    {
+      "name": "superpowers",
+      "source": "https://github.com/obra/superpowers",
+      "skills": [
+        "test-driven-development",
+        "systematic-debugging",
+        "verification-before-completion",
+        "executing-plans",
+        "writing-plans",
+        "requesting-code-review",
+        "receiving-code-review"
+      ],
+      "installCommand": "npx skills add obra/superpowers -a cursor -y --skill test-driven-development --skill systematic-debugging --skill verification-before-completion --skill executing-plans --skill writing-plans --skill requesting-code-review --skill receiving-code-review"
+    },
+    {
+      "name": "cursor-best-practices",
+      "source": "https://github.com/HKTITAN/cursor-best-practices",
+      "skills": ["cursor-best-practices"],
+      "installCommand": "npx skills add HKTITAN/cursor-best-practices -a cursor -y"
+    },
+    {
+      "name": "anthropics-skills",
+      "source": "https://github.com/anthropics/skills",
+      "skills": ["skill-creator"],
+      "installCommand": "npx skills add anthropics/skills -a cursor -y --skill skill-creator"
+    },
+    {
+      "name": "agent-toolkit",
+      "source": "https://github.com/softaworks/agent-toolkit",
+      "skills": ["crafting-effective-readmes", "mermaid-diagrams"],
+      "installCommand": "npx skills add softaworks/agent-toolkit -a cursor -y --skill crafting-effective-readmes --skill mermaid-diagrams"
+    },
+    {
+      "name": "cursor-skills",
+      "source": "https://github.com/gardusig/cursor-skills",
+      "note": "Git/PR workflow pack; includes internal-* delegation skills required by gh-* commands",
+      "installCommand": "npx skills add gardusig/cursor-skills -a cursor -y"
+    }
   ],
-  "installCommand": "npx skills add ZhangHanDong/rust-skills -a cursor -y --skill coding-guidelines --skill domain-cli --skill m01-ownership --skill m06-error-handling --skill m07-concurrency --skill m10-performance --skill unsafe-checker"
+  "projectSkills": [
+    ".cursor/skills/deltasafe"
+  ],
+  "reinstallAll": "Run each installCommand from the repository root, then verify .agents/skills/ and .cursor/skills/"
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "source": "https://github.com/ZhangHanDong/rust-skills",
+  "skills": [
+    "coding-guidelines",
+    "domain-cli",
+    "m01-ownership",
+    "m06-error-handling",
+    "m07-concurrency",
+    "m10-performance",
+    "unsafe-checker"
+  ],
+  "installCommand": "npx skills add ZhangHanDong/rust-skills -a cursor -y --skill coding-guidelines --skill domain-cli --skill m01-ownership --skill m06-error-handling --skill m07-concurrency --skill m10-performance --skill unsafe-checker"
+}

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -74,6 +74,14 @@ pub fn validate_password_strength(password: &str) -> Result<()> {
     Ok(())
 }
 
+/// Rastgele PBKDF2 salt üretir
+pub fn generate_random_salt() -> [u8; SALT_LENGTH] {
+    use rand::Rng;
+    let mut salt = [0u8; SALT_LENGTH];
+    rand::thread_rng().fill(&mut salt);
+    salt
+}
+
 /// Rastgele hex anahtar üretir
 pub fn generate_random_hex_key() -> String {
     use rand::Rng;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! 
 //! // Senkronizasyon başlatma
 //! let key = [0u8; 32]; // 32 baytlık AES anahtarı
-//! start_sync("./source_folder", "192.168.1.100:12345", &key);
+//! start_sync("./source_folder", "192.168.1.100:12345", &key, None);
 //! ```
 
 pub mod cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,14 @@ mod sync;
 mod server;
 mod crypto;
 mod discovery;
-mod utils; // Yeni eklenen modül
+mod utils;
 
 use cli::{Cli, Commands};
 use clap::Parser;
 use sync::start_sync;
 use server::start_server;
-use anyhow::Result; // crypto ve discovery use'ları utils'e taşındı
+use utils::KeyRole;
+use anyhow::Result;
 
 #[tokio::main]
 async fn main() {
@@ -26,9 +27,9 @@ async fn run_command(command: &Commands) -> Result<()> {
         Commands::Sync { source, target, auto, auto_select, key, password } => {
             let target_address = utils::resolve_target_address(target.as_deref(), *auto, *auto_select).await?;
             println!("Sync başlatılıyor: {} -> {}", source, target_address);
-            
-            let key_bytes = utils::resolve_key(key.as_deref(), password.as_deref())?;
-            start_sync(source, &target_address, &key_bytes);
+
+            let resolved = utils::resolve_key(key.as_deref(), password.as_deref(), KeyRole::Client)?;
+            start_sync(source, &target_address, &resolved.key, resolved.pbkdf2_salt);
         },
         Commands::Discover { timeout } => {
             let servers = discovery::discover_servers(*timeout).await?;
@@ -55,9 +56,9 @@ async fn run_command(command: &Commands) -> Result<()> {
         Commands::Server { address, key, password } => {
             let server_address = utils::resolve_server_address(address.as_deref())?;
             println!("Sunucu başlatılıyor: {}", server_address);
-            
-            let key_bytes = utils::resolve_key(key.as_deref(), password.as_deref())?;
-            start_server(&server_address, &key_bytes);
+
+            let resolved = utils::resolve_key(key.as_deref(), password.as_deref(), KeyRole::Server)?;
+            start_server(&server_address, &resolved.key, password.clone());
         },
     }
     Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,154 +1,193 @@
 use std::fs::{self, OpenOptions};
-use std::io::{Write, Read, BufReader};
-use std::path::{Path, PathBuf};
+use std::io::{Write, Read};
+use std::path::Path;
 use std::net::{TcpListener, TcpStream};
 use aes::Aes256;
 use cipher::{block_padding::Pkcs7, BlockDecryptMut, KeyIvInit};
-use serde::{Serialize, Deserialize};
-use serde_json;
-use blake3;
+use anyhow::{Result, Context, anyhow};
 
-// Yeni tip tanımı: CBC ile AES256
-// Aes256Cbc = Cbc<Aes256, Pkcs7>
+use crate::sync::{FileHeader, calculate_file_hash};
+use crate::crypto::derive_key_from_password;
+
 type Aes256CbcDec = cbc::Decryptor<Aes256>;
 
-#[derive(Serialize, Deserialize, Debug)]
-struct FileHeader {
-    file_name: String,
-    file_size: u64,
-    file_hash: String,
-    relative_path: PathBuf,
+fn read_exact_or_eof(stream: &mut TcpStream, buf: &mut [u8]) -> Result<bool> {
+    match stream.read_exact(buf) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => Ok(false),
+        Err(e) => Err(e.into()),
+    }
 }
 
-fn decrypt_chunk(ciphertext: &[u8], key: &[u8; 32], iv: &[u8]) -> Vec<u8> {
+fn read_file_header(stream: &mut TcpStream) -> Result<Option<FileHeader>> {
+    let mut header_len_bytes = [0u8; 4];
+    if !read_exact_or_eof(stream, &mut header_len_bytes)? {
+        return Ok(None);
+    }
+
+    let header_len = u32::from_be_bytes(header_len_bytes) as usize;
+    let mut header_buffer = vec![0u8; header_len];
+    stream.read_exact(&mut header_buffer)
+        .context("Başlık okunamadı")?;
+
+    let header: FileHeader = serde_json::from_slice(&header_buffer)
+        .context("Başlık deserialize edilemedi")?;
+
+    Ok(Some(header))
+}
+
+fn resolve_transfer_key(
+    header: &FileHeader,
+    default_key: &[u8; 32],
+    password: Option<&str>,
+) -> Result<[u8; 32]> {
+    match (&header.pbkdf2_salt, password) {
+        (Some(salt_hex), Some(pwd)) => {
+            let salt = hex::decode(salt_hex)
+                .context("Geçersiz PBKDF2 salt formatı")?;
+            let salt: [u8; 16] = salt.try_into()
+                .map_err(|_| anyhow!("PBKDF2 salt 16 bayt olmalıdır"))?;
+            derive_key_from_password(pwd, Some(&salt))
+        },
+        (Some(_), None) => {
+            anyhow::bail!("İstemci oturum salt gönderdi ancak sunucu şifre modunda başlatılmadı")
+        },
+        (None, _) => Ok(*default_key),
+    }
+}
+
+fn decrypt_chunk(ciphertext: &[u8], key: &[u8; 32], iv: &[u8]) -> Result<Vec<u8>> {
     let mut buf = ciphertext.to_vec();
     let cipher = Aes256CbcDec::new(key.into(), iv.into());
-    let decrypted = cipher.decrypt_padded_mut::<Pkcs7>(&mut buf).unwrap();
-    decrypted.to_vec()
+    let decrypted = cipher.decrypt_padded_mut::<Pkcs7>(&mut buf)
+        .map_err(|_| anyhow!("Chunk çözülemedi"))?;
+    Ok(decrypted.to_vec())
 }
 
-/// Bir dosyanın tamamının BLAKE3 hash'ini hesaplar.
-fn calculate_file_hash(path: &Path) -> Result<String, std::io::Error> {
-    let file = fs::File::open(path)?;
-    let mut reader = BufReader::new(file);
-    let mut hasher = blake3::Hasher::new();
-    let mut buffer = [0; 4096];
-
-    loop {
-        let bytes_read = reader.read(&mut buffer)?;
-        if bytes_read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..bytes_read]);
+fn read_framed_payload(stream: &mut TcpStream, buffer: &mut Vec<u8>) -> Result<Option<()>> {
+    let mut len_bytes = [0u8; 4];
+    if !read_exact_or_eof(stream, &mut len_bytes)? {
+        return Ok(None);
     }
-    Ok(hasher.finalize().to_hex().to_string())
+
+    let payload_len = u32::from_be_bytes(len_bytes) as usize;
+    if payload_len < 16 {
+        anyhow::bail!("Geçersiz chunk boyutu: {}", payload_len);
+    }
+
+    buffer.resize(payload_len, 0);
+    stream.read_exact(buffer)
+        .context("Chunk okunamadı")?;
+
+    Ok(Some(()))
 }
 
-fn handle_client(mut stream: TcpStream, key: &[u8; 32]) {
-    println!("[📥] Bağlantı alındı.");
-
-    // 1. Başlık uzunluğunu oku (4 bayt)
-    let mut header_len_bytes = [0; 4];
-    if stream.read_exact(&mut header_len_bytes).is_err() {
-        println!("[⚠️] Başlık uzunluğu okunamadı.");
-        return;
-    }
-    let header_len = u32::from_be_bytes(header_len_bytes) as usize;
-
-    // 2. Başlığı oku
-    let mut header_buffer = vec![0; header_len];
-    if stream.read_exact(&mut header_buffer).is_err() {
-        println!("[⚠️] Başlık okunamadı.");
-        return;
-    }
-
-    // 3. Başlığı deserialize et
-    let header: FileHeader = match serde_json::from_slice(&header_buffer) {
-        Ok(h) => h,
-        Err(e) => {
-            println!("[⚠️] Başlık deserialize edilemedi: {}", e);
-            return;
-        }
-    };
-
-    println!("[📄] Alınan dosya başlığı: {:?}", header);
-
-    // Hedef yolu oluştur ve dizinleri oluştur
+fn receive_file(stream: &mut TcpStream, header: &FileHeader, key: &[u8; 32]) -> Result<()> {
     let received_dir = Path::new("received_files");
-    fs::create_dir_all(received_dir).expect("Ana dizin oluşturulamadı");
-    
+    fs::create_dir_all(received_dir).context("Ana dizin oluşturulamadı")?;
+
     let full_path = received_dir.join(&header.relative_path);
     if let Some(parent) = full_path.parent() {
-        if let Err(e) = fs::create_dir_all(parent) {
-            println!("[⚠️] Dizin oluşturulamadı: {}", e);
-            return;
-        }
+        fs::create_dir_all(parent).context("Dizin oluşturulamadı")?;
     }
 
-    // 4. İstemciye onay gönder
-    if stream.write_all(&[1]).is_err() {
-        println!("[⚠️] İstemciye onay gönderilemedi.");
-        return;
-    }
-
-    let path = &full_path;
-    let mut file = match OpenOptions::new()
+    let mut file = OpenOptions::new()
         .create(true)
         .write(true)
-        .truncate(true)  // Mevcut dosyayı temizle
-        .open(path) {
-        Ok(f) => f,
-        Err(e) => {
-            println!("[⚠️] Dosya oluşturulamadı: {}", e);
-            return;
+        .truncate(true)
+        .open(&full_path)
+        .context("Dosya oluşturulamadı")?;
+
+    let mut total_bytes_written = 0u64;
+    let mut payload_buffer = Vec::new();
+
+    while total_bytes_written < header.file_size {
+        if read_framed_payload(stream, &mut payload_buffer)?.is_none() {
+            anyhow::bail!(
+                "Bağlantı erken kapandı: {} ({} / {} bayt alındı)",
+                header.file_name,
+                total_bytes_written,
+                header.file_size
+            );
         }
-    };
 
-    let mut total_bytes_read = 0;
-    let mut buffer = [0; 4096]; // 4KB chunk
+        let iv = &payload_buffer[..16];
+        let ciphertext = &payload_buffer[16..];
+        let decrypted = decrypt_chunk(ciphertext, key, iv)
+            .context("Chunk çözülemedi")?;
 
-    while total_bytes_read < header.file_size {
-        let bytes_to_read = std::cmp::min(buffer.len(), (header.file_size - total_bytes_read) as usize);
-        let bytes_read = match stream.read_exact(&mut buffer[..bytes_to_read]) {
-            Ok(_) => bytes_to_read,
-            Err(e) => {
-                println!("[⚠️] Chunk okuma hatası: {}", e);
-                break;
-            }
-        };
-
-        // IV ve şifreli veri ayrıştırılıyor
-        if bytes_read > 16 {
-            let iv = &buffer[..16];
-            let ciphertext = &buffer[16..bytes_read];
-            let decrypted = decrypt_chunk(ciphertext, key, iv);
-            file.write_all(&decrypted).expect("Veri dosyaya yazılamadı");
-            println!("[📦] Alınan ve çözülen chunk: {} bayt", decrypted.len());
-            total_bytes_read += decrypted.len() as u64;
-        } else {
-            println!("[⚠️] Chunk boyutu çok küçük, IV ve veri ayrıştırılamadı.");
-            break;
-        }
+        file.write_all(&decrypted)
+            .context("Veri dosyaya yazılamadı")?;
+        total_bytes_written += decrypted.len() as u64;
     }
 
-    println!("[📂] Dosya '{}' başarıyla alındı ve kaydedildi. Toplam {} bayt.", header.file_name, total_bytes_read);
+    println!(
+        "[📂] Dosya '{}' başarıyla alındı. Toplam {} bayt.",
+        header.file_name, total_bytes_written
+    );
 
-    // Dosya hash'ini doğrula
-    match calculate_file_hash(path) {
+    match calculate_file_hash(&full_path) {
         Ok(calculated_hash) => {
             if calculated_hash == header.file_hash {
                 println!("[✅] Dosya hash doğrulaması başarılı: {}", calculated_hash);
             } else {
-                println!("[❌] Dosya hash doğrulaması BAŞARISIZ! Beklenen: {}, Hesaplanan: {}", header.file_hash, calculated_hash);
+                println!(
+                    "[❌] Dosya hash doğrulaması BAŞARISIZ! Beklenen: {}, Hesaplanan: {}",
+                    header.file_hash, calculated_hash
+                );
             }
         }
         Err(e) => {
             println!("[⚠️] Kaydedilen dosyanın hash'i hesaplanamadı: {}", e);
         }
     }
+
+    Ok(())
 }
 
-pub fn start_server(address: &str, key: &[u8; 32]) {
+fn handle_client(mut stream: TcpStream, default_key: [u8; 32], password: Option<String>) {
+    println!("[📥] Bağlantı alındı.");
+
+    loop {
+        let header = match read_file_header(&mut stream) {
+            Ok(Some(header)) => header,
+            Ok(None) => break,
+            Err(e) => {
+                println!("[⚠️] Başlık okunamadı: {}", e);
+                break;
+            }
+        };
+
+        println!("[📄] Alınan dosya başlığı: {:?}", header);
+
+        let transfer_key = match resolve_transfer_key(
+            &header,
+            &default_key,
+            password.as_deref(),
+        ) {
+            Ok(key) => key,
+            Err(e) => {
+                println!("[⚠️] Anahtar çözümlenemedi: {}", e);
+                let _ = stream.write_all(&[0]);
+                break;
+            }
+        };
+
+        if stream.write_all(&[1]).is_err() {
+            println!("[⚠️] İstemciye onay gönderilemedi.");
+            break;
+        }
+
+        if let Err(e) = receive_file(&mut stream, &header, &transfer_key) {
+            println!("[⚠️] Dosya alınamadı: {}", e);
+            break;
+        }
+    }
+
+    println!("[📥] Bağlantı kapatıldı.");
+}
+
+pub fn start_server(address: &str, key: &[u8; 32], password: Option<String>) {
     let listener = TcpListener::bind(address).expect("Sunucu başlatılamadı");
 
     println!("[📡] Sunucu başlatıldı: {}", address);
@@ -156,10 +195,10 @@ pub fn start_server(address: &str, key: &[u8; 32]) {
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
-                // Her bağlantıyı ayrı bir thread'de ele al
-                let key_clone = key.clone();
+                let key_clone = *key;
+                let password_clone = password.clone();
                 std::thread::spawn(move || {
-                    handle_client(stream, &key_clone);
+                    handle_client(stream, key_clone, password_clone);
                 });
             }
             Err(e) => {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,27 +1,26 @@
 use std::fs::{self, File};
-use std::io::{BufReader, Read};
+use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::net::TcpStream;
-use std::io::{Write};
 use blake3;
 use aes::Aes256;
 use cipher::{block_padding::Pkcs7, BlockEncryptMut, KeyIvInit};
 use rand::Rng;
 use serde::{Serialize, Deserialize};
-use serde_json;
 use walkdir::WalkDir;
 use indicatif::{ProgressBar, ProgressStyle};
 use anyhow::{Result, Context};
 
+pub const CHUNK_SIZE: usize = 4096;
 
-pub const CHUNK_SIZE: usize = 4096; // 4 KB
-
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct FileHeader {
     pub file_name: String,
     pub file_size: u64,
     pub file_hash: String,
     pub relative_path: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pbkdf2_salt: Option<String>,
 }
 
 /// Bir dosyanın tamamının BLAKE3 hash'ini hesaplar.
@@ -41,28 +40,39 @@ pub fn calculate_file_hash(path: &Path) -> Result<String, std::io::Error> {
     Ok(hasher.finalize().to_hex().to_string())
 }
 
-/// TCP üzerinden chunk'ı hedef IP'ye gönderir.
-pub fn send_chunk_to_server(stream: &mut TcpStream, chunk_data: &[u8], key: &[u8; 32], progress: &ProgressBar) -> Result<()> {
-    let (encrypted_chunk, iv) = encrypt_chunk(chunk_data, key);
-    let mut payload = Vec::new();
-    payload.extend_from_slice(&iv); // IV başa ekleniyor
-    payload.extend_from_slice(&encrypted_chunk); // Şifreli veri
-
-    // Şifreli chunk'ı gönder
-    stream.write_all(&payload)
+fn write_framed_payload(stream: &mut TcpStream, payload: &[u8]) -> Result<()> {
+    let len = payload.len() as u32;
+    stream.write_all(&len.to_be_bytes())
+        .context("Chunk uzunluğu gönderilemedi")?;
+    stream.write_all(payload)
         .context("Chunk gönderilemedi")?;
-    
+    Ok(())
+}
+
+/// TCP üzerinden chunk'ı hedef IP'ye gönderir.
+pub fn send_chunk_to_server(
+    stream: &mut TcpStream,
+    chunk_data: &[u8],
+    key: &[u8; 32],
+    progress: &ProgressBar,
+) -> Result<()> {
+    let (encrypted_chunk, iv) = encrypt_chunk(chunk_data, key);
+    let mut payload = Vec::with_capacity(iv.len() + encrypted_chunk.len());
+    payload.extend_from_slice(&iv);
+    payload.extend_from_slice(&encrypted_chunk);
+
+    write_framed_payload(stream, &payload)?;
     progress.inc(chunk_data.len() as u64);
     Ok(())
 }
 
-pub fn start_sync(source: &str, target: &str, key: &[u8; 32]) {
-    if let Err(e) = sync_files(source, target, key) {
+pub fn start_sync(source: &str, target: &str, key: &[u8; 32], pbkdf2_salt: Option<[u8; 16]>) {
+    if let Err(e) = sync_files(source, target, key, pbkdf2_salt) {
         eprintln!("[❌] Senkronizasyon hatası: {}", e);
     }
 }
 
-fn sync_files(source: &str, target: &str, key: &[u8; 32]) -> Result<()> {
+fn sync_files(source: &str, target: &str, key: &[u8; 32], pbkdf2_salt: Option<[u8; 16]>) -> Result<()> {
     println!("[🔍] Kaynak klasör taranıyor: {}", source);
 
     let path = Path::new(source);
@@ -70,10 +80,11 @@ fn sync_files(source: &str, target: &str, key: &[u8; 32]) -> Result<()> {
         anyhow::bail!("'{}' bir klasör değil veya bulunamadı.", source);
     }
 
-    // Önce tüm dosyaları say ve toplam boyutu hesapla
+    let salt_hex = pbkdf2_salt.map(hex::encode);
+
     let mut files = Vec::new();
     let mut total_size = 0u64;
-    
+
     for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
         let file_path = entry.path();
         if file_path.is_file() {
@@ -86,7 +97,6 @@ fn sync_files(source: &str, target: &str, key: &[u8; 32]) -> Result<()> {
 
     println!("[📊] {} dosya bulundu, toplam boyut: {} bayt", files.len(), total_size);
 
-    // Progress bar oluştur
     let progress = ProgressBar::new(total_size);
     progress.set_style(
         ProgressStyle::default_bar()
@@ -98,7 +108,7 @@ fn sync_files(source: &str, target: &str, key: &[u8; 32]) -> Result<()> {
     println!("[🔗] Sunucuya bağlanılıyor: {}", target);
     let mut stream = TcpStream::connect(target)
         .context("Sunucuya bağlanılamadı")?;
-    
+
     println!("[📡] Bağlantı kuruldu: {}", target);
 
     for file_path in files {
@@ -106,11 +116,11 @@ fn sync_files(source: &str, target: &str, key: &[u8; 32]) -> Result<()> {
             .and_then(|n| n.to_str())
             .context("Geçersiz dosya adı")?
             .to_string();
-        
+
         let file_metadata = fs::metadata(&file_path)
             .context("Dosya metadata'sı okunamadı")?;
         let file_size = file_metadata.len();
-        
+
         let relative_path = file_path.strip_prefix(path)
             .context("Relative path hesaplanamadı")?
             .to_path_buf();
@@ -125,28 +135,26 @@ fn sync_files(source: &str, target: &str, key: &[u8; 32]) -> Result<()> {
             file_size,
             file_hash,
             relative_path,
+            pbkdf2_salt: salt_hex.clone(),
         };
 
         let serialized_header = serde_json::to_string(&header)
             .context("Header serialize edilemedi")?;
         let header_len = serialized_header.len() as u32;
 
-        // Başlık gönder
         stream.write_all(&header_len.to_be_bytes())
             .context("Header uzunluğu gönderilemedi")?;
         stream.write_all(serialized_header.as_bytes())
             .context("Header gönderilemedi")?;
 
-        // Sunucudan onay bekle
         let mut response_buffer = [0; 1];
         stream.read_exact(&mut response_buffer)
             .context("Sunucudan yanıt alınamadı")?;
-        
+
         if response_buffer[0] != 1 {
             anyhow::bail!("Sunucudan onay alınamadı: {}", file_name);
         }
 
-        // Dosya içeriğini gönder
         let file = File::open(&file_path)
             .context("Dosya açılamadı")?;
         let mut reader = BufReader::new(file);
@@ -163,34 +171,24 @@ fn sync_files(source: &str, target: &str, key: &[u8; 32]) -> Result<()> {
                 .context("Chunk gönderilemedi")?;
         }
     }
-    
+
     progress.finish_with_message("Tüm dosyalar başarıyla gönderildi!");
     println!("[🚀] Senkronizasyon tamamlandı.");
     Ok(())
 }
 
-// Şifreleme ve çözme için yeni CBC tipleri
-// Encryptor ve Decryptor ayrı ayrı
-
 type Aes256CbcEnc = cbc::Encryptor<Aes256>;
-
-
-
 
 fn encrypt_chunk(chunk: &[u8], key: &[u8; 32]) -> (Vec<u8>, Vec<u8>) {
     let mut iv = [0u8; 16];
     rand::thread_rng().fill(&mut iv);
-    
-    // Buffer'ı padding için yeterli boyutta oluştur
+
     let mut buf = chunk.to_vec();
-    // AES block size (16 byte) için padding alanı ekle
     buf.resize(chunk.len() + 16, 0);
-    
+
     let cipher = Aes256CbcEnc::new(key.into(), &iv.into());
     let ciphertext = cipher.encrypt_padded_mut::<Pkcs7>(&mut buf, chunk.len())
         .expect("Şifreleme hatası")
         .to_vec();
     (ciphertext, iv.to_vec())
 }
-
-

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,23 +1,59 @@
 use anyhow::{Result, Context};
-use crate::crypto::{derive_key_from_password, parse_hex_key, validate_password_strength, generate_random_hex_key};
+use crate::crypto::{
+    derive_key_from_password, parse_hex_key, validate_password_strength,
+    generate_random_hex_key, generate_random_salt,
+};
 use crate::discovery::{discover_servers, select_server_interactive, select_best_server_auto};
 
+/// Çözümlenmiş AES anahtarı ve opsiyonel PBKDF2 salt bilgisi
+pub struct ResolvedKey {
+    pub key: [u8; 32],
+    pub pbkdf2_salt: Option<[u8; 16]>,
+}
+
+/// Anahtar çözümleme bağlamı
+pub enum KeyRole {
+    Client,
+    Server,
+}
+
 /// Anahtar veya şifreden AES anahtarı çözümler
-pub fn resolve_key(key: Option<&str>, password: Option<&str>) -> Result<[u8; 32]> {
+pub fn resolve_key(key: Option<&str>, password: Option<&str>, role: KeyRole) -> Result<ResolvedKey> {
     match (key, password) {
         (Some(hex_key), None) => {
-            parse_hex_key(hex_key)
+            Ok(ResolvedKey {
+                key: parse_hex_key(hex_key)?,
+                pbkdf2_salt: None,
+            })
         },
         (None, Some(pwd)) => {
             validate_password_strength(pwd)?;
-            derive_key_from_password(pwd, None)
+            match role {
+                KeyRole::Client => {
+                    let salt = generate_random_salt();
+                    let derived_key = derive_key_from_password(pwd, Some(&salt))?;
+                    Ok(ResolvedKey {
+                        key: derived_key,
+                        pbkdf2_salt: Some(salt),
+                    })
+                },
+                KeyRole::Server => {
+                    let derived_key = derive_key_from_password(pwd, None)?;
+                    Ok(ResolvedKey {
+                        key: derived_key,
+                        pbkdf2_salt: None,
+                    })
+                }
+            }
         },
         (None, None) => {
-            // Geçici anahtar üret ve kullanıcıya göster
             let temp_key = generate_random_hex_key();
             println!("🔑 Geçici anahtar oluşturuldu: {}", temp_key);
             println!("💡 Bu anahtarı karşı tarafa da verin veya --password kullanın");
-            parse_hex_key(&temp_key)
+            Ok(ResolvedKey {
+                key: parse_hex_key(&temp_key)?,
+                pbkdf2_salt: None,
+            })
         },
         (Some(_), Some(_)) => {
             anyhow::bail!("Hem --key hem --password belirtilemez, birini seçin")
@@ -32,21 +68,19 @@ pub async fn resolve_target_address(target: Option<&str>, auto_discover: bool, a
         (None, true) => {
             println!("[🔍] Otomatik sunucu keşfi başlatılıyor...");
             let servers = discover_servers(5).await?;
-            
+
             if servers.is_empty() {
                 anyhow::bail!("Hiç sunucu bulunamadı. Manuel IP:port belirtin veya önce sunucu başlatın.");
             }
-            
+
             let selected_server = if auto_select {
-                // Otomatik seçim (kullanıcı etkileşimi olmadan)
                 select_best_server_auto(&servers)
                     .context("Otomatik sunucu seçimi başarısız")?
             } else {
-                // Kullanıcıya seçim yaptır
                 select_server_interactive(&servers)
                     .context("Sunucu seçimi iptal edildi")?
             };
-            
+
             println!("[✅] Sunucu seçildi: {} ({:?})", selected_server.address, selected_server.discovery_method);
             Ok(selected_server.address.to_string())
         },
@@ -64,7 +98,6 @@ pub fn resolve_server_address(address: Option<&str>) -> Result<String> {
     match address {
         Some(addr) => Ok(addr.to_string()),
         None => {
-            // Otomatik IP detection
             let local_ip = get_local_ip()?;
             let default_port = 12345;
             let server_address = format!("{}:{}", local_ip, default_port);
@@ -76,14 +109,13 @@ pub fn resolve_server_address(address: Option<&str>) -> Result<String> {
 
 /// Yerel IP adresini bulur
 fn get_local_ip() -> Result<String> {
-    // Google DNS'e bağlanarak yerel IP'yi öğren (gerçekte bağlanmaz)
     let socket = std::net::UdpSocket::bind("0.0.0.0:0")
         .context("UDP socket oluşturulamadı")?;
     socket.connect("8.8.8.8:80")
         .context("Test bağlantısı kurulamadı")?;
-    
+
     let local_addr = socket.local_addr()
         .context("Yerel adres alınamadı")?;
-    
+
     Ok(local_addr.ip().to_string())
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,55 +1,93 @@
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use std::thread;
 use std::time::Duration;
+use deltasafe::server::start_server;
+use deltasafe::sync::start_sync;
+use deltasafe::crypto::parse_hex_key;
+use deltasafe::utils::{resolve_key, KeyRole};
 
 #[test]
 fn test_basic_sync() {
-    // Test klasörlerini oluştur
     let test_dir = "test_data";
     let source_dir = format!("{}/source", test_dir);
     let received_dir = "received_files";
-    
-    // Temizlik
+
     let _ = fs::remove_dir_all(test_dir);
     let _ = fs::remove_dir_all(received_dir);
-    
-    // Test dosyası oluştur
+
     fs::create_dir_all(&source_dir).unwrap();
     fs::write(format!("{}/test.txt", source_dir), "Hello, Deltasafe!").unwrap();
-    
-    // Test anahtarı (32 bayt = 64 hex karakter)
-    let test_key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    
-    // Sunucuyu başlat (arka planda)
+    fs::create_dir_all(format!("{}/nested", source_dir)).unwrap();
+    fs::write(format!("{}/nested/other.txt", source_dir), "Second file").unwrap();
+
+    let test_key = parse_hex_key(
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    ).unwrap();
+
     let server_handle = thread::spawn(move || {
-        Command::new("cargo")
-            .args(&["run", "--", "server", "--address", "127.0.0.1:12346", "--key", test_key])
-            .output()
-            .expect("Sunucu başlatılamadı");
+        start_server("127.0.0.1:12346", &test_key, None);
     });
-    
-    // Sunucunun başlamasını bekle
-    thread::sleep(Duration::from_secs(2));
-    
-    // Sync işlemini başlat
-    let output = Command::new("cargo")
-        .args(&["run", "--", "sync", "--source", &source_dir, "--target", "127.0.0.1:12346", "--key", test_key])
-        .output()
-        .expect("Sync komutu çalıştırılamadı");
-    
-    println!("Sync output: {}", String::from_utf8_lossy(&output.stdout));
-    println!("Sync error: {}", String::from_utf8_lossy(&output.stderr));
-    
-    // Dosyanın alındığını kontrol et
-    thread::sleep(Duration::from_secs(1));
+
+    thread::sleep(Duration::from_millis(500));
+
+    start_sync(&source_dir, "127.0.0.1:12346", &test_key, None);
+
+    thread::sleep(Duration::from_millis(500));
+
     assert!(Path::new("received_files/test.txt").exists());
-    
+    assert!(Path::new("received_files/nested/other.txt").exists());
+
     let received_content = fs::read_to_string("received_files/test.txt").unwrap();
     assert_eq!(received_content, "Hello, Deltasafe!");
-    
-    // Temizlik
+
+    let received_nested = fs::read_to_string("received_files/nested/other.txt").unwrap();
+    assert_eq!(received_nested, "Second file");
+
+    drop(server_handle);
+
+    let _ = fs::remove_dir_all(test_dir);
+    let _ = fs::remove_dir_all(received_dir);
+}
+
+#[test]
+fn test_password_sync_with_session_salt() {
+    let test_dir = "test_data_password";
+    let source_dir = format!("{}/source", test_dir);
+    let received_dir = "received_files";
+
+    let _ = fs::remove_dir_all(test_dir);
+    let _ = fs::remove_dir_all(received_dir);
+
+    fs::create_dir_all(&source_dir).unwrap();
+    fs::write(format!("{}/secret.txt", source_dir), "Password protected").unwrap();
+
+    let password = "testpassword123".to_string();
+    let server_password = password.clone();
+
+    let server_handle = thread::spawn(move || {
+        let resolved = resolve_key(None, Some(&server_password), KeyRole::Server).unwrap();
+        start_server("127.0.0.1:12347", &resolved.key, Some(server_password));
+    });
+
+    thread::sleep(Duration::from_millis(500));
+
+    let resolved = resolve_key(None, Some(&password), KeyRole::Client).unwrap();
+    start_sync(
+        &source_dir,
+        "127.0.0.1:12347",
+        &resolved.key,
+        resolved.pbkdf2_salt,
+    );
+
+    thread::sleep(Duration::from_millis(500));
+
+    assert!(Path::new("received_files/secret.txt").exists());
+    let content = fs::read_to_string("received_files/secret.txt").unwrap();
+    assert_eq!(content, "Password protected");
+
+    drop(server_handle);
+
     let _ = fs::remove_dir_all(test_dir);
     let _ = fs::remove_dir_all(received_dir);
 }
@@ -57,19 +95,13 @@ fn test_basic_sync() {
 #[test]
 fn test_file_operations() {
     use deltasafe::sync::{calculate_file_hash, CHUNK_SIZE};
-    use std::fs;
-    
-    // Test dosyası oluştur
+
     let test_file = "tmp_rovodev_integration_test.txt";
     fs::write(test_file, "Integration test content").unwrap();
-    
-    // Hash hesapla
+
     let hash = calculate_file_hash(std::path::Path::new(test_file)).unwrap();
     assert_eq!(hash.len(), 64);
-    
-    // Chunk size kontrolü
     assert_eq!(CHUNK_SIZE, 4096);
-    
-    // Temizlik
+
     fs::remove_file(test_file).unwrap();
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -56,6 +56,7 @@ mod tests {
             file_size: 1024,
             file_hash: "abcd1234".to_string(),
             relative_path: PathBuf::from("subdir/test.txt"),
+            pbkdf2_salt: None,
         };
         
         let serialized = serde_json::to_string(&header).unwrap();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the critical fixes identified in the project analysis:

- **Build:** `edition = "2021"` so the project compiles on stable Cargo
- **Protocol:** Each encrypted chunk is sent as `u32 length + IV + ciphertext`, fixing client/server framing mismatch
- **Multi-file:** Server now loops over multiple `FileHeader` messages on a single connection
- **Shared types:** `FileHeader` and `calculate_file_hash` live in `sync` and are reused by `server`
- **Password security:** Client generates a per-session PBKDF2 salt, sends it in `FileHeader`, and the server re-derives the key when started with `--password`
- **Tests:** Integration tests call library APIs directly instead of spawning `cargo run` subprocesses
- **Docs:** README notes that mDNS discovery is not implemented yet (port scan only)
- **Agent Skills:** Curated [skills.sh](https://skills.sh) packs for Rust, Cursor workflows, Git/PR, and project-specific `deltasafe` skill

## Installed skill packs (~130 skills)

| Pack | Purpose |
|------|---------|
| ZhangHanDong/rust-skills | Rust CLI, concurrency, errors, crypto |
| obra/superpowers | TDD, debugging, planning, code review |
| HKTITAN/cursor-best-practices | Cursor Agent setup & workflows |
| gardusig/cursor-skills | `gh-pr`, `git-commit`, issue automation |
| softaworks/agent-toolkit | README + mermaid diagrams |
| anthropics/skills | `skill-creator` |
| `.cursor/skills/deltasafe` | Project protocol rules |

Reinstall commands are in `skills-lock.json`.

## Test plan

- [x] `cargo test` (unit, integration, doctests)
- [x] Multi-file sync over hex key
- [x] Password sync with session salt re-derivation on server

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-951ac23b-945c-4d64-9f6e-a894cde88c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-951ac23b-945c-4d64-9f6e-a894cde88c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

